### PR TITLE
Allow filtering by target branch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  digest = "1:16db952e9dbb6f46ca057cbe3b914675f4b0ed26d473e4b1d9888cfc49f53447"
+  digest = "1:2e232f40c39cffc98293e66c36d1276bbb9674f0801f2569a4ee3167be201768"
   name = "github.com/avast/retry-go"
   packages = ["."]
   pruneopts = ""
@@ -10,7 +10,7 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:c4e38a492449061a87eefe7f0ab4eb1d31c1d3048938f4adf136e5dda0771422"
+  digest = "1:982e2547680f9fd2212c6443ab73ea84eef40ee1cdcecb61d997de838445214c"
   name = "github.com/cpuguy83/go-md2man"
   packages = ["md2man"]
   pruneopts = ""
@@ -18,7 +18,7 @@
   version = "v1.0.8"
 
 [[projects]]
-  digest = "1:0a39ec8bf5629610a4bc7873a92039ee509246da3cef1a0ea60f1ed7e5f9cea5"
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = ""
@@ -26,7 +26,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:b2106f1668ea5efc1ecc480f7e922a093adb9563fd9ce58585292871f0d0f229"
+  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   pruneopts = ""
@@ -42,7 +42,7 @@
   revision = "b23993cbb6353f0e6aa98d0ee318a34728f628b9"
 
 [[projects]]
