### PR TITLE
Fix misspellings and add doc comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 install:
 	dep ensure
-	go install -ldflags "-X \"main.version=$$(git  rev-parse --short=10 HEAD)\""  github.com/zaquestion/lab
+	go install -ldflags "-X \"main.version=$$(git rev-parse --short=10 HEAD)\"" github.com/zaquestion/lab
 
 test:
 	bash -c "trap 'trap - SIGINT SIGTERM ERR; mv testdata/.git testdata/test.git; rm coverage-* 2>&1 > /dev/null; exit 1' SIGINT SIGTERM ERR; $(MAKE) internal-test"

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -10,7 +10,7 @@ import (
 	"text/template"
 
 	"github.com/spf13/cobra"
-	"github.com/xanzy/go-gitlab"
+	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
@@ -124,7 +124,7 @@ func issueText() (string, error) {
 }
 
 func init() {
-	issueCreateCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as seperate paragraphs")
+	issueCreateCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	issueCreateCmd.Flags().StringSliceP("label", "l", []string{}, "Set the given label(s) on the created issue")
 	issueCreateCmd.Flags().StringSliceP("assignees", "a", []string{}, "Set assignees by username")
 	issueCmd.AddCommand(issueCreateCmd)

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/tcnksm/go-gitconfig"
-	"github.com/xanzy/go-gitlab"
+	gitconfig "github.com/tcnksm/go-gitconfig"
+	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
@@ -29,7 +29,7 @@ var mrCreateCmd = &cobra.Command{
 }
 
 func init() {
-	mrCreateCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as seperate paragraphs")
+	mrCreateCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	mrCreateCmd.Flags().StringP("assignee", "a", "", "Set assignee by username")
 	mergeRequestCmd.Flags().AddFlagSet(mrCreateCmd.Flags())
 	mrCmd.AddCommand(mrCreateCmd)

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/xanzy/go-gitlab"
+	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
@@ -169,7 +169,7 @@ func init() {
 	snippetCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "Make snippet private; visible only to project members (default: internal)")
 	snippetCreateCmd.Flags().BoolVar(&public, "public", false, "Make snippet public; can be accessed without any authentication (default: internal)")
 	snippetCreateCmd.Flags().StringVarP(&name, "name", "n", "", "(optional) Name snippet to add code highlighting, e.g. potato.go for GoLang")
-	snippetCreateCmd.Flags().StringSliceP("message", "m", []string{"-"}, "Use the given <msg>; multiple -m are concatenated as seperate paragraphs")
+	snippetCreateCmd.Flags().StringSliceP("message", "m", []string{"-"}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	snippetCmd.Flags().AddFlagSet(snippetCreateCmd.Flags())
 	snippetCmd.AddCommand(snippetCreateCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/zaquestion/lab/internal/git"
 )
 
-// Version is set by main during build
+// Version is set with linker flags during build.
 var Version string
 
 // versionCmd represents the version command

--- a/docs/lab_issue_create.md
+++ b/docs/lab_issue_create.md
@@ -16,7 +16,7 @@ lab issue create [remote] [flags]
   -a, --assignees strings   Set assignees by username
   -h, --help                help for create
   -l, --label strings       Set the given label(s) on the created issue
-  -m, --message strings     Use the given <msg>; multiple -m are concatenated as seperate paragraphs
+  -m, --message strings     Use the given <msg>; multiple -m are concatenated as separate paragraphs
 ```
 
 ### SEE ALSO

--- a/docs/lab_merge-request.md
+++ b/docs/lab_merge-request.md
@@ -15,7 +15,7 @@ lab merge-request [remote [branch]] [flags]
 ```
   -a, --assignee string   Set assignee by username
   -h, --help              help for merge-request
-  -m, --message strings   Use the given <msg>; multiple -m are concatenated as seperate paragraphs
+  -m, --message strings   Use the given <msg>; multiple -m are concatenated as separate paragraphs
 ```
 
 ### SEE ALSO

--- a/docs/lab_mr_create.md
+++ b/docs/lab_mr_create.md
@@ -15,7 +15,7 @@ lab mr create [remote [branch]] [flags]
 ```
   -a, --assignee string   Set assignee by username
   -h, --help              help for create
-  -m, --message strings   Use the given <msg>; multiple -m are concatenated as seperate paragraphs
+  -m, --message strings   Use the given <msg>; multiple -m are concatenated as separate paragraphs
 ```
 
 ### SEE ALSO

--- a/docs/lab_snippet.md
+++ b/docs/lab_snippet.md
@@ -20,7 +20,7 @@ lab snippet [flags]
   -g, --global            create as a personal snippet
   -h, --help              help for snippet
   -l, --list              list snippets
-  -m, --message strings   Use the given <msg>; multiple -m are concatenated as seperate paragraphs (default [-])
+  -m, --message strings   Use the given <msg>; multiple -m are concatenated as separate paragraphs (default [-])
   -n, --name string       (optional) Name snippet to add code highlighting, e.g. potato.go for GoLang
   -p, --private           Make snippet private; visible only to project members (default: internal)
       --public            Make snippet public; can be accessed without any authentication (default: internal)

--- a/docs/lab_snippet_create.md
+++ b/docs/lab_snippet_create.md
@@ -16,7 +16,7 @@ lab snippet create [remote] [flags]
 
 ```
   -h, --help              help for create
-  -m, --message strings   Use the given <msg>; multiple -m are concatenated as seperate paragraphs (default [-])
+  -m, --message strings   Use the given <msg>; multiple -m are concatenated as separate paragraphs (default [-])
   -n, --name string       (optional) Name snippet to add code highlighting, e.g. potato.go for GoLang
   -p, --private           Make snippet private; visible only to project members (default: internal)
       --public            Make snippet public; can be accessed without any authentication (default: internal)

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1,7 +1,7 @@
 // Package gitlab is an internal wrapper for the go-gitlab package
 //
 // Most functions serve to expose debug logging if set and accept a project
-// name string over an ID
+// name string over an ID.
 package gitlab
 
 import (
@@ -15,11 +15,12 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/xanzy/go-gitlab"
+	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/git"
 )
 
 var (
+	// ErrProjectNotFound is returned when a GitLab project cannot be found.
 	ErrProjectNotFound = errors.New("gitlab project not found")
 )
 


### PR DESCRIPTION
goreportcard (https://goreportcard.com/report/github.com/zaquestion/lab)
reports a few minor issues with lab, including a misspelling of
"separate" in several locations. This PR fixes that, and also adds a
documentation comment that was reported missing.

Imports whose package names do not match the basename of their import
path (e.g., go-gitlab, go-gitconfig) have had their package names
explicitly rendered by goimports, to more clearly identify the package
name being imported.