### PR TITLE
Implement #15; support for "upstream" remotes

### DIFF
--- a/cmd/mergeRequest.go
+++ b/cmd/mergeRequest.go
@@ -8,7 +8,7 @@ import (
 var mergeRequestCmd = &cobra.Command{
 	Use:   "merge-request",
 	Short: "Open Merge Request on GitLab",
-	Long:  `Currently only supports MRs into origin/master`,
+	Long:  `Currently only supports MRs into master`,
 	Args:  cobra.ExactArgs(0),
 	Run:   runMRCreate,
 }

--- a/cmd/mrCheckout.go
+++ b/cmd/mrCheckout.go
@@ -14,11 +14,11 @@ import (
 // listCmd represents the list command
 var checkoutCmd = &cobra.Command{
 	Use:   "checkout",
-	Short: "Checkout an open Merge Request",
+	Short: "Checkout an open merge request",
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, err := git.PathWithNameSpace("origin")
+		rn, err := git.PathWithNameSpace(targetRemote)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -39,7 +39,7 @@ var checkoutCmd = &cobra.Command{
 		}
 		branch := mrs[0].SourceBranch
 		mr := fmt.Sprintf("refs/merge-requests/%s/head", mrIDStr)
-		gitf := git.New("fetch", "origin", mr, fmt.Sprintf(":%s", branch))
+		gitf := git.New("fetch", targetRemote, mr, fmt.Sprintf(":%s", branch))
 		err = gitf.Run()
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/mrList.go
+++ b/cmd/mrList.go
@@ -14,11 +14,11 @@ import (
 // listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List Merge Requests",
+	Short: "List merge requests",
 	Long:  ``,
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, err := git.PathWithNameSpace("origin")
+		rn, err := git.PathWithNameSpace(targetRemote)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -153,3 +153,17 @@ func RepoName() (string, error) {
 	parts := strings.Split(o, "/")
 	return parts[len(parts)-1:][0], nil
 }
+
+func RemoteAdd(name, url string) error {
+	err := New("remote", "add", name, url).Run()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Updating", name)
+	err = New("fetch", name).Run()
+	if err != nil {
+		return err
+	}
+	fmt.Println("new remote:", name)
+	return nil
+}


### PR DESCRIPTION
(clone) support "upstream"
(fork) fork and clone to "upstream"
(mr) support "upstream"
 - list
 - checkout
 - create