### PR TITLE
issue show: add --comments flag to print notes & discussions for issue

### DIFF
--- a/cmd/issue_show_test.go
+++ b/cmd/issue_show_test.go
@@ -10,7 +10,7 @@ import (
 func Test_issueShow(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
-	cmd := exec.Command("../lab_bin", "issue", "1")
+	cmd := exec.Command("../lab_bin", "issue", "show", "1", "--comments")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()
@@ -34,4 +34,6 @@ Time Stats: Estimated 1w, Spent 1d
 Labels: bug
 WebURL: https://gitlab.com/zaquestion/test/issues/1
 `)
+
+	require.Contains(t, string(b), `commented at`)
 }

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/spf13/viper v0.0.0-20180507071007-15738813a09d
 	github.com/stretchr/testify v1.2.1
 	github.com/tcnksm/go-gitconfig v0.1.2
-	github.com/xanzy/go-gitlab v0.0.0-20180921132519-8d21e61ce4a9
+	github.com/xanzy/go-gitlab v0.11.3
 	golang.org/x/crypto v0.0.0-20180420171155-e73bf333ef89
 	golang.org/x/oauth2 v0.0.0-20180724155351-3d292e4d0cdc // indirect
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/tcnksm/go-gitconfig v0.1.2 h1:iiDhRitByXAEyjgBqsKi9QU4o2TNtv9kPP3RgPg
 github.com/tcnksm/go-gitconfig v0.1.2/go.mod h1:/8EhP4H7oJZdIPyT+/UIsG87kTzrzM4UsLGSItWYCpE=
 github.com/xanzy/go-gitlab v0.0.0-20180921132519-8d21e61ce4a9 h1:gmCeo/bSUp/oLKpsZrICPRTgwsuI3m17l5c2X8y4/0g=
 github.com/xanzy/go-gitlab v0.0.0-20180921132519-8d21e61ce4a9/go.mod h1:CRKHkvFWNU6C3AEfqLWjnCNnAs4nj8Zk95rX2S3X6Mw=
+github.com/xanzy/go-gitlab v0.11.3 h1:gSYcSb+pCx3fco6/O3w784/omQVTcrgxRzyf14SBvUQ=
+github.com/xanzy/go-gitlab v0.11.3/go.mod h1:CRKHkvFWNU6C3AEfqLWjnCNnAs4nj8Zk95rX2S3X6Mw=
 golang.org/x/crypto v0.0.0-20180420171155-e73bf333ef89 h1:YMKUzb2eHV8HdgAr0z9lbGN1Av2h4cgMMsvi+JV60MM=
 golang.org/x/crypto v0.0.0-20180420171155-e73bf333ef89/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -383,6 +383,21 @@ func IssueClose(pid interface{}, id int) error {
 	return nil
 }
 
+// IssueListDiscussions retrieves the discussions (aka notes & comments) for an issue
+func IssueListDiscussions(project string, issueNum int) ([]*gitlab.Discussion, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return nil, err
+	}
+
+	discussions, _, err := lab.Discussions.ListIssueDiscussions(p.ID, issueNum, &gitlab.ListIssueDiscussionsOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return discussions, nil
+}
+
 // BranchPushed checks if a branch exists on a GitLab project
 func BranchPushed(pid interface{}, branch string) bool {
 	b, _, err := lab.Branches.GetBranch(pid, branch)


### PR DESCRIPTION
See #207.

* default: do not print comments (current behavior)
* added `-c/--comments` flag to print comments as well as normal `issue show` output. I put this behind a flag b/c it became immediately obvious after I started using it locally that I have 2 use cases for viewing issues: viewing the issue metadata (descriptions, todos, labels, deadlines, etc) and viewing the discussions. If comments are printed on every `show`, it's tedious to scroll up past them to view the meta.
* does not print the system notes (like "soandso added label 'bug'" or '... changed the description')
* I had to upgrade the version of `go-gitlab` to 0.11.3 in order to get the Discussions API.

The format of the comments is not sacred. I just wanted to get something in place to get to discussion started.

### Sample Output from https://gitlab.com/claytonrcarter/test/issues/2

```
$ ./lab issue show crc-testing 2 --comments

#2 Test issue for notes & discussions.
===================================
This is just an issues for testing notes and discussions in `lab`.
-----------------------------------
Project: claytonrcarter/test
Status: Open
Assignees:
Author: claytonrcarter
Milestone: None
Due Date: None
Time Stats: None
Labels:
WebURL: https://gitlab.com/claytonrcarter/test/issues/2

-----------------------------------
claytonrcarter commented at 2018-11-12 02:52:18.178 +0000 UTC

This comment is a note. (Comment 1.)

-----------------------------------
claytonrcarter started a discussion at 2018-11-12 02:52:39.251 +0000 UTC

    This comment is a discussion. (Comment 2.)

    -----------------------------------
    claytonrcarter commented at 2018-11-12 02:53:13.168 +0000 UTC

    This is a comment on the discussion. (Comment 2a.)

    -----------------------------------
    claytonrcarter commented at 2018-11-12 02:55:19.244 +0000 UTC

    This is another comment on the discussion. (Comment 2b.)

-----------------------------------
claytonrcarter started a discussion at 2018-11-12 02:55:28.528 +0000 UTC

    Another discussion. (Comment 3.)

-----------------------------------
claytonrcarter commented at 2018-11-12 02:56:23.967 +0000 UTC

Another comment. (Comment 4.)
```