### PR TITLE
tview patch: replace ANSII by ANSI

### DIFF
--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -323,7 +323,7 @@ func jobsView(app *tview.Application, jobsCh chan []*gitlab.Job, root *tview.Pag
 				tv.SetBorderPadding(0, 0, 1, 1).SetBorder(true)
 
 				go func() {
-					err := doTrace(context.Background(), vtclean.NewWriter(tview.ANSIIWriter(tv), true), projectID, branch, curJob.Name)
+					err := doTrace(context.Background(), vtclean.NewWriter(tview.ANSIWriter(tv), true), projectID, branch, curJob.Name)
 					if err != nil {
 						app.Stop()
 						log.Fatal(err)


### PR DESCRIPTION
The tview package has replaced ANSII* by ANSI* everywhere; this patch makes lab build with the current tview package.

This patch is due to Felix Lechner <felix.lechner@lease-up.com>