### PR TITLE
project create: update help text

### DIFF
--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -11,13 +11,24 @@ import (
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
+// private and public are defined in snippet_create.go
+var internal bool
+
 // projectCreateCmd represents the create command
 var projectCreateCmd = &cobra.Command{
 	Use:   "create [path]",
 	Short: "Create a new project on GitLab",
-	Long: `If no path or name is provided the name of the git repo working directory
+	Long: `Create a new project on GitLab in your user namespace.
 
-path refers the path on gitlab including the full group/namespace/project. If no path or name is provided and the directory is a git repo the name of the current working directory will be used.`,
+path refers to the path on GitLab not including the group/namespace. If no path
+or name is provided and the current directory is a git repo, the name of the
+current working directory will be used.`,
+	Example: `# this command...                          # creates this project
+lab project create                         # user/<curr dir> named <curr dir>
+                                           # (above only works w/i git repo)
+lab project create myproject               # user/myproject named myproject
+lab project create myproject -n "new proj" # user/myproject named "new proj"
+lab project create -n "new proj"           # user/new-proj named "new proj"`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
@@ -29,10 +40,17 @@ path refers the path on gitlab including the full group/namespace/project. If no
 			log.Fatal("path or name must be set")
 		}
 
+		// set the default visibility
 		visibility := gitlab.InternalVisibility
+
+		// now override the visibility if the user passed in relevant flags. if
+		// the user passes multiple flags, this will use the "most private"
+		// option given, ignoring the rest
 		switch {
 		case private:
 			visibility = gitlab.PrivateVisibility
+		case internal:
+			visibility = gitlab.InternalVisibility
 		case public:
 			visibility = gitlab.PublicVisibility
 		}
@@ -75,9 +93,10 @@ func determinePath(args []string, name string) string {
 }
 
 func init() {
-	projectCreateCmd.Flags().StringP("name", "n", "", "name to use for the new project")
-	projectCreateCmd.Flags().StringP("description", "d", "", "description to use for the new project")
-	projectCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "Make project private; visible only to project members (default: internal)")
-	projectCreateCmd.Flags().BoolVar(&public, "public", false, "Make project public; can be accessed without any authentication (default: internal)")
+	projectCreateCmd.Flags().StringP("name", "n", "", "name of the new project")
+	projectCreateCmd.Flags().StringP("description", "d", "", "description of the new project")
+	projectCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "Make project private: visible only to project members")
+	projectCreateCmd.Flags().BoolVar(&public, "public", false, "Make project public: visible without any authentication")
+	projectCreateCmd.Flags().BoolVar(&internal,"internal", false, "Make project internal: visible to any authenticated user (default)")
 	projectCmd.AddCommand(projectCreateCmd)
 }


### PR DESCRIPTION
Based on #250, I removed the verbiage from the help text about visibility and left in the `--internal` flag to do the explaining for us. While I was at it, I made `--internal` an actual flag b/c I was worried that someone might (mistakenly) try to use `--internal --public`. In the case of multiple visibility flags, the command with use the "most private" of those provided.
