### PR TITLE
Add `lab label` for listing and searching labels.

### DIFF
--- a/cmd/label.go
+++ b/cmd/label.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var labelCmd = &cobra.Command{
+	Use:   "label",
+	Short: `List and search labels`,
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+		return
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(labelCmd)
+}

--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var labelListCmd = &cobra.Command{
+	Use:     "list [remote] [search]",
+	Aliases: []string{"ls", "search"},
+	Short:   "List labels",
+	Long:    ``,
+	Example: `lab label list                       # list all labels
+lab label list "search term"         # search labels for "search term"
+lab label search "search term"       # same as above
+lab label list remote "search term"  # search "remote" for labels with "search term"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, labelSearch, err := parseArgsRemoteString(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		labelSearch = strings.ToLower(labelSearch)
+
+		labels, err := lab.LabelList(rn)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, label := range labels {
+			// GitLab API has no search for labels, so we do it ourselves
+			if labelSearch != "" &&
+				!(strings.Contains(strings.ToLower(label.Name), labelSearch) || strings.Contains(strings.ToLower(label.Description), labelSearch)) {
+				continue
+			}
+
+			description := ""
+			if label.Description != "" {
+				description = " - " + label.Description
+			}
+
+			fmt.Printf("%s%s\n", label.Name, description)
+		}
+	},
+}
+
+func init() {
+	labelCmd.AddCommand(labelListCmd)
+}

--- a/cmd/label_list_test.go
+++ b/cmd/label_list_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_labelList(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "label", "list")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	labels := strings.Split(string(b), "\n")
+	t.Log(labels)
+	require.Contains(t, labels, "bug")
+	require.Contains(t, labels, "confirmed")
+	require.Contains(t, labels, "critical")
+}
+
+func Test_labelListSearch(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "label", "list", "bug")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	labels := strings.Split(string(b), "\n")
+	t.Log(labels)
+	require.Contains(t, labels, "bug")
+	require.NotContains(t, labels, "confirmed")
+}
+
+func Test_labelListSearchCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "label", "list", "BUG")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	labels := strings.Split(string(b), "\n")
+	t.Log(labels)
+	require.Contains(t, labels, "bug")
+	require.NotContains(t, labels, "confirmed")
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -432,6 +432,21 @@ func BranchPushed(pid interface{}, branch string) bool {
 	return b != nil
 }
 
+// LabelList gets a list of labels on a GitLab Project
+func LabelList(project string) ([]*gitlab.Label, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return nil, err
+	}
+
+	list, _, err := lab.Labels.ListLabels(p.ID, &gitlab.ListLabelsOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return list, nil
+}
+
 // ProjectSnippetCreate creates a snippet in a project
 func ProjectSnippetCreate(pid interface{}, opts *gitlab.CreateProjectSnippetOptions) (*gitlab.Snippet, error) {
 	snip, _, err := lab.ProjectSnippets.CreateSnippet(pid, opts)


### PR DESCRIPTION
Nothing fancy, but I've had this kicking around for a while and might as well see if it sticks. This adds the ability to list and search labels such as:

```
lab label list
lab label search "search term"
```
