### PR TITLE
Add goreleaser with CI process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,54 @@
+project_name: lab
+release:
+  github:
+    owner: zaquestion
+    name: lab
+  name_template: '{{.Tag}}'
+brew:
+  description: "CLI tool for GitLab, like hub"
+  homepage: "https://github.com/zaquestion/lab"
+  github:
+    owner: zaquestion
+    name: homebrew-tap
+  commit_author:
+    name: goreleaserbot
+    email: goreleaser@carlosbecker.com
+  install: bin.install "lab"
+  test: |
+    system "git", "init"
+    %w[haunted house].each { |f| touch testpath/f }
+    system "git", "add", "haunted", "house"
+    system "git", "commit", "-a", "-m", "Initial Commit"
+    system "git", "config", "--local", "--add", "gitlab.host", "http://example.com"
+    system "git", "config", "--local", "--add", "gitlab.user", "test"
+    system "git", "config", "--local", "--add", "gitlab.token", "test"
+    assert_equal "haunted\nhouse", shell_output("#{bin}/lab ls-files").strip
+builds:
+- goos:
+  - linux
+  - darwin
+  goarch:
+  - amd64
+  - "386"
+  goarm:
+  - "6"
+  main: .
+  ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+  binary: lab
+archive:
+  format: tar.gz
+  name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{
+    .Arm }}{{ end }}'
+  files:
+  - licence*
+  - LICENCE*
+  - license*
+  - LICENSE*
+  - readme*
+  - README*
+  - changelog*
+  - CHANGELOG*
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,12 @@ sudo: false
 script:
   - go test ./...
 
+deploy:
+  provider: script
+  script: curl -sL https://git.io/goreleaser | bash
+  on:
+    branch: master
+    tags: true
+
 notifications:
   email: false


### PR DESCRIPTION
This automates compilation of binary releases and update of Homebrew formula through [goreleaser](https://goreleaser.com/). When you push tag on master branch, Travis will pickup the commit and run the `deploy` phase. This invokes goreleaser, which:

- Builds binaries for Linux and macOS (both 32- and 64-bit builds)
- Creates GitHub release with changelog and binaries (see example: https://github.com/jnv/lab/releases/tag/v0.5.1)
- Updates formula in tap repository (see here: https://github.com/jnv/homebrew-tap/commit/9a4a4400fc073247e92616586f9f5352af6ed7e3)

Unfortunately there are currently no options to create formula with build recipes and the original formula is overriden completely.

**ACTION NEEDED**: You will need to add secret environment variable `GITHUB_TOKEN` with `public_repo` access to Travis, so goreleaser can update releases and push to tap repository.