### PR TITLE
Issue list search

### DIFF
--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -22,6 +22,10 @@ var issueListCmd = &cobra.Command{
 	Aliases: []string{"ls", "search"},
 	Short:   "List issues",
 	Long:    ``,
+	Example: `lab issue list                        # list all open issues
+lab issue list "search terms"         # search issues for "search terms"
+lab issue search "search terms"       # same as above
+lab issue list remote "search terms"  # search "remote" for issues with "search terms"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, issueSearch, err := parseArgsRemoteString(args)
 		if err != nil {

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -18,12 +18,12 @@ var (
 )
 
 var issueListCmd = &cobra.Command{
-	Use:     "list [remote]",
-	Aliases: []string{"ls"},
+	Use:     "list [remote] [search]",
+	Aliases: []string{"ls", "search"},
 	Short:   "List issues",
 	Long:    ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, _, err := parseArgs(args)
+		rn, issueSearch, err := parseArgsRemoteString(args)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -62,9 +62,6 @@ func init() {
 	issueListCmd.Flags().StringVarP(
 		&issueState, "state", "s", "opened",
 		"Filter issues by state (opened/closed)")
-	issueListCmd.Flags().StringVarP(
-		&issueSearch, "search", "", "",
-		"Search project issues against their title and description")
 	issueListCmd.Flags().IntVarP(
 		&issueNumRet, "number", "n", 10,
 		"Number of issues to return")

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -12,6 +12,7 @@ import (
 var (
 	issueLabels []string
 	issueState  string
+	issueSearch string
 	issueNumRet int
 	issueAll    bool
 )
@@ -35,6 +36,11 @@ var issueListCmd = &cobra.Command{
 			State:   &issueState,
 			OrderBy: gitlab.String("updated_at"),
 		}
+
+		if issueSearch != "" {
+			opts.Search = &issueSearch
+		}
+
 		num := issueNumRet
 		if issueAll {
 			num = -1
@@ -51,13 +57,19 @@ var issueListCmd = &cobra.Command{
 
 func init() {
 	issueListCmd.Flags().StringSliceVarP(
-		&issueLabels, "label", "l", []string{}, "Filter issues by label")
+		&issueLabels, "label", "l", []string{},
+		"Filter issues by label")
 	issueListCmd.Flags().StringVarP(
 		&issueState, "state", "s", "opened",
 		"Filter issues by state (opened/closed)")
+	issueListCmd.Flags().StringVarP(
+		&issueSearch, "search", "", "",
+		"Search project issues against their title and description")
 	issueListCmd.Flags().IntVarP(
 		&issueNumRet, "number", "n", 10,
 		"Number of issues to return")
-	issueListCmd.Flags().BoolVarP(&issueAll, "all", "a", false, "List all issues on the project")
+	issueListCmd.Flags().BoolVarP(
+		&issueAll, "all", "a", false,
+		"List all issues on the project")
 	issueCmd.AddCommand(issueListCmd)
 }

--- a/cmd/issue_list_test.go
+++ b/cmd/issue_list_test.go
@@ -55,3 +55,19 @@ func Test_issueListStateClosed(t *testing.T) {
 	t.Log(issues)
 	require.Contains(t, issues, "#4 test closed issue")
 }
+
+func Test_issueListSearch(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command("../lab_bin", "issue", "list", "--search", "filter labels")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	issues := strings.Split(string(b), "\n")
+	t.Log(issues)
+	require.Contains(t, issues, "#3 test filter labels 1")
+}

--- a/cmd/issue_list_test.go
+++ b/cmd/issue_list_test.go
@@ -59,7 +59,7 @@ func Test_issueListStateClosed(t *testing.T) {
 func Test_issueListSearch(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
-	cmd := exec.Command("../lab_bin", "issue", "list", "--search", "filter labels")
+	cmd := exec.Command("../lab_bin", "issue", "list", "filter labels")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()
@@ -70,4 +70,5 @@ func Test_issueListSearch(t *testing.T) {
 	issues := strings.Split(string(b), "\n")
 	t.Log(issues)
 	require.Contains(t, issues, "#3 test filter labels 1")
+	require.NotContains(t, issues, "#1 test issue for lab list")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,9 +168,11 @@ func parseArgsRemoteInt(args []string) (string, int64, error) {
 	return rn, num, nil
 }
 
-// returns a remote name and a string if parsed
-// returns two empty strings on error; if no remote is given, return project name
-// for default remote (ie 'origin'); if no second argument is given, returns ""
+// parseArgsRemoteString returns a remote name and a string if parsed.
+// If there is an error, it returns two empty strings.
+// If no remote is given, it returns the project name of the default remote
+// (ie 'origin').
+// If no second argument is given, it returns "" as second return value.
 func parseArgsRemoteString(args []string) (string, string, error) {
 	if !git.InsideGitRepo() {
 		return "", "", nil

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -329,3 +329,68 @@ func Test_parseArgs(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseArgsRemoteString(t *testing.T) {
+	tests := []struct {
+		Name           string
+		Args           []string
+		ExpectedRemote string
+		ExpectedString string
+		ExpectedErr    string
+	}{
+		{
+			Name:           "No Args",
+			Args:           nil,
+			ExpectedRemote: "zaquestion/test",
+			ExpectedString: "",
+			ExpectedErr:    "",
+		},
+		{
+			Name:           "1 arg remote",
+			Args:           []string{"lab-testing"},
+			ExpectedRemote: "lab-testing/test",
+			ExpectedString: "",
+			ExpectedErr:    "",
+		},
+		{
+			Name:           "1 arg non remote",
+			Args:           []string{"foo123"},
+			ExpectedRemote: "zaquestion/test",
+			ExpectedString: "foo123",
+			ExpectedErr:    "",
+		},
+		{
+			Name:           "1 arg page",
+			Args:           []string{"100"},
+			ExpectedRemote: "zaquestion/test",
+			ExpectedString: "100",
+			ExpectedErr:    "",
+		},
+		{
+			Name:           "2 arg remote and string",
+			Args:           []string{"origin", "foo123"},
+			ExpectedRemote: "zaquestion/test",
+			ExpectedString: "foo123",
+			ExpectedErr:    "",
+		},
+		{
+			Name:           "2 arg invalid remote and string",
+			Args:           []string{"foo", "string123"},
+			ExpectedRemote: "",
+			ExpectedString: "",
+			ExpectedErr:    "foo is not a valid remote",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test := test
+			t.Parallel()
+			r, s, err := parseArgsRemoteString(test.Args)
+			if err != nil {
+				assert.EqualError(t, err, test.ExpectedErr)
+			}
+			assert.Equal(t, test.ExpectedRemote, r)
+			assert.Equal(t, test.ExpectedString, s)
+		})
+	}
+}


### PR DESCRIPTION
Adds search feature to `lab issue list`. (See #208)  Also aliases `list` to `search`, as in `lab project list`. 

```
lab issue list                        # no change; list all open issues
lab issue list "search terms"         # search issues for "search terms"
lab issue search "search terms"       # ditto
lab issue list remote "search terms"  # search "remote" for issues with "search terms"
```

Also, hope its OK I took the liberty to rename the `parseArgs*` functions to make them a little more clear.