### PR TITLE
Add support for GitLab subgroups

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -136,6 +136,7 @@ func CurrentBranch() (string, error) {
 
 // PathWithNameSpace returns the owner/repository for the current repo
 // Such as zaquestion/lab
+// Respects GitLab subgroups (https://docs.gitlab.com/ce/user/group/subgroups/)
 func PathWithNameSpace(remote string) (string, error) {
 	remoteURL, err := gitconfig.Local("remote." + remote + ".url")
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -141,16 +141,25 @@ func PathWithNameSpace(remote string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	parts := strings.Split(remoteURL, "/")
-	l := len(parts)
-	if l < 2 {
+
+	parts := strings.Split(remoteURL, "//")
+
+	if len(parts) == 1 {
+		// scp-like short syntax (e.g. git@gitlab.com...)
+		part := parts[0]
+		parts = strings.Split(part, ":")
+	} else if len(parts) == 2 {
+		// every other protocol syntax (e.g. ssh://, http://, git://)
+		part := parts[1]
+		parts = strings.SplitN(part, "/", 2)
+	} else {
 		return "", errors.Errorf("cannot parse remote: %s url: %s", remote, remoteURL)
 	}
 
-	path := strings.Join(parts[l-2:l], "/")
-	if i := strings.LastIndex(path, ":"); i != -1 {
-		path = path[i+1:]
+	if len(parts) != 2 {
+		return "", errors.Errorf("cannot parse remote: %s url: %s", remote, remoteURL)
 	}
+	path := parts[1]
 	path = strings.TrimSuffix(path, ".git")
 	return path, nil
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -120,8 +120,14 @@ func TestPathWithNameSpace(t *testing.T) {
 			expectedErr: "",
 		},
 		{
-			desc:        "subdfolders",
-			remote:      "origin-subfolder",
+			desc:        "subdfolders-ssh",
+			remote:      "origin-subfolder-ssh",
+			expected:    "zaquestion/sub/folder/test",
+			expectedErr: "",
+		},
+		{
+			desc:        "subdfolders-git",
+			remote:      "origin-subfolder-git",
 			expected:    "zaquestion/sub/folder/test",
 			expectedErr: "",
 		},

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -97,19 +97,19 @@ func TestPathWithNameSpace(t *testing.T) {
 		},
 		{
 			desc:        "https://token@gitlab.com/org/repo",
-			remote:      "origin-https",
+			remote:      "origin-https-token",
 			expected:    "zaquestion/test",
 			expectedErr: "",
 		},
 		{
 			desc:        "git://",
-			remote:      "origin-https",
+			remote:      "origin-git",
 			expected:    "zaquestion/test",
 			expectedErr: "",
 		},
 		{
 			desc:        "ssh://",
-			remote:      "origin-https",
+			remote:      "origin-ssh-alt",
 			expected:    "zaquestion/test",
 			expectedErr: "",
 		},
@@ -117,6 +117,12 @@ func TestPathWithNameSpace(t *testing.T) {
 			desc:        "no .git suffix",
 			remote:      "origin-no_dot_git",
 			expected:    "zaquestion/test",
+			expectedErr: "",
+		},
+		{
+			desc:        "subdfolders",
+			remote:      "origin-subfolder",
+			expected:    "zaquestion/sub/folder/test",
 			expectedErr: "",
 		},
 		{

--- a/testdata/test.git/config
+++ b/testdata/test.git/config
@@ -34,6 +34,9 @@
 [remote "garbage"]
 	url = garbageurl
 	fetch = +refs/heads/*:refs/remotes/garbage/*
-[remote "origin-subfolder"]
-	url = git://gitlab.com/zaquestion/sub/folder/test.git
-	fetch = +refs/heads/*:refs/remotes/origin-subfolder/*
+[remote "origin-subfolder-ssh"]
+	url = ssh://gitlab.com/zaquestion/sub/folder/test.git
+	fetch = +refs/heads/*:refs/remotes/origin-subfolder-ssh/*
+[remote "origin-subfolder-git"]
+	url = git@gitlab.com:zaquestion/sub/folder/test.git
+	fetch = +refs/heads/*:refs/remotes/origin-subfolder-git/*

--- a/testdata/test.git/config
+++ b/testdata/test.git/config
@@ -20,7 +20,7 @@
 	url = https://gitlab.com/zaquestion/test.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
 [remote "origin-https-token"]
-	url = https://gitlab.com/zaquestion/test.git
+	url = https://token@gitlab.com/zaquestion/test.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
 [remote "origin-git"]
 	url = git://gitlab.com/zaquestion/test.git
@@ -34,3 +34,6 @@
 [remote "garbage"]
 	url = garbageurl
 	fetch = +refs/heads/*:refs/remotes/garbage/*
+[remote "origin-subfolder"]
+	url = git://gitlab.com/zaquestion/sub/folder/test.git
+	fetch = +refs/heads/*:refs/remotes/origin-subfolder/*


### PR DESCRIPTION
This adds support for GitLab subgroups, i.e. remote URLs like `git@gitlab.com:c137/rick/sanchez/schmeckle.git`
I also took a chance to fix what seemed to be a copy-paste issue in tests.