### PR TITLE
[#12] (internal/git) support parsing remotes using http/s, ssh://, and git://

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -141,11 +141,18 @@ func PathWithNameSpace(remote string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	parts := strings.Split(remoteURL, ":")
-	if len(parts) == 0 {
-		return "", errors.New("remote." + remote + ".url missing repository")
+	parts := strings.Split(remoteURL, "/")
+	l := len(parts)
+	if l < 2 {
+		return "", errors.Errorf("cannot parse remote: %s url: %s", remote, remoteURL)
 	}
-	return strings.TrimSuffix(parts[len(parts)-1:][0], ".git"), nil
+
+	path := strings.Join(parts[l-2:l], "/")
+	if i := strings.LastIndex(path, ":"); i != -1 {
+		path = path[i+1:]
+	}
+	path = strings.TrimSuffix(path, ".git")
+	return path, nil
 }
 
 // RepoName returns the name of the repository, such as "lab"

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,12 +71,81 @@ func TestCurrentBranch(t *testing.T) {
 }
 
 func TestPathWithNameSpace(t *testing.T) {
-	path, err := PathWithNameSpace("origin")
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		desc        string
+		remote      string
+		expected    string
+		expectedErr string
+	}{
+		{
+			desc:        "ssh",
+			remote:      "origin",
+			expected:    "zaquestion/test",
+			expectedErr: "",
+		},
+		{
+			desc:        "http",
+			remote:      "origin-http",
+			expected:    "zaquestion/test",
+			expectedErr: "",
+		},
+		{
+			desc:        "https",
+			remote:      "origin-https",
+			expected:    "zaquestion/test",
+			expectedErr: "",
+		},
+		{
+			desc:        "https://token@gitlab.com/org/repo",
+			remote:      "origin-https",
+			expected:    "zaquestion/test",
+			expectedErr: "",
+		},
+		{
+			desc:        "git://",
+			remote:      "origin-https",
+			expected:    "zaquestion/test",
+			expectedErr: "",
+		},
+		{
+			desc:        "ssh://",
+			remote:      "origin-https",
+			expected:    "zaquestion/test",
+			expectedErr: "",
+		},
+		{
+			desc:        "no .git suffix",
+			remote:      "origin-no_dot_git",
+			expected:    "zaquestion/test",
+			expectedErr: "",
+		},
+		{
+			desc:        "remote doesn't exist",
+			remote:      "phoney",
+			expected:    "",
+			expectedErr: "the key `remote.phoney.url` is not found",
+		},
+		{
+			desc:        "remote doesn't exist",
+			remote:      "garbage",
+			expected:    "",
+			expectedErr: "cannot parse remote: garbage url: garbageurl",
+		},
 	}
-	expectedPath := "zaquestion/test"
-	require.Equal(t, expectedPath, path)
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			path, err := PathWithNameSpace(test.remote)
+			if test.expectedErr != "" {
+				assert.EqualError(t, err, test.expectedErr)
+			} else {
+				assert.Nil(t, err)
+			}
+			assert.Equal(t, test.expected, path)
+		})
+	}
 }
 
 func TestRepoName(t *testing.T) {

--- a/testdata/test.git/config
+++ b/testdata/test.git/config
@@ -10,3 +10,27 @@
 [remote "lab-testing"]
         url = git@gitlab.com:lab-testing/test.git
         fetch = +refs/heads/*:refs/remotes/origin/*
+
+# Other formats for testing in internal/git/git_test.go
+# https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a
+[remote "origin-http"]
+	url = http://gitlab.com/zaquestion/test.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "origin-https"]
+	url = https://gitlab.com/zaquestion/test.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "origin-https-token"]
+	url = https://gitlab.com/zaquestion/test.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "origin-git"]
+	url = git://gitlab.com/zaquestion/test.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "origin-ssh-alt"]
+	url = ssh://gitlab.com/zaquestion/test.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "origin-no_dot_git"]
+	url = git@gitlab.com:zaquestion/test
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "garbage"]
+	url = garbageurl
+	fetch = +refs/heads/*:refs/remotes/garbage/*


### PR DESCRIPTION
This should resolve most issues with using non scp style ssh urls (e.g. git@gitlab.com:user/repo) with lab