### PR TITLE
Rename mr -> merge-request

### DIFF
--- a/cmd/mergeRequest.go
+++ b/cmd/mergeRequest.go
@@ -26,7 +26,7 @@ const (
 
 // mrCmd represents the mr command
 var mrCmd = &cobra.Command{
-	Use:   "mr",
+	Use:   "merge-request",
 	Short: "Open Merge Request on GitLab",
 	Long:  `Currently only supports MRs into origin/master`,
 	Args:  cobra.ExactArgs(0),


### PR DESCRIPTION
`lab mr` was originally added because cobra does not implicitly
support commands with `-`'s in them and it was believed that `hub pr`
and hub `pull-request` were aliases. It is now understood that these
are seperate commands. This change corrects the mistake by renaming the
mr command.