### PR TITLE
Touchup makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
-install:
+VERSION ?= $(shell git rev-parse --short=10 HEAD)
+GOURL ?= github.com/zaquestion/lab
+
+deps:
 	dep ensure
-	go install -ldflags "-X \"main.version=$$(git rev-parse --short=10 HEAD)\"" github.com/zaquestion/lab
+
+build: deps
+	go build -ldflags "-X \"main.version=$(VERSION)\"" $(GOURL)
+
+install: build
+	go install $(GOURL)
 
 test:
 	bash -c "trap 'trap - SIGINT SIGTERM ERR; mv testdata/.git testdata/test.git; rm coverage-* 2>&1 > /dev/null; exit 1' SIGINT SIGTERM ERR; $(MAKE) internal-test"
@@ -8,9 +16,9 @@ test:
 internal-test:
 	rm coverage-* 2>&1 > /dev/null || true
 	mv testdata/test.git testdata/.git
-	go test -coverprofile=coverage-main.out -covermode=count -coverpkg ./... -run=$(run) github.com/zaquestion/lab/cmd github.com/zaquestion/lab/internal/...
+	go test -coverprofile=coverage-main.out -covermode=count -coverpkg ./... -run=$(run) $(GOURL)/cmd $(GOURL)/internal/...
 	mv testdata/.git testdata/test.git
 	go get github.com/wadey/gocovmerge
 	gocovmerge coverage-*.out > coverage.txt && rm coverage-*.out
 
-.PHONY: install test internal-test
+.PHONY: deps install test internal-test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= $(shell git rev-parse --short=10 HEAD)
+VERSION ?= $(shell git describe --long --tags)
 GOURL ?= github.com/zaquestion/lab
 
 deps:


### PR DESCRIPTION
Here are a couple things I fixed up while messing around building this on my own systems and [packaging it for ArchLinux](https://aur.archlinux.org/packages/lab). Golang projects are actually a pain in the butt to package because they are so adamant about doing everything themselves (downloading sources, verifying checksums, building form only verified remote paths, etc.) that it's hard to get a package manager wrapped around them. The more bits of the process have standard `make` or similar wrappers the better, and splitting these dependencies so they can be run at the corresponding time in the package process would be better than the monolithic approach.