### PR TITLE
load config from file only if env is not present

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,11 @@ func loadConfig() (string, string, string) {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
+	host, user, token := viper.GetString("core.host"), viper.GetString("core.user"), viper.GetString("core.token")
+	if host != "" && user != "" && token != "" {
+		return host, user, token
+	}
+
 	if _, ok := viper.ReadInConfig().(viper.ConfigFileNotFoundError); ok {
 		if err := config.New(path.Join(confpath, "lab.hcl"), os.Stdin); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Hello @zaquestion 
Continuing #155, even after setting the required env (LAB_CORE_HOST, LAB_CORE_USER, LAB_CORE_TOKEN), lab still asks to create the config file if it's not present.

So this pull request handles if no config file is present but the config is in env, then it wont asks user to input the config from stdin, but return the values from env instead.

And `viper.AllSettings()` seems to not return config from env, hence this pr checks for env and return the config asap