### PR TITLE
(listing) abstract pagination from user

### DIFF
--- a/cmd/fork_test.go
+++ b/cmd/fork_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -49,6 +50,7 @@ func Test_fork(t *testing.T) {
 		}
 		require.Contains(t, string(b), "lab-testing")
 	})
+	time.Sleep(2 * time.Second)
 
 	// Failing to find the project will fail the test and is a legit
 	// failure case since its the only thing asserting the project exists

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -12,28 +12,34 @@ import (
 var (
 	issueLabels []string
 	issueState  string
+	issueNumRet int
+	issueAll    bool
 )
 
 var issueListCmd = &cobra.Command{
-	Use:     "list [remote] [page]",
+	Use:     "list [remote]",
 	Aliases: []string{"ls"},
 	Short:   "List issues",
 	Long:    ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, page, err := parseArgs(args)
+		rn, _, err := parseArgs(args)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		issues, err := lab.IssueList(rn, &gitlab.ListProjectIssuesOptions{
+		opts := gitlab.ListProjectIssuesOptions{
 			ListOptions: gitlab.ListOptions{
-				Page:    int(page),
-				PerPage: 10,
+				PerPage: issueNumRet,
 			},
 			Labels:  issueLabels,
 			State:   &issueState,
 			OrderBy: gitlab.String("updated_at"),
-		})
+		}
+		num := issueNumRet
+		if issueAll {
+			num = -1
+		}
+		issues, err := lab.IssueList(rn, opts, num)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -45,9 +51,13 @@ var issueListCmd = &cobra.Command{
 
 func init() {
 	issueListCmd.Flags().StringSliceVarP(
-		&issueLabels, "label", "l", []string{}, "filter issues by label")
+		&issueLabels, "label", "l", []string{}, "Filter issues by label")
 	issueListCmd.Flags().StringVarP(
 		&issueState, "state", "s", "opened",
-		"filter issues by state (opened/closed)")
+		"Filter issues by state (opened/closed)")
+	issueListCmd.Flags().IntVarP(
+		&issueNumRet, "number", "n", 10,
+		"Number of issues to return")
+	issueListCmd.Flags().BoolVarP(&issueAll, "all", "a", false, "List all issues on the project")
 	issueCmd.AddCommand(issueListCmd)
 }

--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -33,9 +33,9 @@ var checkoutCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		mrs, err := lab.MRList(rn, &gitlab.ListProjectMergeRequestsOptions{
+		mrs, err := lab.MRList(rn, gitlab.ListProjectMergeRequestsOptions{
 			IIDs: []int{int(mrID)},
-		})
+		}, 1)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/project_list.go
+++ b/cmd/project_list.go
@@ -9,30 +9,41 @@ import (
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
+var projectListConfig struct {
+	All        bool
+	Owned      bool
+	Membership bool
+	Starred    bool
+
+	Number int
+}
+
 var projectListCmd = &cobra.Command{
-	Use:     "list [search [page]]",
+	Use:     "list [search]",
 	Aliases: []string{"ls", "search"},
 	Short:   "List your projects",
 	Run: func(cmd *cobra.Command, args []string) {
-		search, page, err := parseArgsStr(args)
+		search, _, err := parseArgsStr(args)
 		if err != nil {
 			log.Fatal(err)
 		}
-		all, err := cmd.Flags().GetBool("all")
-		if err != nil {
-			log.Fatal(err)
-		}
-		projects, err := lab.ProjectList(&gitlab.ListProjectsOptions{
+		opt := gitlab.ListProjectsOptions{
 			ListOptions: gitlab.ListOptions{
-				Page:    int(page),
-				PerPage: 10,
+				PerPage: projectListConfig.Number,
 			},
-			Simple:  gitlab.Bool(true),
-			OrderBy: gitlab.String("id"),
-			Sort:    gitlab.String("asc"),
-			Owned:   gitlab.Bool(!all),
-			Search:  gitlab.String(search),
-		})
+			Simple:     gitlab.Bool(true),
+			OrderBy:    gitlab.String("id"),
+			Sort:       gitlab.String("asc"),
+			Owned:      gitlab.Bool(projectListConfig.Owned),
+			Membership: gitlab.Bool(projectListConfig.Membership),
+			Starred:    gitlab.Bool(projectListConfig.Starred),
+			Search:     gitlab.String(search),
+		}
+		num := projectListConfig.Number
+		if projectListConfig.All {
+			num = -1
+		}
+		projects, err := lab.ProjectList(opt, num)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -44,5 +55,9 @@ var projectListCmd = &cobra.Command{
 
 func init() {
 	projectCmd.AddCommand(projectListCmd)
-	projectListCmd.Flags().BoolP("all", "a", false, "list all projects")
+	projectListCmd.Flags().BoolVarP(&projectListConfig.All, "all", "a", false, "List all projects on the instance")
+	projectListCmd.Flags().BoolVarP(&projectListConfig.Owned, "mine", "m", false, "limit by your projects")
+	projectListCmd.Flags().BoolVar(&projectListConfig.Membership, "member", false, "limit by projects which you are a member")
+	projectListCmd.Flags().BoolVar(&projectListConfig.Starred, "starred", false, "limit by your starred projects")
+	projectListCmd.Flags().IntVarP(&projectListConfig.Number, "number", "n", 100, "Number of projects to return")
 }

--- a/cmd/project_list_test.go
+++ b/cmd/project_list_test.go
@@ -11,7 +11,7 @@ import (
 func Test_projectList(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
-	cmd := exec.Command("../lab_bin", "project", "list")
+	cmd := exec.Command("../lab_bin", "project", "list", "-m")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()
@@ -21,4 +21,21 @@ func Test_projectList(t *testing.T) {
 	projects := strings.Split(string(b), "\n")
 	t.Log(projects)
 	require.Equal(t, "lab-testing/www-gitlab-com", projects[0])
+}
+
+func Test_projectList_many(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command("../lab_bin", "project", "list", "-n", "101")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	projects := strings.Split(string(b), "\n")
+	t.Log(projects[:len(projects)-3])
+	require.Equal(t, "PASS", projects[len(projects)-3 : len(projects)-1][0])
+	require.Contains(t, projects[len(projects)-2 : len(projects)][0], "of statements in ./...")
+	require.Equal(t, 101, len(projects[:len(projects)-3]))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -128,6 +128,9 @@ func parseArgsStr(args []string) (string, int64, error) {
 }
 
 func parseArgs(args []string) (string, int64, error) {
+	if !git.InsideGitRepo() {
+		return "", 0, nil
+	}
 	remote, num, err := parseArgsStr(args)
 	if err != nil {
 		return "", 0, err

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -201,6 +201,7 @@ func RemoteAdd(name, url, dir string) error {
 func IsRemote(remote string) (bool, error) {
 	cmd := New("remote")
 	cmd.Stdout = nil
+	cmd.Stderr = nil
 	remotes, err := cmd.Output()
 	if err != nil {
 		return false, err

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -181,15 +181,36 @@ func MRGet(project string, mrNum int) (*gitlab.MergeRequest, error) {
 }
 
 // MRList lists the MRs on a GitLab project
-func MRList(project string, opts *gitlab.ListProjectMergeRequestsOptions) ([]*gitlab.MergeRequest, error) {
+func MRList(project string, opts gitlab.ListProjectMergeRequestsOptions, n int) ([]*gitlab.MergeRequest, error) {
+	if n == -1 {
+		opts.PerPage = 100
+	}
 	p, err := FindProject(project)
 	if err != nil {
 		return nil, err
 	}
 
-	list, _, err := lab.MergeRequests.ListProjectMergeRequests(p.ID, opts)
+	list, resp, err := lab.MergeRequests.ListProjectMergeRequests(p.ID, &opts)
 	if err != nil {
 		return nil, err
+	}
+	if resp.CurrentPage == resp.TotalPages {
+		return list, nil
+	}
+	opts.Page = resp.NextPage
+	for len(list) < n || n == -1 {
+		if n != -1 {
+			opts.PerPage = n - len(list)
+		}
+		mrs, resp, err := lab.MergeRequests.ListProjectMergeRequests(p.ID, &opts)
+		if err != nil {
+			return nil, err
+		}
+		opts.Page = resp.NextPage
+		list = append(list, mrs...)
+		if resp.CurrentPage == resp.TotalPages {
+			break
+		}
 	}
 	return list, nil
 }
@@ -253,15 +274,37 @@ func IssueGet(project string, issueNum int) (*gitlab.Issue, error) {
 }
 
 // IssueList gets a list of issues on a GitLab Project
-func IssueList(project string, opts *gitlab.ListProjectIssuesOptions) ([]*gitlab.Issue, error) {
+func IssueList(project string, opts gitlab.ListProjectIssuesOptions, n int) ([]*gitlab.Issue, error) {
+	if n == -1 {
+		opts.PerPage = 100
+	}
 	p, err := FindProject(project)
 	if err != nil {
 		return nil, err
 	}
 
-	list, _, err := lab.Issues.ListProjectIssues(p.ID, opts)
+	list, resp, err := lab.Issues.ListProjectIssues(p.ID, &opts)
 	if err != nil {
 		return nil, err
+	}
+	if resp.CurrentPage == resp.TotalPages {
+		return list, nil
+	}
+
+	opts.Page = resp.NextPage
+	for len(list) < n || n == -1 {
+		if n != -1 {
+			opts.PerPage = n - len(list)
+		}
+		issues, resp, err := lab.Issues.ListProjectIssues(p.ID, &opts)
+		if err != nil {
+			return nil, err
+		}
+		opts.Page = resp.NextPage
+		list = append(list, issues...)
+		if resp.CurrentPage == resp.TotalPages {
+			break
+		}
 	}
 	return list, nil
 }
@@ -301,12 +344,33 @@ func ProjectSnippetDelete(pid interface{}, id int) error {
 }
 
 // ProjectSnippetList lists snippets on a project
-func ProjectSnippetList(pid interface{}, opts *gitlab.ListProjectSnippetsOptions) ([]*gitlab.Snippet, error) {
-	snips, _, err := lab.ProjectSnippets.ListSnippets(pid, opts)
+func ProjectSnippetList(pid interface{}, opts gitlab.ListProjectSnippetsOptions, n int) ([]*gitlab.Snippet, error) {
+	if n == -1 {
+		opts.PerPage = 100
+	}
+	list, resp, err := lab.ProjectSnippets.ListSnippets(pid, &opts)
 	if err != nil {
 		return nil, err
 	}
-	return snips, nil
+	if resp.CurrentPage == resp.TotalPages {
+		return list, nil
+	}
+	opts.Page = resp.NextPage
+	for len(list) < n || n == -1 {
+		if n != -1 {
+			opts.PerPage = n - len(list)
+		}
+		snips, resp, err := lab.ProjectSnippets.ListSnippets(pid, &opts)
+		if err != nil {
+			return nil, err
+		}
+		opts.Page = resp.NextPage
+		list = append(list, snips...)
+		if resp.CurrentPage == resp.TotalPages {
+			break
+		}
+	}
+	return list, nil
 }
 
 // SnippetCreate creates a personal snippet
@@ -326,12 +390,33 @@ func SnippetDelete(id int) error {
 }
 
 // SnippetList lists snippets on a project
-func SnippetList(opts *gitlab.ListSnippetsOptions) ([]*gitlab.Snippet, error) {
-	snips, _, err := lab.Snippets.ListSnippets(opts)
+func SnippetList(opts gitlab.ListSnippetsOptions, n int) ([]*gitlab.Snippet, error) {
+	if n == -1 {
+		opts.PerPage = 100
+	}
+	list, resp, err := lab.Snippets.ListSnippets(&opts)
 	if err != nil {
 		return nil, err
 	}
-	return snips, nil
+	if resp.CurrentPage == resp.TotalPages {
+		return list, nil
+	}
+	opts.Page = resp.NextPage
+	for len(list) < n || n == -1 {
+		if n != -1 {
+			opts.PerPage = n - len(list)
+		}
+		snips, resp, err := lab.Snippets.ListSnippets(&opts)
+		if err != nil {
+			return nil, err
+		}
+		opts.Page = resp.NextPage
+		list = append(list, snips...)
+		if resp.CurrentPage == resp.TotalPages {
+			break
+		}
+	}
+	return list, nil
 }
 
 // Lint validates .gitlab-ci.yml contents
@@ -365,10 +450,28 @@ func ProjectDelete(pid interface{}) error {
 }
 
 // ProjectList gets a list of projects on GitLab
-func ProjectList(opts *gitlab.ListProjectsOptions) ([]*gitlab.Project, error) {
-	list, _, err := lab.Projects.ListProjects(opts)
+func ProjectList(opts gitlab.ListProjectsOptions, n int) ([]*gitlab.Project, error) {
+	list, resp, err := lab.Projects.ListProjects(&opts)
 	if err != nil {
 		return nil, err
+	}
+	if resp.CurrentPage == resp.TotalPages {
+		return list, nil
+	}
+	opts.Page = resp.NextPage
+	for len(list) < n || n == -1 {
+		if n != -1 {
+			opts.PerPage = n - len(list)
+		}
+		projects, resp, err := lab.Projects.ListProjects(&opts)
+		if err != nil {
+			return nil, err
+		}
+		opts.Page = resp.NextPage
+		list = append(list, projects...)
+		if resp.CurrentPage == resp.TotalPages {
+			break
+		}
 	}
 	return list, nil
 }
@@ -383,15 +486,31 @@ func CIJobs(pid interface{}, branch string) ([]*gitlab.Job, error) {
 		return nil, err
 	}
 	target := pipelines[0].ID
-	jobs, _, err := lab.Jobs.ListPipelineJobs(pid, target, &gitlab.ListJobsOptions{
+	opts := &gitlab.ListJobsOptions{
 		ListOptions: gitlab.ListOptions{
 			PerPage: 500,
 		},
-	})
+	}
+	list, resp, err := lab.Jobs.ListPipelineJobs(pid, target, opts)
 	if err != nil {
 		return nil, err
 	}
-	return jobs, nil
+	if resp.CurrentPage == resp.TotalPages {
+		return list, nil
+	}
+	opts.Page = resp.NextPage
+	for {
+		jobs, resp, err := lab.Jobs.ListPipelineJobs(pid, target, opts)
+		if err != nil {
+			return nil, err
+		}
+		opts.Page = resp.NextPage
+		list = append(list, jobs...)
+		if resp.CurrentPage == resp.TotalPages {
+			break
+		}
+	}
+	return list, nil
 }
 
 // CITrace searches by name for a job and returns its trace file. The trace is


### PR DESCRIPTION
Users can either use `-a` to fetch all results or `-n` to specify a number of results