### PR TITLE
add `lab issue note` command

### DIFF
--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"runtime"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+	gitlab "github.com/xanzy/go-gitlab"
+	"github.com/zaquestion/lab/internal/git"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var issueCreateNoteCmd = &cobra.Command{
+	Use:     "note [remote] <id>",
+	Aliases: []string{"comment"},
+	Short:   "Add a note or comment to an issue on GitLab",
+	Long:    ``,
+	Args:    cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, issueNum, err := parseArgs(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		msgs, err := cmd.Flags().GetStringSlice("message")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		body, err := noteMsg(msgs)
+		if err != nil {
+			_, f, l, _ := runtime.Caller(0)
+			log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
+		}
+		if body == "" {
+			log.Fatal("aborting note due to empty note msg")
+		}
+
+		noteURL, err := lab.IssueCreateNote(rn, int(issueNum), &gitlab.CreateIssueNoteOptions{
+			Body: &body,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(noteURL)
+	},
+}
+
+//
+func noteMsg(msgs []string) (string, error) {
+	if len(msgs) > 0 {
+		return strings.Join(msgs[0:], "\n\n"), nil
+	}
+
+	text, err := noteText()
+	if err != nil {
+		return "", err
+	}
+	return git.EditFile("ISSUE_NOTE", text)
+}
+
+func noteText() (string, error) {
+	const tmpl = `{{.InitMsg}}
+{{.CommentChar}} Write a message for this note. Commented lines are discarded.`
+
+	initMsg := "\n"
+	commentChar := git.CommentChar()
+
+	t, err := template.New("tmpl").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+
+	msg := &struct {
+		InitMsg     string
+		CommentChar string
+	}{
+		InitMsg:     initMsg,
+		CommentChar: commentChar,
+	}
+
+	var b bytes.Buffer
+	err = t.Execute(&b, msg)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+func init() {
+	issueCreateNoteCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	issueCmd.AddCommand(issueCreateNoteCmd)
+}

--- a/cmd/issue_note_test.go
+++ b/cmd/issue_note_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_issueCreateNote(t *testing.T) {
+	repo := copyTestRepo(t)
+	cmd := exec.Command("../lab_bin", "issue", "note", "lab-testing", "1",
+		"-m", "note text")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+
+	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/issues/1#note_")
+}
+
+func Test_issueNoteMsg(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Msgs          []string
+		ExpectedBody  string
+	}{
+		{
+			Name:          "Using messages",
+			Msgs:          []string{"note paragraph 1", "note paragraph 2"},
+			ExpectedBody:  "note paragraph 1\n\nnote paragraph 2",
+		},
+		{
+			Name:          "From Editor",
+			Msgs:          nil,
+			ExpectedBody:  "", // this is not a great test
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test := test
+			t.Parallel()
+			body, err := noteMsg(test.Msgs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, test.ExpectedBody, body)
+		})
+	}
+}
+
+func Test_issueNoteText(t *testing.T) {
+	t.Parallel()
+	text, err := noteText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, `
+
+# Write a message for this note. Commented lines are discarded.`, text)
+
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -292,6 +292,23 @@ func IssueCreate(project string, opts *gitlab.CreateIssueOptions) (string, error
 	return mr.WebURL, nil
 }
 
+// IssueCreateNote creates a new note on an issue and returns the note URL
+func IssueCreateNote(project string, issueNum int, opts *gitlab.CreateIssueNoteOptions) (string, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return "", err
+	}
+
+	note, _, err := lab.Notes.CreateIssueNote(p.ID, issueNum, opts)
+	if err != nil {
+		return "", err
+	}
+
+	// Unlike Issue, Note has no WebURL property, so we have to create it
+	// ourselves from the project, noteable id and note id
+	return fmt.Sprintf("%s/issues/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+}
+
 // IssueGet retrieves the issue information from a GitLab project
 func IssueGet(project string, issueNum int) (*gitlab.Issue, error) {
 	p, err := FindProject(project)


### PR DESCRIPTION
See #68. This adds a very simple `lab issue note` command. It's my first time wrting
Go, so I'm very open to suggestions or corrections. I refactored some of the code in internal/git/edit.go to support this, and most of the code is copied from issue_create.go and issue_browse.go.

If this looks OK, I'd be happy to add `lab snippet note` and possibly `lab mr note` (#83).

As far as I can tell, the tests are still passing. I had trouble getting `make test` to work, but I was able to get things setup so that testing individual files seems to work:

```sh
$ cd cmd/                                                 
$ go test -run Test_issueCreateNote                     
PASS
ok      github.com/zaquestion/lab/cmd   3.373s
$ cd ../internal/git                                    
$ go test -run Test_parseTitleBody                    
PASS
ok      github.com/zaquestion/lab/internal/git  0.025s
```