### PR TITLE
(snippet) check for input on standard in when deciding to create a snippet with `lab snippet`

### DIFF
--- a/cmd/snippet.go
+++ b/cmd/snippet.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -28,16 +30,17 @@ var snippetCmd = &cobra.Command{
 			return
 		}
 
-		if global, _ := cmd.Flags().GetBool("global"); global {
+		if stat, _ := os.Stdin.Stat(); (stat.Mode() & os.ModeCharDevice) == 0 {
 			snippetCreateCmd.Run(cmd, args)
 			return
 		}
 
-		if len(args) == 0 && file == "" {
-			cmd.Help()
+		if !(len(args) == 0 || file == "") {
+			snippetCreateCmd.Run(cmd, args)
 			return
 		}
-		snippetCreateCmd.Run(cmd, args)
+
+		cmd.Help()
 	},
 }
 

--- a/cmd/snippet.go
+++ b/cmd/snippet.go
@@ -35,7 +35,7 @@ var snippetCmd = &cobra.Command{
 			return
 		}
 
-		if !(len(args) == 0 || file == "") {
+		if len(args) > 0 || file != "" {
 			snippetCreateCmd.Run(cmd, args)
 			return
 		}

--- a/cmd/snippetCreate.go
+++ b/cmd/snippetCreate.go
@@ -42,10 +42,11 @@ Optionally add a title & description with -m`,
 			}
 			if ok {
 				remote = args[0]
-			} else if ok && len(args) > 1 {
-				file = args[1]
 			} else {
 				file = args[0]
+			}
+			if ok && len(args) > 1 {
+				file = args[1]
 			}
 		}
 		code, err := snipCode(file)

--- a/cmd/snippetCreate_test.go
+++ b/cmd/snippetCreate_test.go
@@ -42,19 +42,34 @@ func Test_snippetCreate(t *testing.T) {
 	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/snippets/")
 }
 
-func Test_snippetCreate_Global(t *testing.T) {
+func Test_snippetCreate_file(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
-
-	// Remove .git dir forcing the cmd to exec outside of a git repo
-	cmd := exec.Command("rm", "-rf", ".git")
-	cmd.Dir = repo
-	err := cmd.Run()
+	t.Log(filepath.Join(repo, "testfile"))
+	err := ioutil.WriteFile(filepath.Join(repo, "testfile"), []byte("test file contents"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cmd = exec.Command("../lab_bin", "snippet", "create", "-g",
+	cmd := exec.Command("../lab_bin", "snippet", "lab-testing", "testfile",
+		"-m", "snippet title",
+		"-m", "snippet description")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+
+	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/snippets/")
+}
+
+func Test_snippetCreate_Global(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+
+	cmd := exec.Command("../lab_bin", "snippet", "create", "-g",
 		"-m", "personal snippet title",
 		"-m", "personal snippet description")
 
@@ -83,7 +98,9 @@ func Test_snippetCreate_Global(t *testing.T) {
 }
 
 // This test is a little ridiculus, if we find it doesn't work well on other
-// envionments, we can just remove it. Its sole purpose is to test that a personal snippet can be created (with the users git editor) outside of a git repo. issue #98
+// envionments, we can just remove it. Its sole purpose is to test that a
+// personal snippet can be created (with the users git editor) outside of a git
+// repo. issue #98
 func Test_snippetCreate_Global_Editor(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)

--- a/cmd/snippetCreate_test.go
+++ b/cmd/snippetCreate_test.go
@@ -115,7 +115,7 @@ func Test_snippetCreate_Global_Editor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd = exec.Command(os.ExpandEnv("$GOPATH/src/github.com/zaquestion/lab/lab_bin"), "snippet", "-g")
+	cmd = exec.Command(os.ExpandEnv("$GOPATH/src/github.com/zaquestion/lab/lab_bin"), "snippet", "create", "-g")
 	cmd.Env = []string{"PATH=/usr/local/bin:/usr/bin:/bin", "EDITOR=test -f"}
 	cmd.Dir = repo
 

--- a/cmd/snippetList_test.go
+++ b/cmd/snippetList_test.go
@@ -28,7 +28,7 @@ func Test_snippetList(t *testing.T) {
 func Test_snippetList_Global(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
-	cmd := exec.Command("../lab_bin", "snippet", "list", "-g")
+	cmd := exec.Command("../lab_bin", "snippet", "-l", "-g")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()

--- a/cmd/snippet_test.go
+++ b/cmd/snippet_test.go
@@ -14,7 +14,7 @@ func Test_snippetCmd(t *testing.T) {
 	var snipID string
 	t.Run("create_personal", func(t *testing.T) {
 		repo := copyTestRepo(t)
-		cmd := exec.Command("../lab_bin", "snippet", "create", "-g",
+		cmd := exec.Command("../lab_bin", "snippet", "-g",
 			"-m", "personal snippet title",
 			"-m", "personal snippet description")
 		cmd.Dir = repo

--- a/cmd/snippet_test.go
+++ b/cmd/snippet_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_snippetCmd(t *testing.T) {
+func Test_snippetCmd_personal(t *testing.T) {
 	t.Parallel()
 	var snipID string
 	t.Run("create_personal", func(t *testing.T) {

--- a/internal/git/edit.go
+++ b/internal/git/edit.go
@@ -27,7 +27,6 @@ func Edit(filePrefix, message string) (string, string, error) {
 		dir = "/tmp"
 	}
 	filePath := filepath.Join(dir, fmt.Sprintf("%s_EDITMSG", filePrefix))
-	fmt.Println(filePath)
 	editorPath, err := editorPath()
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
This is better than just checking if its a global snippet since it works for project and personal snippets. It also forces snippets created from scratch (editor workflow) to explicitly use `lab snippet create`