### PR TITLE
install.sh script fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,4 +55,5 @@ latest="$(curl -sL 'https://api.github.com/repos/zaquestion/lab/releases/latest'
 
 curl -sL "https://github.com/zaquestion/lab/releases/download/v${latest}/lab_${latest}_${os}_${machine}.tar.gz" | tar -C /tmp/ -xzf -
 cp /tmp/lab $BINDIR/lab
+chmod +x $BINDIR/lab
 echo "Successfully installed lab into $BINDIR/"

--- a/install.sh
+++ b/install.sh
@@ -9,9 +9,21 @@ fi
 : ${PREFIX:=/usr/local}
 BINDIR="$PREFIX/bin"
 
+_can_install() {
+  if [[ ! -d "$BINDIR" ]]; then
+    mkdir -p "$BINDIR" 2> /dev/null
+  fi
+  [[ -d "$BINDIR" && -w "$BINDIR" ]]
+}
+
 if [[ $EUID != 0 ]]; then
     sudo "$0" "$@"
     exit "$?"
+fi
+
+if ! _can_install; then
+  echo "Can't install to $BINDIR"
+  exit 1
 fi
 
 case "$(uname -m)" in

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,5 @@ esac
 latest="$(curl -sL 'https://api.github.com/repos/zaquestion/lab/releases/latest' | grep 'tag_name' | grep --only 'v[0-9\.]\+' | cut -c 2-)"
 
 curl -sL "https://github.com/zaquestion/lab/releases/download/v${latest}/lab_${latest}_${os}_${machine}.tar.gz" | tar -C /tmp/ -xzf -
-cp /tmp/lab $BINDIR/lab
-chmod +x $BINDIR/lab
+install -m755 /tmp/lab $BINDIR/lab
 echo "Successfully installed lab into $BINDIR/"

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
-if [[ ! -z $DEBUG ]]; then
+if [[ ! -z ${DEBUG-} ]]; then
     set -x
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eu -o pipefail
 
 if [[ ! -z ${DEBUG-} ]]; then
     set -x

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,10 @@ fi
 : ${PREFIX:=/usr/local}
 BINDIR="$PREFIX/bin"
 
+if [[ $# -gt 0 ]]; then
+  BINDIR=$1
+fi
+
 _can_install() {
   if [[ ! -d "$BINDIR" ]]; then
     mkdir -p "$BINDIR" 2> /dev/null

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,9 @@ if [[ ! -z $DEBUG ]]; then
     set -x
 fi
 
+: ${PREFIX:=/usr/local}
+BINDIR="$PREFIX/bin"
+
 if [[ $EUID != 0 ]]; then
     sudo "$0" "$@"
     exit "$?"
@@ -39,5 +42,5 @@ esac
 latest="$(curl -sL 'https://api.github.com/repos/zaquestion/lab/releases/latest' | grep 'tag_name' | grep --only 'v[0-9\.]\+' | cut -c 2-)"
 
 curl -sL "https://github.com/zaquestion/lab/releases/download/v${latest}/lab_${latest}_${os}_${machine}.tar.gz" | tar -C /tmp/ -xzf -
-cp /tmp/lab /usr/local/bin/lab
-echo "Successfully installed lab into /usr/local/bin/"
+cp /tmp/lab $BINDIR/lab
+echo "Successfully installed lab into $BINDIR/"

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ _can_install() {
   [[ -d "$BINDIR" && -w "$BINDIR" ]]
 }
 
-if [[ $EUID != 0 ]]; then
+if ! _can_install && [[ $EUID != 0 ]]; then
     sudo "$0" "$@"
     exit "$?"
 fi


### PR DESCRIPTION
Started looking at this script to fix #262, and fixed a few other things while there :)

installing to a custom location is now done by setting the environment variable `PREFIX` before executing the script; eg.:
```bash
PREFIX=/usr install.sh
```
or
```bash
PREFIX=~/.local install.sh
```