### PR TITLE
drop support for hub command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center"><img src="https://user-images.githubusercontent.com/2358914/34196973-420d389a-e519-11e7-92e6-3a1486d6b280.png" align="center" height="350"></p>
 
-Lab wraps Git or [Hub](https://github.com/github/hub), making it simple to clone, fork, and interact with repositories on GitLab, including seamless workflows for creating merge requests, issues and snippets.
+Lab wraps Git, making it simple to clone, fork, and interact with repositories on GitLab, including seamless workflows for creating merge requests, issues and snippets.
 
 ```
 $ lab clone gitlab-com/infrastructure
@@ -11,25 +11,15 @@ $ lab clone gitlab-com/infrastructure
 $ git clone git@gitlab.com:gitlab-com/infrastructure
 ```
 
-## hub + lab = hublab??
-
-lab will look for hub and uses that as your git binary when available so you don't have to give up hub to use lab
-```
-$ lab version
-git version 2.11.0
-hub version 2.3.0-pre9
-lab version 0.11.1
-```
-
 # Inspiration
 
-The [hub](https://github.com/github/hub) tool made my life significantly easier and still does! lab is heavily inspired by hub and attempts to provide a similar feel.
+The [hub](https://github.com/github/hub) tool made my life significantly easier and still does! lab is heavily inspired by hub and attempts to provide a similar feel. Be aware, lab and hub differ in that most commands in lab are organized by `lab <NOUN> <verb>`. For instance use `lab mr create` to create a merge request.
 
 # Installation
 
 Dependencies
 
-* `git` or `hub`
+* `git`
 
 ### Homebrew
 ```
@@ -77,5 +67,7 @@ Enter default GitLab token:
 
 Like hub, lab feels best when aliased as `git`. In your `.bashrc` or `.bash_profile`
 ```
-alias git=lab
+if which lab 2>&1 > /dev/null; then
+	alias git=lab
+fi
 ```

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -33,19 +33,6 @@ func forkFromOrigin(cmd *cobra.Command, args []string) {
 		log.Fatal("remote: upstream already exists")
 	}
 
-	remoteURL, err := gitconfig.Local("remote.origin.url")
-	if err != nil {
-		log.Fatal(err)
-	}
-	if git.IsHub && strings.Contains(remoteURL, "github.com") {
-		git := git.New("fork")
-		git.Run()
-		if err != nil {
-			log.Fatal(err)
-		}
-		return
-	}
-
 	project, err := git.PathWithNameSpace("origin")
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,9 +80,6 @@ func helpFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 	formatChar := "\n"
-	if git.IsHub {
-		formatChar = ""
-	}
 
 	git := git.New()
 	git.Stdout = nil
@@ -182,7 +179,6 @@ func Execute() {
 	if cmd, _, err := RootCmd.Find(os.Args[1:]); err != nil || cmd.Use == "clone" {
 		// Determine if any undefined flags were passed to "clone"
 		// TODO: Evaluate and support some of these flags
-		// NOTE: `hub help -a` wraps the `git help -a` output
 		if (cmd.Use == "clone" && len(os.Args) > 2) || os.Args[1] == "help" {
 			// ParseFlags will err in these cases
 			err = cmd.ParseFlags(os.Args[1:])

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -15,24 +15,11 @@ import (
 	gitconfig "github.com/tcnksm/go-gitconfig"
 )
 
-// IsHub is true when using "hub" as the git binary
-var IsHub bool
-
-func init() {
-	_, err := exec.LookPath("hub")
-	if err == nil {
-		IsHub = true
-	}
-}
-
 // New looks up the hub or git binary and returns a cmd which outputs to stdout
 func New(args ...string) *exec.Cmd {
-	gitPath, err := exec.LookPath("hub")
+	gitPath, err := exec.LookPath("git")
 	if err != nil {
-		gitPath, err = exec.LookPath("git")
-		if err != nil {
-			log.Fatal(err)
-		}
+		log.Fatal(err)
 	}
 
 	cmd := exec.Command(gitPath, args...)


### PR DESCRIPTION
not 100% about merging this, but issues like #163 and #149 show that integrating with hub complicates things and can produce unexpected results or confusion. Such as creating a repo on github, when you meant to create on on gitlab