### PR TITLE
(tests,fix) coverage for clone test was getting trapped inside the repo dir

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -43,16 +43,17 @@ var cloneCmd = &cobra.Command{
 		// to forked from repo
 		if project.ForkedFromProject != nil &&
 			strings.Contains(project.PathWithNamespace, gitlab.User()) {
+			var dir string
 			if len(args) > 1 {
-				os.Chdir(args[1])
+				dir = args[1]
 			} else {
-				os.Chdir(project.Name)
+				dir = project.Name
 			}
 			ffProject, err := gitlab.FindProject(project.ForkedFromProject.PathWithNamespace)
 			if err != nil {
 				log.Fatal(err)
 			}
-			err = git.RemoteAdd("upstream", ffProject.SSHURLToRepo)
+			err = git.RemoteAdd("upstream", ffProject.SSHURLToRepo, "./"+dir)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -14,10 +14,11 @@ func Test_clone(t *testing.T) {
 
 	b, err := cmd.CombinedOutput()
 	if err != nil {
+		t.Log(string(b))
 		t.Fatal(err)
 	}
-
 	out := string(b)
+	t.Log(out)
 
 	assert.Contains(t, out, "Cloning into 'test'...")
 	assert.Contains(t, out, " * [new branch]      master     -> upstream/master")

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -53,7 +53,7 @@ func forkFromOrigin(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	err = git.RemoteAdd(lab.User(), remote)
+	err = git.RemoteAdd(lab.User(), remote, ".")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -163,14 +163,16 @@ func RepoName() (string, error) {
 }
 
 // RemoteAdd both adds a remote and fetches it
-func RemoteAdd(name, url string) error {
-	err := New("remote", "add", name, url).Run()
-	if err != nil {
+func RemoteAdd(name, url, dir string) error {
+	cmd := New("remote", "add", name, url)
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
 		return err
 	}
 	fmt.Println("Updating", name)
-	err = New("fetch", name).Run()
-	if err != nil {
+	cmd = New("fetch", name)
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
 		return err
 	}
 	fmt.Println("new remote:", name)

--- a/main.go
+++ b/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"github.com/zaquestion/lab/cmd"
 	"github.com/zaquestion/lab/internal/gitlab"
+	"log"
 )
 
 var version = "master"
 
 func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	cmd.Version = version
 	gitlab.Init()
 	cmd.Execute()


### PR DESCRIPTION
- when adding the upstream remote well run the command from the directory instead of changing to the directory to run the command for now on. This is probably how I should have done it the first time, that logic is written by someone who doesnt use the "upstream" paradigm