### PR TITLE
add positional completion to issue edit

### DIFF
--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -281,5 +281,7 @@ func issueEditCmdAddFlags(flags *pflag.FlagSet) *pflag.FlagSet {
 
 func init() {
 	issueEditCmdAddFlags(issueEditCmd.Flags())
+	issueEditCmd.MarkZshCompPositionalArgumentCustom(1, "__lab_completion_remote")
+	issueEditCmd.MarkZshCompPositionalArgumentCustom(2, "__lab_completion_issue $words[2]")
 	issueCmd.AddCommand(issueEditCmd)
 }


### PR DESCRIPTION
#245 landed just after #252, so it missed the completion party. I think that this adds the required code to enable positional completion of `[remote]` and `<id>`. @rsteube can you take a peek to make sure I'm doing it right? I ~~copi~~...based this off of the completions in `issue note`.

Thanks!