### PR TITLE
(mr,issue) update show all assignees on issues

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -130,7 +130,7 @@
 [[projects]]
   name = "github.com/xanzy/go-gitlab"
   packages = ["."]
-  revision = "c457b58fba09cc12a36c8a311ed8a8b85ffeb7e9"
+  revision = "c85e4e9d786c10e15e28446456f0e8918561b2d9"
 
 [[projects]]
   branch = "master"
@@ -159,6 +159,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "def5262350f0fdf77607b83022fc3c1da8ac2cad95789c1e5dd767c4b41a245a"
+  inputs-digest = "c71a3581e8f87d3e7a6b305500da8f6c22db51f9e62f2df609a07da401d166ff"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,4 +43,4 @@
 
 [[constraint]]
   name = "github.com/xanzy/go-gitlab"
-  revision = "c457b58fba09cc12a36c8a311ed8a8b85ffeb7e9"
+  revision = "ec65bc7934094df33cb05d541a4ffadcd1f64861"

--- a/cmd/issueList_test.go
+++ b/cmd/issueList_test.go
@@ -20,8 +20,7 @@ func Test_issueList(t *testing.T) {
 
 	issues := strings.Split(string(b), "\n")
 	t.Log(issues)
-	firstIssue := issues[len(issues)-5 : len(issues)-4]
-	require.Equal(t, "#1 test issue for lab list", firstIssue[0])
+	require.Equal(t, "#1 test issue for lab list", issues[0])
 }
 
 func Test_issueListFlagLabel(t *testing.T) {

--- a/cmd/issueShow.go
+++ b/cmd/issueShow.go
@@ -44,7 +44,6 @@ func printIssue(issue *gitlab.Issue, project string) {
 	milestone := "None"
 	timestats := "None"
 	dueDate := "None"
-	assignee := "None"
 	state := map[string]string{
 		"opened": "Open",
 		"closed": "Closed",
@@ -62,8 +61,11 @@ func printIssue(issue *gitlab.Issue, project string) {
 	if issue.DueDate != nil {
 		dueDate = time.Time(*issue.DueDate).String()
 	}
-	if issue.Assignee.Username != "" {
-		assignee = issue.Assignee.Username
+	assignees := make([]string, len(issue.Assignees))
+	if len(issue.Assignees) > 0 && issue.Assignees[0].Username != "" {
+		for i, a := range issue.Assignees {
+			assignees[i] = a.Username
+		}
 	}
 
 	fmt.Printf(`
@@ -73,7 +75,7 @@ func printIssue(issue *gitlab.Issue, project string) {
 -----------------------------------
 Project: %s
 Status: %s
-Assignee: %s
+Assignees: %s
 Author: %s
 Milestone: %s
 Due Date: %s
@@ -81,7 +83,7 @@ Time Stats: %s
 Labels: %s
 WebURL: %s
 `,
-		issue.IID, issue.Title, issue.Description, project, state, assignee,
+		issue.IID, issue.Title, issue.Description, project, state, strings.Join(assignees, ", "),
 		issue.Author.Username, milestone, dueDate, timestats,
 		strings.Join(issue.Labels, ", "), issue.WebURL,
 	)

--- a/cmd/issueShow_test.go
+++ b/cmd/issueShow_test.go
@@ -25,11 +25,11 @@ func Test_issueShow(t *testing.T) {
 -----------------------------------
 Project: zaquestion/test
 Status: Open
-Assignee: zaquestion
+Assignees: zaquestion, lab-testing
 Author: lab-testing
-Milestone: None
-Due Date: None
-Time Stats: None
+Milestone: 1.0
+Due Date: 2018-01-01 00:00:00 +0000 UTC
+Time Stats: Estimated 1w, Spent 1d
 Labels: bug
 WebURL: https://gitlab.com/zaquestion/test/issues/1
 `)

--- a/cmd/mrList_test.go
+++ b/cmd/mrList_test.go
@@ -18,10 +18,9 @@ func Test_mrList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	issues := strings.Split(string(b), "\n")
-	t.Log(issues)
-	firstIssue := issues[len(issues)-4 : len(issues)-3]
-	require.Equal(t, "#1 Test MR for lab list", firstIssue[0])
+	mrs := strings.Split(string(b), "\n")
+	t.Log(mrs)
+	require.Equal(t, "#1 Test MR for lab list", mrs[0])
 }
 
 func Test_mrListFlagLabel(t *testing.T) {

--- a/cmd/mrShow.go
+++ b/cmd/mrShow.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -67,7 +66,6 @@ func printMR(mr *gitlab.MergeRequest, project string) {
 Project: %s
 Branches: %s->%s
 Status: %s
-Work in Progress: %s
 Assignee: %s
 Author: %s
 Milestone: %s
@@ -75,7 +73,7 @@ Labels: %s
 WebURL: %s
 `,
 		mr.IID, mr.Title, mr.Description, project, mr.SourceBranch,
-		mr.TargetBranch, state, strconv.FormatBool(mr.WorkInProgress), assignee,
+		mr.TargetBranch, state, assignee,
 		mr.Author.Username, milestone, labels, mr.WebURL)
 }
 

--- a/cmd/mrShow_test.go
+++ b/cmd/mrShow_test.go
@@ -9,7 +9,7 @@ import (
 
 func Test_mrShow(t *testing.T) {
 	repo := copyTestRepo(t)
-	cmd := exec.Command("../lab_bin", "mr", "4")
+	cmd := exec.Command("../lab_bin", "mr", "1")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()
@@ -19,18 +19,17 @@ func Test_mrShow(t *testing.T) {
 	}
 
 	require.Contains(t, string(b), `
-#4 merged merge request
+#1 Test MR for lab list
 ===================================
-
+This MR is to remain open for testing the `+"`lab mr list`"+` functionality
 -----------------------------------
 Project: zaquestion/test
-Branches: merged->master
-Status: Merged
-Work in Progress: false
-Assignee: None
+Branches: mrtest->master
+Status: Open
+Assignee: zaquestion
 Author: zaquestion
-Milestone: None
-Labels: None
-WebURL: https://gitlab.com/zaquestion/test/merge_requests/4
+Milestone: 1.0
+Labels: documentation
+WebURL: https://gitlab.com/zaquestion/test/merge_requests/1
 `)
 }


### PR DESCRIPTION
secondarily use gitlab a issue and mr that cover of the show commands

NOTE: Blocked on: https://github.com/xanzy/go-gitlab/pull/294