### PR TITLE
Stop "brew test" from hanging

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,10 +19,8 @@ brew:
     %w[haunted house].each { |f| touch testpath/f }
     system "git", "add", "haunted", "house"
     system "git", "commit", "-a", "-m", "Initial Commit"
-    system "git", "config", "--local", "--add", "gitlab.host", "http://example.com"
-    system "git", "config", "--local", "--add", "gitlab.user", "test"
-    system "git", "config", "--local", "--add", "gitlab.token", "test"
-    assert_equal "haunted\nhouse", shell_output("#{bin}/lab ls-files").strip
+    lab_env_config = "LAB_CORE_HOST=foo LAB_CORE_USER=bar LAB_CORE_TOKEN=baz"
+    assert_equal "haunted\nhouse", shell_output("#{lab_env_config} #{bin}/lab ls-files").strip
 scoop:
   bucket:
     owner: zaquestion


### PR DESCRIPTION
https://github.com/zaquestion/lab/issues/291 reports that "brew test" hangs
indefintely for lab. This is because a new lab is built and then, when
executed, it prompts the user for configuration. Standard output is captured by
the brew test runtime environment, so this is not clear for a casual observer.

Ideally, passthrough commands that are serviced by git (or hub) ought not to
stop the world and demand configuration, as well as commands that do not
require access to a GitLab API (e.g., "version"). However, this may require
non-negligible work for minimal gain, and the issue at hand can be avoided by
providing lab with some dummy configuration values passed through the
environment.

In addition, the "git config" lines in the test script have been removed, in
line with comments in the aforementioned issue that git configuration is no
longer used by lab.