### PR TITLE
Reduce dependencies

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -12,6 +12,7 @@ import (
 
 	retry "github.com/avast/retry-go"
 	"github.com/pkg/errors"
+	gitconfig "github.com/tcnksm/go-gitconfig"
 )
 
 // IsHub is true when using "hub" as the git binary

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -12,7 +12,6 @@ import (
 
 	retry "github.com/avast/retry-go"
 	"github.com/pkg/errors"
-	"github.com/tcnksm/go-gitconfig"
 )
 
 // IsHub is true when using "hub" as the git binary
@@ -93,7 +92,7 @@ func LastCommitMessage() (string, error) {
 	return strings.TrimSpace(string(msg)), nil
 }
 
-// Log produces a a formatted gitlog between 2 git shas
+// Log produces a formatted gitlog between 2 git shas
 func Log(sha1, sha2 string) (string, error) {
 	cmd := New("-c", "log.showSignature=false",
 		"log",

--- a/main.go
+++ b/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"log"
 	"os"
+	"os/user"
 	"path"
+	"runtime"
 
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 	"github.com/zaquestion/lab/cmd"
 	"github.com/zaquestion/lab/internal/config"
@@ -19,10 +20,20 @@ func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	cmd.Version = version
 
-	home, err := homedir.Dir()
-	if err != nil {
-		log.Fatal(err)
+	var home string
+	switch runtime.GOOS {
+	case "windows":
+		// userprofile works for roaming AD profiles
+		home = os.Getenv("USERPROFILE")
+	default:
+		// Assume linux or osx
+		u, err := user.Current()
+		if err != nil {
+			log.Fatalf("cannot retrieve current user: %v \n", err)
+		}
+		home = u.HomeDir
 	}
+
 	confpath := path.Join(home, ".config")
 	if _, err := os.Stat(confpath); os.IsNotExist(err) {
 		os.Mkdir(confpath, 0700)


### PR DESCRIPTION
- Simplify home directory detection, still without the need for cgo. Remove import. 
- Fix typo
- Undo a mistake where `goimports` removed a library that was used in the file