-  digest = "1:d4cddfcb65b181789fea33c56a63763f4001321a8c32da7f119e7b978bffff2f"
+  digest = "1:cfdc5e7e40860f3fc94d0a5afac8c2aede88878ec28b23833d01e992fd51d66e"
   name = "github.com/gdamore/tcell"
   packages = [
     ".",
@@ -52,7 +52,7 @@
   revision = "2f258105ca8ce35819115b49f5ac58197241653e"
 
 [[projects]]
-  digest = "1:b1d3041d568e065ab4d76f7477844458e9209c0bb241eaccdc0770bf0a13b120"
+  digest = "1:f958a1c137db276e52f0b50efee41a1a389dcdded59a69711f3e872757dab34b"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   pruneopts = ""
@@ -69,7 +69,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ccfc44438ba7fc24effffbe9c7b75bbbb51e7a275e361e62a4dbffbc9e8e43d9"
+  digest = "1:9b7c5846d70f425d7fe279595e32a20994c6075e87be03b5c367ed07280877c5"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -96,7 +96,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:77dca848052bd83c887c2e39a0b04d8814c99f8df83d3390a6e9d6b932b109e7"
+  digest = "1:04d51db1d12a604203af8469c6d2f6d7473a78b88cf2cf37bd2cd3dcf74d03bd"
   name = "github.com/lucasb-eyer/go-colorful"
   packages = ["."]
   pruneopts = ""
@@ -104,14 +104,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:61d82517e1ce874e1a66ad61f98f1abbfe28695bdbf6522e2fae41983d499ca8"
+  digest = "1:a1df2b8580d14ed39468ed683fa344ef2ebabd77eccb45cbad057b30181bb6c0"
   name = "github.com/lunixbochs/vtclean"
   packages = ["."]
   pruneopts = ""
   revision = "2d01aacdc34a083dca635ba869909f5fc0cd4f41"
 
 [[projects]]
-  digest = "1:093cd7ebfdecf5692c66f0b0f7a1877d796c89d9940f5769439c53dc65264036"
+  digest = "1:d244eb7b2d8e9f4c9355d215d65159c176603874ba10bfb7cbe6dcbd212813f5"
   name = "github.com/magiconair/properties"
   packages = ["."]
   pruneopts = ""
@@ -135,7 +135,7 @@
   revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
-  digest = "1:fef37519c971ab3c464318a0c9da6a7fb9c21439aa587e61bf10af651e6119b9"
+  digest = "1:d60cfeee185019d4fcd35e8c89c83aff576e4723b6100300bf67b05be961388f"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
   pruneopts = ""
@@ -160,7 +160,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8920336e72a33a368712a810cf8e05e849c05cae4135dff6c1ca43f48c90c0e9"
+  digest = "1:a9529e755e91fbe91b8827886115f21c34d140abc1d9673dcd73cfaf89468c8e"
   name = "github.com/rivo/tview"
   packages = ["."]
   pruneopts = ""
@@ -175,7 +175,7 @@
   version = "v1.5.1"
 
 [[projects]]
-  digest = "1:05d0bccb23fd1755bf6f37ea91988c757503c4672e4670d1c93d86bd104d16ab"
+  digest = "1:d3e2e29bc7342053edc85e1ad751275694a96d58516f749cf3413db1a0eca2ba"
   name = "github.com/spf13/afero"
   packages = [
     ".",
@@ -195,7 +195,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:df5ae221c1219d6cc540dc7e17867baa84a96b620958f0d6ae65e3ef4c513c52"
+  digest = "1:12d1c2a16b6e81ddaae74a6def13592490823a9c260ec6f946299cf8eb109f9e"
   name = "github.com/spf13/cobra"
   packages = [
     ".",
@@ -222,14 +222,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4aed327da9e7da8fe7a9b817890b68fbcfd4aa9493c87f4e4904fa7c9b0fed05"
+  digest = "1:e0eb1581c2c9cdfa5ce30e3b724ba9d4541b6d8971c2f9cb65f6e3e5a3d041fe"
   name = "github.com/spf13/viper"
   packages = ["."]
   pruneopts = ""
   revision = "15738813a09db5c8e5b60a19d67d3f9bd38da3a4"
 
 [[projects]]
-  digest = "1:a70d585d45f695f2e8e6782569bdf181419667a35e6035ceb086706b495aa21a"
+  digest = "1:a30066593578732a356dc7e5d7f78d69184ca65aeeff5939241a3ab10559bb06"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -249,15 +249,15 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3f9051dcff3acee0ffa85e3cb627c31362a56aefa7e137d6f13a45de9fffb94a"
+  digest = "1:dd57cf720278da9359135dd12dd30b0b265684bcaaa6ebd22d772bb69747b097"
   name = "github.com/xanzy/go-gitlab"
   packages = ["."]
   pruneopts = ""
-  revision = "af28ecc530599f542dee9a748c4a8e3a22ae4659"
+  revision = "c5f12546e975c24b6ec0f64dce80959756950229"
 
 [[projects]]
   branch = "master"
-  digest = "1:882e82fbbfc924a04860de32c1e9029ee036961df31b13c9be276c186bbe2a47"
+  digest = "1:e03c8afd6f75c7349451fbfef3f548f845d3fda097af28d6144a725023c1ce1a"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = ""
@@ -265,7 +265,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:55a4820f7c2439376a659edc78142a90f814eaa0ec3da6303c254f22d87b3f88"
+  digest = "1:b970d5e8b11b4c8927a06298566eb8daf66a009702688b4142cc2a961e374e91"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -276,7 +276,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:74e084732dda056797a936c46f287c45fef85514506f0b448117be182a5a5979"
+  digest = "1:a8172cf4304ef01f0c7dd634c331880247d10f9e28b041821f2321a8e4bb3b7c"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -287,7 +287,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:47ca0def7e389f3de91c61a8aba9f8d7af98e4438c19bbb82891415f3bc1482c"
+  digest = "1:e947dc04c62cf4cca2b3b137d3f266fb592f5de429b9e18c0c3018df0eb78c76"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -297,7 +297,7 @@
   revision = "79b0c6888797020a994db17c8510466c72fe75d9"
 
 [[projects]]
-  digest = "1:af9bfca4298ef7502c52b1459df274eed401a4f5498b900e9a92d28d3d87ac5a"
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -314,7 +314,7 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:eede11c81b63c8f6fd06ef24ba0a640dc077196ec9b7a58ecde03c82eee2f151"
+  digest = "1:c1771ca6060335f9768dff6558108bc5ef6c58506821ad43377ee23ff059e472"
   name = "google.golang.org/appengine"
   packages = [
     "internal",

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -38,17 +38,15 @@ var listCmd = &cobra.Command{
 			ListOptions: gitlab.ListOptions{
 				PerPage: mrNumRet,
 			},
-			Labels:  mrLabels,
-			State:   &mrState,
-			OrderBy: gitlab.String("updated_at"),
+			Labels:       mrLabels,
+			State:        &mrState,
+			TargetBranch: &mrTargetBranch,
+			OrderBy:      gitlab.String("updated_at"),
 		}, num)
 		if err != nil {
 			log.Fatal(err)
 		}
 		for _, mr := range mrs {
-			if mrTargetBranch != "" && mrTargetBranch != mr.TargetBranch {
-				continue
-			}
 			fmt.Printf("#%d %s\n", mr.IID, mr.Title)
 		}
 	},

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -10,10 +10,11 @@ import (
 )
 
 var (
-	mrLabels []string
-	mrState  string
-	mrNumRet int
-	mrAll    bool
+	mrLabels       []string
+	mrState        string
+	mrTargetBranch string
+	mrNumRet       int
+	mrAll          bool
 )
 
 // listCmd represents the list command
@@ -45,6 +46,9 @@ var listCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		for _, mr := range mrs {
+			if mrTargetBranch != "" && mrTargetBranch != mr.TargetBranch {
+				continue
+			}
 			fmt.Printf("#%d %s\n", mr.IID, mr.Title)
 		}
 	},
@@ -59,6 +63,9 @@ func init() {
 	listCmd.Flags().IntVarP(
 		&mrNumRet, "number", "n", 10,
 		"number of merge requests to return")
+	listCmd.Flags().StringVarP(
+		&mrTargetBranch, "target-branch", "t", "",
+		"filter merge requests by target branch")
 	listCmd.Flags().BoolVarP(&mrAll, "all", "a", false, "List all MRs on the project")
 	mrCmd.AddCommand(listCmd)
 }

--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -101,7 +101,7 @@ func Test_mrFilterByTargetBranch(t *testing.T) {
 	}
 
 	mrs := strings.Split(string(b), "\n")
-	require.Equal(t, "PASS", mrs[0])
+	require.Equal(t, 3, len(mrs))
 }
 
 func Test_mrListByTargetBranch(t *testing.T) {
@@ -116,5 +116,5 @@ func Test_mrListByTargetBranch(t *testing.T) {
 	}
 
 	mrs := strings.Split(string(b), "\n")
-	require.Equal(t, "#107 WIP: Resolve \"issue title\"", mrs[0])
+	require.Equal(t, "#1 Test MR for lab list", mrs[0])
 }

