### PR TITLE
Add usage gif to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <p align="center"><img src="https://user-images.githubusercontent.com/2358914/34196973-420d389a-e519-11e7-92e6-3a1486d6b280.png" align="center" height="350"></p>
 
+<p align="center"><img src="http://lelandbatey.com/files/lab-demonstration-gifs/lab-demo--800x450.gif" align="center"></p>
 Lab wraps Git or [Hub](https://github.com/github/hub), making it simple to clone, fork, and interact with repositories on GitLab, including seamless workflows for creating merge requests, issues and snippets.
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center"><img src="https://user-images.githubusercontent.com/2358914/34196973-420d389a-e519-11e7-92e6-3a1486d6b280.png" align="center" height="350"></p>
 
-<p align="center"><img src="http://lelandbatey.com/files/lab-demonstration-gifs/lab-demo--800x450.gif" align="center"></p>
+<p align="center"><img src="https://user-images.githubusercontent.com/1964720/42740177-6478d834-8858-11e8-9667-97f193ecb404.gif" align="center"></p>
 Lab wraps Git or [Hub](https://github.com/github/hub), making it simple to clone, fork, and interact with repositories on GitLab, including seamless workflows for creating merge requests, issues and snippets.
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 <p align="center"><img src="https://user-images.githubusercontent.com/2358914/34196973-420d389a-e519-11e7-92e6-3a1486d6b280.png" align="center" height="350"></p>
 
-<p align="center"><img src="https://user-images.githubusercontent.com/1964720/42740177-6478d834-8858-11e8-9667-97f193ecb404.gif" align="center"></p>
 Lab wraps Git or [Hub](https://github.com/github/hub), making it simple to clone, fork, and interact with repositories on GitLab, including seamless workflows for creating merge requests, issues and snippets.
 
 ```
@@ -11,6 +10,8 @@ $ lab clone gitlab-com/infrastructure
 # expands to:
 $ git clone git@gitlab.com:gitlab-com/infrastructure
 ```
+
+<p align="center"><img src="https://user-images.githubusercontent.com/1964720/42740177-6478d834-8858-11e8-9667-97f193ecb404.gif" align="center"></p>
 
 ## hub + lab = hublab??
 


### PR DESCRIPTION
This PR adds a link to a .gif file showing how to make use of `lab` starting from a terminal without lab installed. The gif demonstrates the following actions:

1. Install lab
2. Clone the test repo
3. Fork the repo
4. Make a change
5. MR that change
6. Look at the resulting CI pipelines

-----

Please note that currently the gif in question is hosted on my personal website. I encourage the maintainers of this repo to, at some point, archive this gif and it's associated files and then change README.md to point to that archived gif. However, it is left as an exercise for the reader.