### PR TITLE
WIP: Add `--patch` option to `mr show`

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -110,6 +110,29 @@ func Log(sha1, sha2 string) (string, error) {
 	return string(outputs), nil
 }
 
+// Fetch a commit from a given remote
+func Fetch(remote, commit string) error {
+	gitcmd := []string{"fetch", remote, commit}
+	cmd := New(gitcmd...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	err := cmd.Run()
+	if err != nil {
+		return errors.Errorf("Can't fetch git commit %s from remote %s", commit, remote)
+	}
+	return nil
+}
+
+// Show all the commits between 2 git commits
+func Show(commit1, commit2 string, reverse bool) {
+	gitcmd := []string{"show"}
+	if reverse {
+		gitcmd = append(gitcmd, "--reverse")
+	}
+	gitcmd = append(gitcmd, fmt.Sprintf("%s..%s", commit1, commit2))
+	New(gitcmd...).Run()
+}
+
 // CurrentBranch returns the currently checked out branch and strips away all
 // but the branchname itself.
 func CurrentBranch() (string, error) {


### PR DESCRIPTION
Fixes #277

I also need to write tests for all the bits added; will do if/when you guys confirm that this is the right approach.

Also, an open question: do we want to mimic the behavior of `git show` with the `--reverse` flag, or can we just make it always pass `--reverse` so that the commits always show up in chronological order?
I'd prefer the latter, but I understand if we want the former for consistency.