### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+
+go:
+  - 1.9.x
+
+go_import_path: github.com/zaquestion/lab
+
+# use containers which run faster and have cache
+sudo: false
+
+script:
+  - go build -v github.com/zaquestion/lab/...
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# git + lab = gitlab
+# git + lab = gitlab [![Build Status](https://travis-ci.org/zaquestion/lab.svg?branch=master)](https://travis-ci.org/zaquestion/lab)
 
 lab wraps git or [hub](https://github.com/github/hub) and adds additional features to make working with GitLab smoother
 


### PR DESCRIPTION
I'm not sure how to install, adding a `.travis.yml` will enable people to see a reproducible way to build this project.

Note that you must add this repo on [travis-ci.org](https://travis-ci.org/zaquestion/lab).

I am guessing `dep` is needed? Or is it just 1.9?

I'm getting this:
```
$ go get -u github.com/zaquestion/lab/...
# github.com/zaquestion/lab/vendor/github.com/spf13/cobra/cobra/cmd
vendor/github.com/spf13/cobra/cobra/cmd/root.go:49: cannot use rootCmd.PersistentFlags().Lookup("author") (type *"github.com/zaquestion/lab/vendor/github.com/spf13/pflag".Flag) as type *"github.com/spf13/pflag".Flag in argument to viper.BindPFlag
vendor/github.com/spf13/cobra/cobra/cmd/root.go:50: cannot use rootCmd.PersistentFlags().Lookup("viper") (type *"github.com/zaquestion/lab/vendor/github.com/spf13/pflag".Flag) as type *"github.com/spf13/pflag".Flag in argument to viper.BindPFlag
```