### PR TITLE
Fix crash when opening issue in browser

### DIFF
--- a/cmd/issue_browse.go
+++ b/cmd/issue_browse.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"log"
-	"path"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -28,9 +27,11 @@ var issueBrowseCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		issueURL := path.Join(project.WebURL, "issues")
+		// path.Join will remove 1 "/" from "http://" as it's consider that's
+		// file system path. So we better use normal string concat
+		issueURL := project.WebURL + "/issues"
 		if num > 0 {
-			issueURL = path.Join(issueURL, strconv.FormatInt(num, 10))
+			issueURL = issueURL + "/" + strconv.FormatInt(num, 10)
 		}
 
 		err = browse(issueURL)

--- a/cmd/issue_browse.go
+++ b/cmd/issue_browse.go
@@ -2,13 +2,12 @@ package cmd
 
 import (
 	"log"
-	"net/url"
 	"path"
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/zaquestion/lab/internal/browser"
+	"github.com/zaquestion/lab/internal/gitlab"
 )
 
 var browse = browser.Open
@@ -24,20 +23,17 @@ var issueBrowseCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		c := viper.AllSettings()["core"]
-		config := c.([]map[string]interface{})[0]
-		host := config["host"].(string)
-
-		hostURL, err := url.Parse(host)
+		project, err := gitlab.FindProject(rn)
 		if err != nil {
 			log.Fatal(err)
 		}
-		hostURL.Path = path.Join(hostURL.Path, rn, "issues")
+
+		issueURL := path.Join(project.WebURL, "issues")
 		if num > 0 {
-			hostURL.Path = path.Join(hostURL.Path, strconv.FormatInt(num, 10))
+			issueURL = path.Join(issueURL, strconv.FormatInt(num, 10))
 		}
 
-		err = browse(hostURL.String())
+		err = browse(issueURL)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Lab crashes due to loading a non existed config file for the host url. Since other commands work just fine without the config file, we can use similar approach for `issue browse` command, which is detect project url from git host and build up the url.