### PR TITLE
Add lab mr checkout <mrID> -b for naming branch.

### DIFF
--- a/cmd/mrCheckout.go
+++ b/cmd/mrCheckout.go
@@ -10,6 +10,10 @@ import (
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
+var (
+	branch string
+)
+
 // listCmd represents the list command
 var checkoutCmd = &cobra.Command{
 	Use:   "checkout",
@@ -33,7 +37,9 @@ var checkoutCmd = &cobra.Command{
 			return
 		}
 		// https://docs.gitlab.com/ee/user/project/merge_requests/#checkout-merge-requests-locally
-		branch := mrs[0].SourceBranch
+		if branch == "" {
+			branch = mrs[0].SourceBranch
+		}
 		mr := fmt.Sprintf("refs/merge-requests/%d/head", mrID)
 		gitf := git.New("fetch", forkedFromRemote, fmt.Sprintf("%s:%s", mr, branch))
 		err = gitf.Run()
@@ -50,5 +56,6 @@ var checkoutCmd = &cobra.Command{
 }
 
 func init() {
+	checkoutCmd.Flags().StringVarP(&branch, "branch", "b", "", "checkout merge request with <branch> name")
 	mrCmd.AddCommand(checkoutCmd)
 }

--- a/cmd/mrCheckout_test.go
+++ b/cmd/mrCheckout_test.go
@@ -39,3 +39,36 @@ func Test_mrCheckoutCmdRun(t *testing.T) {
 	require.Contains(t, eLog, "Test file for MR test")
 	require.Contains(t, eLog, "54fd49a2ac60aeeef5ddc75efecd49f85f7ba9b0")
 }
+
+func Test_mrCheckoutCmdRunWithDifferentName(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+
+	cmd := exec.Command("../lab_bin", "mr", "checkout", "1", "-b", "mrtest_custom_name")
+	cmd.Dir = repo
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+	t.Log(string(b))
+
+	cmd = exec.Command("git", "branch")
+	cmd.Dir = repo
+
+	branch, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Contains(t, string(branch), "mrtest_custom_name")
+
+	cmd = exec.Command("git", "log", "-n1")
+	cmd.Dir = repo
+	log, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	eLog := string(log)
+	require.Contains(t, eLog, "Test file for MR test")
+	require.Contains(t, eLog, "54fd49a2ac60aeeef5ddc75efecd49f85f7ba9b0")
+}


### PR DESCRIPTION
Similar to convention for `git checkout -b`.
```
    -b <branch>           create and checkout a new branch
```

Though in this case, we are cheching out a remote branch with the name
<branch>. Without this flag set, we use the remote branch name as
before.