### PR TITLE
Add `lab mr` commands checkout, list, create

### DIFF
--- a/cmd/mergeRequest.go
+++ b/cmd/mergeRequest.go
@@ -1,141 +1,18 @@
 package cmd
 
 import (
-	"bytes"
-	"fmt"
-	"log"
-	"regexp"
-	"runtime"
-	"strconv"
-	"strings"
-	"text/template"
-
 	"github.com/spf13/cobra"
-	"github.com/tcnksm/go-gitconfig"
-	"github.com/xanzy/go-gitlab"
-	"github.com/zaquestion/lab/internal/git"
-	lab "github.com/zaquestion/lab/internal/gitlab"
-)
-
-// Only supporting merges into master currently, using this constant to keep
-// track of reference when setting your own base allowed
-const (
-	targetBranch = "master"
-	targetRemote = "origin"
 )
 
 // mrCmd represents the mr command
-var mrCmd = &cobra.Command{
+var mergeRequestCmd = &cobra.Command{
 	Use:   "merge-request",
 	Short: "Open Merge Request on GitLab",
 	Long:  `Currently only supports MRs into origin/master`,
 	Args:  cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		branch, err := git.CurrentBranch()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		sourceRemote, err := gitconfig.Local("branch." + branch + ".remote")
-		if err != nil {
-			sourceRemote = "origin"
-		}
-		sourceProjectName, err := git.PathWithNameSpace(sourceRemote)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		targetProjectName, err := git.PathWithNameSpace(targetRemote)
-		if err != nil {
-			log.Fatal(err)
-		}
-		targetProject, err := lab.FindProject(targetProjectName)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		msg, err := mrMsg(targetBranch, branch, sourceRemote, targetRemote)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		title, body, err := git.Edit("MERGEREQ", msg)
-		if err != nil {
-			_, f, l, _ := runtime.Caller(0)
-			log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
-		}
-
-		if title == "" {
-			log.Fatal("aborting MR due to empty MR msg")
-		}
-
-		mrURL, err := lab.MergeRequest(sourceProjectName, &gitlab.CreateMergeRequestOptions{
-			SourceBranch:    &branch,
-			TargetBranch:    gitlab.String(targetBranch),
-			TargetProjectID: &targetProject.ID,
-			Title:           &title,
-			Description:     &body,
-		})
-		if err != nil {
-			log.Fatal(err)
-		}
-		fmt.Println(mrURL)
-	},
-}
-
-func mrMsg(base, head, sourceRemote, targetRemote string) (string, error) {
-	lastCommitMsg, err := git.LastCommitMessage()
-	if err != nil {
-		return "", err
-	}
-	const tmpl = `{{if .InitMsg}}{{.InitMsg}}
-{{end}}
-{{.CommentChar}} Requesting a merge into {{.Base}} from {{.Head}}
-{{.CommentChar}}
-{{.CommentChar}} Write a message for this merge request. The first block
-{{.CommentChar}} of text is the title and the rest is the description.{{if .CommitLogs}}
-{{.CommentChar}}
-{{.CommentChar}} Changes:
-{{.CommentChar}}
-{{.CommitLogs}}{{end}}`
-
-	commitLogs, err := git.Log(base, head)
-	if err != nil {
-		return "", err
-	}
-	startRegexp := regexp.MustCompilePOSIX("^")
-	commentChar := git.CommentChar()
-	commitLogs = strings.TrimSpace(commitLogs)
-	commitLogs = startRegexp.ReplaceAllString(commitLogs, fmt.Sprintf("%s ", commentChar))
-
-	t, err := template.New("tmpl").Parse(tmpl)
-	if err != nil {
-		return "", err
-	}
-
-	msg := &struct {
-		InitMsg     string
-		CommentChar string
-		Base        string
-		Head        string
-		CommitLogs  string
-	}{
-		InitMsg:     lastCommitMsg,
-		CommentChar: commentChar,
-		Base:        targetRemote + ":" + base,
-		Head:        sourceRemote + ":" + head,
-		CommitLogs:  commitLogs,
-	}
-
-	var b bytes.Buffer
-	err = t.Execute(&b, msg)
-	if err != nil {
-		return "", err
-	}
-
-	return b.String(), nil
+	Run:   runMRCreate,
 }
 
 func init() {
-	RootCmd.AddCommand(mrCmd)
+	RootCmd.AddCommand(mergeRequestCmd)
 }

