### PR TITLE
#321: allow completions to be generated without authenticating with GitLab

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,6 +127,20 @@ func getUser(host, token string) string {
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	cmd.Version = version
-	lab.Init(loadConfig())
+	if !skipInit() {
+		lab.Init(loadConfig())
+	}
 	cmd.Execute()
+}
+
+func skipInit() bool {
+	if len(os.Args) <= 1 {
+		return false
+	}
+	switch os.Args[1] {
+	case "completion":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
This makes it easy for distributors to provide completion out of the box in packaged versions of lab