--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -88,3 +88,33 @@ func Test_mrListFivePerPage(t *testing.T) {
 	t.Log(mrs)
 	require.Contains(t, mrs, "#1 Test MR for lab list")
 }
+
+func Test_mrFilterByTargetBranch(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command("../lab_bin", "mr", "list", "-t", "non-existing")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mrs := strings.Split(string(b), "\n")
+	require.Equal(t, "PASS", mrs[0])
+}
+
+func Test_mrListByTargetBranch(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command("../lab_bin", "mr", "list", "-t", "master")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mrs := strings.Split(string(b), "\n")
+	require.Equal(t, "#107 WIP: Resolve \"issue title\"", mrs[0])
+}

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -38,10 +38,11 @@ path refers the path on gitlab including the full group/namespace/project. If no
 		}
 
 		opts := gitlab.CreateProjectOptions{
-			Path:        gitlab.String(path),
-			Name:        gitlab.String(name),
-			Description: gitlab.String(desc),
-			Visibility:  &visibility,
+			Path:                 gitlab.String(path),
+			Name:                 gitlab.String(name),
+			Description:          gitlab.String(desc),
+			Visibility:           &visibility,
+			ApprovalsBeforeMerge: gitlab.Int(0),
 		}
 		p, err := lab.ProjectCreate(&opts)
 		if err != nil {


### PR DESCRIPTION
This introduces a feature for `mr list`, where users can filter the list of printed merge requests by target branch.