--- a/cmd/mr.go
+++ b/cmd/mr.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// mrCmd represents the mr command
+var mrCmd = &cobra.Command{
+	Use:   "mr",
+	Short: "",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(mrCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// mrCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// mrCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/mrCheckout.go
+++ b/cmd/mrCheckout.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+	"github.com/zaquestion/lab/internal/git"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+// listCmd represents the list command
+var checkoutCmd = &cobra.Command{
+	Use:   "checkout",
+	Short: "Checkout an open Merge Request",
+	Long:  ``,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, err := git.RepoName()
+		if err != nil {
+			log.Fatal(err)
+		}
+		mrIDStr := args[0]
+		mrID, err := strconv.Atoi(mrIDStr)
+		if err != nil {
+			log.Fatal(err)
+		}
+		mrs, err := lab.ListMRs(rn, &gitlab.ListMergeRequestsOptions{
+			IIDs: []int{mrID},
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		if len(mrs) < 1 {
+			fmt.Fprintf(os.Stdout, "MR #%s", mrIDStr)
+			return
+		}
+		branch := mrs[0].SourceBranch
+		mr := fmt.Sprintf("refs/merge-requests/%s/head", mrIDStr)
+		gitf := git.New("fetch", "origin", mr, fmt.Sprintf(":%s", branch))
+		err = gitf.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		gitc := git.New("checkout", branch)
+		err = gitc.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	mrCmd.AddCommand(checkoutCmd)
+}

--- a/cmd/mrCreate.go
+++ b/cmd/mrCreate.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+	"github.com/tcnksm/go-gitconfig"
+	"github.com/xanzy/go-gitlab"
+	"github.com/zaquestion/lab/internal/git"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+// Only supporting merges into master currently, using this constant to keep
+// track of reference when setting your own base allowed
+const (
+	targetBranch = "master"
+	targetRemote = "origin"
+)
+
+// mrCmd represents the mr command
+var mrCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Open Merge Request on GitLab",
+	Long:  `Currently only supports MRs into origin/master`,
+	Args:  cobra.ExactArgs(0),
+	Run:   runMRCreate,
+}
+
+func init() {
+	mrCmd.AddCommand(mrCreateCmd)
+}
+
+func runMRCreate(cmd *cobra.Command, args []string) {
+	branch, err := git.CurrentBranch()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sourceRemote, err := gitconfig.Local("branch." + branch + ".remote")
+	if err != nil {
+		sourceRemote = "origin"
+	}
+	sourceProjectName, err := git.PathWithNameSpace(sourceRemote)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	targetProjectName, err := git.PathWithNameSpace(targetRemote)
+	if err != nil {
+		log.Fatal(err)
+	}
+	targetProject, err := lab.FindProject(targetProjectName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	msg, err := mrMsg(targetBranch, branch, sourceRemote, targetRemote)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	title, body, err := git.Edit("MERGEREQ", msg)
+	if err != nil {
+		_, f, l, _ := runtime.Caller(0)
+		log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
+	}
+
+	if title == "" {
+		log.Fatal("aborting MR due to empty MR msg")
+	}
+
+	mrURL, err := lab.MergeRequest(sourceProjectName, &gitlab.CreateMergeRequestOptions{
+		SourceBranch:    &branch,
+		TargetBranch:    gitlab.String(targetBranch),
+		TargetProjectID: &targetProject.ID,
+		Title:           &title,
+		Description:     &body,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(mrURL)
+}
+
+func mrMsg(base, head, sourceRemote, targetRemote string) (string, error) {
+	lastCommitMsg, err := git.LastCommitMessage()
+	if err != nil {
+		return "", err
+	}
+	const tmpl = `{{if .InitMsg}}{{.InitMsg}}
+{{end}}
+{{.CommentChar}} Requesting a merge into {{.Base}} from {{.Head}}
+{{.CommentChar}}
+{{.CommentChar}} Write a message for this merge request. The first block
+{{.CommentChar}} of text is the title and the rest is the description.{{if .CommitLogs}}
+{{.CommentChar}}
+{{.CommentChar}} Changes:
+{{.CommentChar}}
+{{.CommitLogs}}{{end}}`
+
+	commitLogs, err := git.Log(base, head)
+	if err != nil {
+		return "", err
+	}
+	startRegexp := regexp.MustCompilePOSIX("^")
+	commentChar := git.CommentChar()
+	commitLogs = strings.TrimSpace(commitLogs)
+	commitLogs = startRegexp.ReplaceAllString(commitLogs, fmt.Sprintf("%s ", commentChar))
+
+	t, err := template.New("tmpl").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+
+	msg := &struct {
+		InitMsg     string
+		CommentChar string
+		Base        string
+		Head        string
+		CommitLogs  string
+	}{
+		InitMsg:     lastCommitMsg,
+		CommentChar: commentChar,
+		Base:        targetRemote + ":" + base,
+		Head:        sourceRemote + ":" + head,
+		CommitLogs:  commitLogs,
+	}
+
+	var b bytes.Buffer
+	err = t.Execute(&b, msg)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}

--- a/cmd/mrList.go
+++ b/cmd/mrList.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+	"github.com/zaquestion/lab/internal/git"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List Merge Requests",
+	Long:  ``,
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, err := git.RepoName()
+		if err != nil {
+			log.Fatal(err)
+		}
+		page := 0
+		if len(args) == 1 {
+			page, err = strconv.Atoi(args[0])
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		mrs, err := lab.ListMRs(rn, &gitlab.ListMergeRequestsOptions{
+			ListOptions: gitlab.ListOptions{
+				Page:    page,
+				PerPage: 10,
+			},
+			OrderBy: gitlab.String("updated_at"),
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, mr := range mrs {
+			fmt.Fprintf(os.Stdout, "#%d %s\n", mr.IID, mr.Title)
+		}
+	},
+}
+
+type formattedMR struct {
+	IID   int
+	Title string
+}
+
+func init() {
+	mrCmd.AddCommand(listCmd)
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -188,3 +188,16 @@ func MergeRequest(project string, opts *gitlab.CreateMergeRequestOptions) (strin
 	}
 	return mr.WebURL, nil
 }
+
+func ListMRs(project string, opts *gitlab.ListMergeRequestsOptions) ([]*gitlab.MergeRequest, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return nil, err
+	}
+
+	list, _, err := lab.MergeRequests.ListMergeRequests(p.ID, opts)
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}


### PR DESCRIPTION
Implementing these in an attempt to follow the ideas presented here:
https://github.com/github/hub/issues/1536

Honestly, not sure how I feel about these changes. Some considerations:
- `lab mr checkout` could be `lab checkout` with some special cases to
 determine if it should checkout the ref
- Aliasing `lab mr` and `lab merge-request`
- `lab mr list` feels better as `lab list mrs`

Following for edit
- `lab edit mr`
- `lab edit issue`