### PR TITLE
Better ci status

### DIFF
--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -7,28 +7,31 @@ import (
 	"text/tabwriter"
 
 	color "github.com/fatih/color"
-        flag "github.com/spf13/pflag"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/git"
-        gitlab "github.com/xanzy/go-gitlab"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
 var (
-  onlyFailures bool
-  useColor bool
-  noSkipped bool
-  wait bool
-  noCreated bool
-  summaryOnly bool
-  jobFormat = "%s:\t%s\t-\t%s\tid: %d\n"
-  failed = color.New(color.FgRed)
-  passed = color.New(color.FgGreen)
-  skipped = color.New(color.FgYellow)
-  running = color.New(color.FgBlue)
-  created = color.New(color.FgMagenta)
-  defaultPrinter = color.New(color.FgBlack)
+	onlyFailures   bool
+	useColor       bool
+	noSkipped      bool
+	wait           bool
+	noCreated      bool
+	summaryOnly    bool
+	failed         = color.New(color.FgRed)
+	passed         = color.New(color.FgGreen)
+	skipped        = color.New(color.FgYellow)
+	running        = color.New(color.FgBlue)
+	created        = color.New(color.FgMagenta)
+	defaultPrinter = color.New(color.FgBlack)
+)
+
+const (
+	jobFormat = "%*s: %*s - %10s id: %d\n"
 )
 
 // ciStatusCmd represents the run command
@@ -40,136 +43,147 @@ var ciStatusCmd = &cobra.Command{
 	Example: `lab ci status
 lab ci status --wait`,
 	RunE: nil,
-	Run: runCommand,
-      }
+	Run:  runCommand,
+}
 
 func runCommand(cmd *cobra.Command, args []string) {
-        branch, err := git.CurrentBranch()
-        if err != nil {
-                log.Fatal(err)
-        }
+	branch, err := git.CurrentBranch()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-        if len(args) > 1 {
-                branch = args[1]
-        }
-        remote := determineSourceRemote(branch)
-        if len(args) > 0 {
-                ok, err := git.IsRemote(args[0])
-                if err != nil || !ok {
-                        log.Fatal(args[0], " is not a remote:", err)
-                }
-                remote = args[0]
-        }
-        rn, err := git.PathWithNameSpace(remote)
-        if err != nil {
-                log.Fatal(err)
-        }
-        pid := rn
+	if len(args) > 1 {
+		branch = args[1]
+	}
+	remote := determineSourceRemote(branch)
+	if len(args) > 0 {
+		ok, err := git.IsRemote(args[0])
+		if err != nil || !ok {
+			log.Fatal(args[0], " is not a remote:", err)
+		}
+		remote = args[0]
+	}
+	rn, err := git.PathWithNameSpace(remote)
+	if err != nil {
+		log.Fatal(err)
+	}
+	pid := rn
 
-        w := tabwriter.NewWriter(os.Stdout, 2, 4, 1, byte(' '), 0)
-        jobs, err := lab.CIJobs(pid, branch)
-        if err != nil {
-                log.Fatal(errors.Wrap(err, "failed to find ci jobs"))
-        }
-        jobs = latestJobs(jobs)
+	w := tabwriter.NewWriter(os.Stdout, 2, 4, 1, byte(' '), 0)
+	jobs, err := lab.CIJobs(pid, branch)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "failed to find ci jobs"))
+	}
+	jobs = latestJobs(jobs)
 
-        if len(jobs) == 0 {
-                return
-        }
+	if len(jobs) == 0 {
+		return
+	}
 
-        if !summaryOnly {
-          fmt.Fprintln(w, "Stage:\tName\t-\tStatus")
-        }
-        color.NoColor = !useColor
-        var (
-                printer *color.Color
-        )
-        pipelineId := jobs[0].Pipeline.ID
-        pipeline, _, err := lab.Client().Pipelines.GetPipeline(pid, pipelineId)
-        if err != nil {
-                log.Fatal(errors.Wrap(err, "failed to get pipeline information"))
-        }
-        for {
-                if !summaryOnly {
-                  for _, job := range jobs {
-                            if noSkipped && job.Status == "skipped" {
-                                    continue
-                            } else if onlyFailures && job.Status != "failed" {
-                                    continue
-                            } else if noCreated && job.Status == "created" {
-                                    continue
-                            } else {
-                                    printer = statusColor(job.Status)
-                                    printer.Fprintf(w, jobFormat, job.Stage, job.Name, job.Status, job.ID)
-                            }
-                  }
-                }
-                if !wait {
-                        break
-                }
-                pl, _, err := lab.Client().Pipelines.GetPipeline(pid, pipelineId)
-                if err != nil {
-                        log.Fatal(errors.Wrap(err, "failed to get pipeline information"))
-                }
-                pipeline = pl
-                if pipeline.Status != "pending" && pipeline.Status != "running" {
-                        break
-                }
-                fmt.Fprintln(w)
-        }
+	if !summaryOnly {
+		fmt.Fprintln(w, "Stage:\tName\t-\tStatus")
+	}
+	color.NoColor = !useColor
+	var (
+		printer *color.Color
+	)
+	pipelineId := jobs[0].Pipeline.ID
+	pipeline, _, err := lab.Client().Pipelines.GetPipeline(pid, pipelineId)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "failed to get pipeline information"))
+	}
+	maxNameLength := 0
+	maxStageLength := 0
+	for _, job := range jobs {
+		if len(job.Name) > maxNameLength {
+			maxNameLength = len(job.Name)
+		}
+		if len(job.Stage) > maxStageLength {
+			maxStageLength = len(job.Stage)
+		}
+	}
 
-        fmt.Fprintf(w, pipelineStatus(pipeline, jobs))
-        if wait && pipeline.Status != "success" {
-                os.Exit(1)
-        }
-        w.Flush()
+	for {
+		if !summaryOnly {
+			for _, job := range jobs {
+				if noSkipped && job.Status == "skipped" {
+					continue
+				} else if onlyFailures && job.Status != "failed" {
+					continue
+				} else if noCreated && job.Status == "created" {
+					continue
+				} else {
+					printer = statusColor(job.Status)
+					printer.Fprintf(w, jobFormat, maxStageLength, job.Stage, -maxNameLength, job.Name, job.Status, job.ID)
+				}
+			}
+		}
+		if !wait {
+			break
+		}
+		pl, _, err := lab.Client().Pipelines.GetPipeline(pid, pipelineId)
+		if err != nil {
+			log.Fatal(errors.Wrap(err, "failed to get pipeline information"))
+		}
+		pipeline = pl
+		if pipeline.Status != "pending" && pipeline.Status != "running" {
+			break
+		}
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintf(w, pipelineStatus(pipeline, jobs))
+	if wait && pipeline.Status != "success" {
+		os.Exit(1)
+	}
+	w.Flush()
 }
 
 func pipelineStatus(pipeline *gitlab.Pipeline, jobs []*gitlab.Job) string {
-        return fmt.Sprintf("\nPipeline Status:\t%s\n%s\n\n%s\n",
-                statusColor(pipeline.Status).Sprintf(pipeline.Status), timeMessage(pipeline), jobSummary(jobs))
+	return fmt.Sprintf("\nPipeline Status:\t%s\n%s\n\n%s\n",
+		statusColor(pipeline.Status).Sprintf(pipeline.Status), timeMessage(pipeline), jobSummary(jobs))
 }
 
 func jobSummary(jobs []*gitlab.Job) string {
-        numPassed := 0
-        totalJobs := 0
-        numQueued := 0
-        numFailed := 0
+	numPassed := 0
+	totalJobs := 0
+	numQueued := 0
+	numFailed := 0
 
-        for _, job := range jobs {
-                totalJobs++
-                if (job.Status == "success") {
-                  numPassed++
-                }
-                if (job.Status == "created") {
-                  numQueued++
-                }
-                if (job.Status == "failed") {
-                  numFailed++
-                }
-        }
+	for _, job := range jobs {
+		totalJobs++
+		if job.Status == "success" {
+			numPassed++
+		}
+		if job.Status == "created" {
+			numQueued++
+		}
+		if job.Status == "failed" {
+			numFailed++
+		}
+	}
 
-        return fmt.Sprintf("total\tpassed\tfailed\tqueued\n%d\t%d\t%d\t%d",
-                           totalJobs, numPassed, numFailed, numQueued)
+	return fmt.Sprintf("total\tpassed\tfailed\tqueued\n%d\t%d\t%d\t%d",
+		totalJobs, numPassed, numFailed, numQueued)
 }
 
 func timeMessage(pipeline *gitlab.Pipeline) string {
-        if pipeline.Status == "pending" {
-          return fmt.Sprintf("created at %v", pipeline.CreatedAt)
-        } else if pipeline.Status == "running" {
-          return fmt.Sprintf("started at %v", pipeline.StartedAt)
-        } else {
-          hours   := pipeline.Duration / (60 * 60)
-          minutes := (pipeline.Duration / 60) - (hours * 60)
-          seconds := pipeline.Duration % 60
-          if hours > 0 {
-            return fmt.Sprintf("duration:\t%d hrs, %d min, %d secs", hours, minutes, seconds)
-          } else if minutes > 0 {
-            return fmt.Sprintf("duration:\t%d min, %d secs", minutes, seconds)
-          } else {
-            return fmt.Sprintf("duration:\t%d secs", pipeline.Duration)
-          }
-        }
+	if pipeline.Status == "pending" {
+		return fmt.Sprintf("created at %v", pipeline.CreatedAt)
+	} else if pipeline.Status == "running" {
+		return fmt.Sprintf("started at %v", pipeline.StartedAt)
+	} else {
+		hours := pipeline.Duration / (60 * 60)
+		minutes := (pipeline.Duration / 60) - (hours * 60)
+		seconds := pipeline.Duration % 60
+		if hours > 0 {
+			return fmt.Sprintf("duration:\t%d hrs, %d min, %d secs", hours, minutes, seconds)
+		} else if minutes > 0 {
+			return fmt.Sprintf("duration:\t%d min, %d secs", minutes, seconds)
+		} else {
+			return fmt.Sprintf("duration:\t%d secs", pipeline.Duration)
+		}
+	}
 }
 
 func aliasFailures(f *flag.FlagSet, name string) flag.NormalizedName {
@@ -182,35 +196,35 @@ func aliasFailures(f *flag.FlagSet, name string) flag.NormalizedName {
 }
 
 func statusColor(status string) *color.Color {
-        switch status {
-        case "failed":
-                return failed
-        case "success":
-                return passed
-        case "passed":
-                return passed
-        case "running":
-                return running
-        case "created":
-                return created
-        case "pending":
-                return created
-        case "skipped":
-                return skipped
-        default:
-                return defaultPrinter
-        }
+	switch status {
+	case "failed":
+		return failed
+	case "success":
+		return passed
+	case "passed":
+		return passed
+	case "running":
+		return running
+	case "created":
+		return created
+	case "pending":
+		return created
+	case "skipped":
+		return skipped
+	default:
+		return defaultPrinter
+	}
 }
 
 func init() {
-        defaultPrinter.DisableColor()
+	defaultPrinter.DisableColor()
 	ciStatusCmd.MarkZshCompPositionalArgumentCustom(1, "__lab_completion_remote_branches")
 	ciStatusCmd.Flags().BoolVarP(&wait, "wait", "w", false, "Continuously print the status and wait to exit until the pipeline finishes. Exit code indicates pipeline status")
 	ciStatusCmd.Flags().BoolVarP(&noSkipped, "no-skipped", "", false, "Ignore skipped tests - do not print them")
 	ciStatusCmd.Flags().BoolVarP(&useColor, "color", "c", false, "Use color for success and failure")
 	ciStatusCmd.Flags().BoolVarP(&onlyFailures, "failures", "f", false, "Only print failures")
-        ciStatusCmd.Flags().BoolVarP(&noCreated, "results-only", "r", false, "Only show completed and running tests. Does not report queued jobs")
-        ciStatusCmd.Flags().BoolVarP(&summaryOnly, "summary", "s", false, "Do not show individual jobs, just the pipeline summary")
-        ciStatusCmd.Flags().SetNormalizeFunc(aliasFailures)
+	ciStatusCmd.Flags().BoolVarP(&noCreated, "results-only", "r", false, "Only show completed and running tests. Does not report queued jobs")
+	ciStatusCmd.Flags().BoolVarP(&summaryOnly, "summary", "s", false, "Do not show individual jobs, just the pipeline summary")
+	ciStatusCmd.Flags().SetNormalizeFunc(aliasFailures)
 	ciCmd.AddCommand(ciStatusCmd)
 }

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/git"
+        gitlab "github.com/xanzy/go-gitlab"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
@@ -19,6 +20,8 @@ var (
   useColor bool
   noSkipped bool
   wait bool
+  noCreated bool
+  summaryOnly bool
   jobFormat = "%s:\t%s\t-\t%s\tid: %d\n"
   failed = color.New(color.FgRed)
   passed = color.New(color.FgGreen)
@@ -37,72 +40,136 @@ var ciStatusCmd = &cobra.Command{
 	Example: `lab ci status
 lab ci status --wait`,
 	RunE: nil,
-	Run: func(cmd *cobra.Command, args []string) {
-		branch, err := git.CurrentBranch()
-		if err != nil {
-			log.Fatal(err)
-		}
+	Run: runCommand,
+      }
 
-		if len(args) > 1 {
-			branch = args[1]
-		}
-		remote := determineSourceRemote(branch)
-		if len(args) > 0 {
-			ok, err := git.IsRemote(args[0])
-			if err != nil || !ok {
-				log.Fatal(args[0], " is not a remote:", err)
-			}
-			remote = args[0]
-		}
-		rn, err := git.PathWithNameSpace(remote)
-		if err != nil {
-			log.Fatal(err)
-		}
-		pid := rn
+func runCommand(cmd *cobra.Command, args []string) {
+        branch, err := git.CurrentBranch()
+        if err != nil {
+                log.Fatal(err)
+        }
 
-		w := tabwriter.NewWriter(os.Stdout, 2, 4, 1, byte(' '), 0)
-		jobs, err := lab.CIJobs(pid, branch)
-		if err != nil {
-			log.Fatal(errors.Wrap(err, "failed to find ci jobs"))
-		}
-		jobs = latestJobs(jobs)
+        if len(args) > 1 {
+                branch = args[1]
+        }
+        remote := determineSourceRemote(branch)
+        if len(args) > 0 {
+                ok, err := git.IsRemote(args[0])
+                if err != nil || !ok {
+                        log.Fatal(args[0], " is not a remote:", err)
+                }
+                remote = args[0]
+        }
+        rn, err := git.PathWithNameSpace(remote)
+        if err != nil {
+                log.Fatal(err)
+        }
+        pid := rn
 
-		if len(jobs) == 0 {
-			return
-		}
+        w := tabwriter.NewWriter(os.Stdout, 2, 4, 1, byte(' '), 0)
+        jobs, err := lab.CIJobs(pid, branch)
+        if err != nil {
+                log.Fatal(errors.Wrap(err, "failed to find ci jobs"))
+        }
+        jobs = latestJobs(jobs)
 
-		fmt.Fprintln(w, "Stage:\tName\t-\tStatus")
-		color.NoColor = !useColor
-		var (
-			printer *color.Color
-		)
-		for {
-			for _, job := range jobs {
-				if noSkipped && job.Status == "skipped" {
-					continue
-				} else if onlyFailures && job.Status != "failed" {
-					continue
-				} else {
-                                        printer = statusColor(job.Status)
-					printer.Fprintf(w, jobFormat, job.Stage, job.Name, job.Status, job.ID)
-				}
-			}
-			if !wait {
-				break
-			}
-			if jobs[0].Pipeline.Status != "pending" &&
-				jobs[0].Pipeline.Status != "running" {
-				break
-			}
-			fmt.Fprintln(w)
-		}
+        if len(jobs) == 0 {
+                return
+        }
 
-		fmt.Fprintf(w, "\nPipeline Status: %s\n", jobs[0].Pipeline.Status)
-		if wait && jobs[0].Pipeline.Status != "success" {
-			os.Exit(1)
-		}
-		w.Flush()
-	},
+        if !summaryOnly {
+          fmt.Fprintln(w, "Stage:\tName\t-\tStatus")
+        }
+        color.NoColor = !useColor
+        var (
+                printer *color.Color
+        )
+        pipelineId := jobs[0].Pipeline.ID
+        pipeline, _, err := lab.Client().Pipelines.GetPipeline(pid, pipelineId)
+        if err != nil {
+                log.Fatal(errors.Wrap(err, "failed to get pipeline information"))
+        }
+        for {
+                if !summaryOnly {
+                  for _, job := range jobs {
+                            if noSkipped && job.Status == "skipped" {
+                                    continue
+                            } else if onlyFailures && job.Status != "failed" {
+                                    continue
+                            } else if noCreated && job.Status == "created" {
+                                    continue
+                            } else {
+                                    printer = statusColor(job.Status)
+                                    printer.Fprintf(w, jobFormat, job.Stage, job.Name, job.Status, job.ID)
+                            }
+                  }
+                }
+                if !wait {
+                        break
+                }
+                pl, _, err := lab.Client().Pipelines.GetPipeline(pid, pipelineId)
+                if err != nil {
+                        log.Fatal(errors.Wrap(err, "failed to get pipeline information"))
+                }
+                pipeline = pl
+                if pipeline.Status != "pending" && pipeline.Status != "running" {
+                        break
+                }
+                fmt.Fprintln(w)
+        }
+
+        fmt.Fprintf(w, pipelineStatus(pipeline, jobs))
+        if wait && pipeline.Status != "success" {
+                os.Exit(1)
+        }
+        w.Flush()
+}
+
+func pipelineStatus(pipeline *gitlab.Pipeline, jobs []*gitlab.Job) string {
+        return fmt.Sprintf("\nPipeline Status:\t%s\n%s\n\n%s\n",
+                pipeline.Status, timeMessage(pipeline), jobSummary(jobs))
+}
+
+func jobSummary(jobs []*gitlab.Job) string {
+        numPassed := 0
+        totalJobs := 0
+        numQueued := 0
+        numFailed := 0
+
+        for _, job := range jobs {
+                totalJobs++
+                if (job.Status == "success") {
+                  numPassed++
+                }
+                if (job.Status == "created") {
+                  numQueued++
+                }
+                if (job.Status == "failed") {
+                  numFailed++
+                }
+        }
+
+        return fmt.Sprintf("total\tpassed\tfailed\tqueued\n%d\t%d\t%d\t%d",
+                           totalJobs, numPassed, numFailed, numQueued)
+}
+
+func timeMessage(pipeline *gitlab.Pipeline) string {
+        if pipeline.Status == "pending" {
+          return fmt.Sprintf("created at %v", pipeline.CreatedAt)
+        } else if pipeline.Status == "running" {
+          return fmt.Sprintf("started at %v", pipeline.StartedAt)
+        } else {
+          hours   := pipeline.Duration / (60 * 60)
+          minutes := (pipeline.Duration / 60) - (hours * 60)
+          seconds := pipeline.Duration % 60
+          if hours > 0 {
+            return fmt.Sprintf("duration:\t%d hrs, %d min, %d secs", hours, minutes, seconds)
+          } else if minutes > 0 {
+            return fmt.Sprintf("duration:\t%d min, %d secs", minutes, seconds)
+          } else {
+            return fmt.Sprintf("duration:\t%d secs", pipeline.Duration)
+          }
+        }
 }
 
 func aliasFailures(f *flag.FlagSet, name string) flag.NormalizedName {
@@ -138,6 +205,8 @@ func init() {
 	ciStatusCmd.Flags().BoolVarP(&noSkipped, "no-skipped", "", false, "Ignore skipped tests - do not print them")
 	ciStatusCmd.Flags().BoolVarP(&useColor, "color", "c", false, "Use color for success and failure")
 	ciStatusCmd.Flags().BoolVarP(&onlyFailures, "failures", "f", false, "Only print failures")
+        ciStatusCmd.Flags().BoolVarP(&noCreated, "results-only", "r", false, "Only show completed and running tests. Does not report queued jobs")
+        ciStatusCmd.Flags().BoolVarP(&summaryOnly, "summary", "s", false, "Do not show individual jobs, just the pipeline summary")
         ciStatusCmd.Flags().SetNormalizeFunc(aliasFailures)
 	ciCmd.AddCommand(ciStatusCmd)
 }

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -127,7 +127,7 @@ func runCommand(cmd *cobra.Command, args []string) {
 
 func pipelineStatus(pipeline *gitlab.Pipeline, jobs []*gitlab.Job) string {
         return fmt.Sprintf("\nPipeline Status:\t%s\n%s\n\n%s\n",
-                pipeline.Status, timeMessage(pipeline), jobSummary(jobs))
+                statusColor(pipeline.Status).Sprintf(pipeline.Status), timeMessage(pipeline), jobSummary(jobs))
 }
 
 func jobSummary(jobs []*gitlab.Job) string {
@@ -187,9 +187,13 @@ func statusColor(status string) *color.Color {
                 return failed
         case "success":
                 return passed
+        case "passed":
+                return passed
         case "running":
                 return running
         case "created":
+                return created
+        case "pending":
                 return created
         case "skipped":
                 return skipped

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -78,6 +78,14 @@ lab ci status --wait`,
 		failed := color.New(color.FgRed)
 		passed := color.New(color.FgGreen)
 		skipped := color.New(color.FgYellow)
+		running := color.New(color.FgBlue)
+		created := color.New(color.FgMagenta)
+		defaultPrinter := color.New(color.FgBlack)
+		defaultPrinter.DisableColor()
+		color.NoColor = !useColor
+		var (
+			printer *color.Color
+		)
 		for {
 			for _, job := range jobs {
 				if noSkipped && job.Status == "skipped" {
@@ -85,15 +93,21 @@ lab ci status --wait`,
 				} else if onlyFailures && job.Status != "failed" {
 					continue
 				} else {
-					if useColor && job.Status == "failed" {
-						failed.Fprintf(w, jobFormat, job.Stage, job.Name, job.ID, job.Status)
-					} else if useColor && job.Status == "success" {
-						passed.Fprintf(w, jobFormat, job.Stage, job.Name, job.ID, job.Status)
-					} else if useColor && job.Status == "skipped" {
-						skipped.Fprintf(w, jobFormat, job.Stage, job.Name, job.ID, job.Status)
-					} else {
-						fmt.Fprintf(w, jobFormat, job.Stage, job.Name, job.ID, job.Status)
+					switch job.Status {
+					case "failed":
+						printer = failed
+					case "success":
+						printer = passed
+					case "running":
+						printer = running
+					case "created":
+						printer = created
+					case "skipped":
+						printer = skipped
+					default:
+						printer = defaultPrinter
 					}
+					printer.Fprintf(w, jobFormat, job.Stage, job.Name, job.ID, job.Status)
 				}
 			}
 			if !wait {

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -102,12 +102,13 @@ func doTraceByJobID(ctx context.Context, w io.Writer, pid interface{}, jobID int
 	if err != nil {
 		return err
 	}
-	cacheKey = fmt.Sprintf("%d-%v.log", jobID, job.CreatedAt)
+	cacheKey = fmt.Sprintf("%d-%d.log", jobID, job.CreatedAt.Unix())
 	var reader io.Reader
 
 	inCache, cached, err := lab.ReadCache(cacheKey)
 
 	if jobIsFinished(job) && inCache && err == nil {
+		fmt.Fprintf(w, "[FROM CACHE]")
 		reader = bytes.NewReader(cached)
 	} else {
 		trace, _, err := client.Jobs.GetTraceFile(pid, jobID)

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -7,12 +7,14 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
@@ -43,8 +45,24 @@ var ciTraceCmd = &cobra.Command{
 		remote = determineSourceRemote(branch)
 		if len(args) > 0 {
 			ok, err := git.IsRemote(args[0])
-			if err != nil || !ok {
+			if err != nil {
 				log.Fatal(args[0], " is not a remote:", err)
+			} else if !ok {
+				i, err := strconv.Atoi(args[0])
+				if err == nil {
+					rn, err := git.PathWithNameSpace(remote)
+					if err != nil {
+						log.Fatal(err)
+					}
+					project, err := lab.FindProject(rn)
+					if err != nil {
+						log.Fatal(err)
+					}
+					doTraceByJobID(context.Background(), os.Stdout, project.ID, i)
+					return
+				} else {
+					log.Fatal(args[0], " is not a remote:", err)
+				}
 			}
 			remote = args[0]
 		}
@@ -64,15 +82,41 @@ var ciTraceCmd = &cobra.Command{
 	},
 }
 
+func doTraceByJobID(ctx context.Context, w io.Writer, pid interface{}, jobID int) error {
+	var (
+		offset int64
+	)
+	client := lab.Client()
+	offset = 0
+	job, _, err := client.Jobs.GetJob(pid, jobID)
+	if err != nil {
+		return err
+	}
+	trace, _, err := client.Jobs.GetTraceFile(pid, jobID)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "Showing logs for %s job #%d\n", job.Name, job.ID)
+	return printTrace(w, job, &offset, trace)
+}
+
+func printTrace(w io.Writer, job *gitlab.Job, offset *int64, trace io.Reader) error {
+	_, err := io.CopyN(ioutil.Discard, trace, *offset)
+	lenT, err := io.Copy(w, trace)
+	if err != nil {
+		return err
+	}
+	*offset += int64(lenT)
+	return nil
+}
+
 func doTrace(ctx context.Context, w io.Writer, pid interface{}, branch, name string) error {
 	var (
 		once   sync.Once
-		offset int64
+		offset *int64
 	)
+	*offset = 0
 	for range time.NewTicker(time.Second * 3).C {
-		if ctx.Err() == context.Canceled {
-			break
-		}
 		trace, job, err := lab.CITrace(pid, branch, name)
 		if err != nil || job == nil || trace == nil {
 			return errors.Wrap(err, "failed to find job")
@@ -91,13 +135,10 @@ func doTrace(ctx context.Context, w io.Writer, pid interface{}, branch, name str
 			}
 			fmt.Fprintf(w, "Showing logs for %s job #%d\n", job.Name, job.ID)
 		})
-		_, err = io.CopyN(ioutil.Discard, trace, offset)
-		lenT, err := io.Copy(w, trace)
-		if err != nil {
-			return err
+		if ctx.Err() == context.Canceled {
+			break
 		}
-		offset += int64(lenT)
-
+		printTrace(w, job, offset, trace)
 		if job.Status == "success" ||
 			job.Status == "failed" ||
 			job.Status == "cancelled" {

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -102,7 +102,7 @@ func doTraceByJobID(ctx context.Context, w io.Writer, pid interface{}, jobID int
 	if err != nil {
 		return err
 	}
-	cacheKey = fmt.Sprintf("%d-%d.log", jobID, job.CreatedAt.Unix())
+	cacheKey = fmt.Sprintf("cmd_trace-%d-%d.log", jobID, job.CreatedAt.Unix())
 	var reader io.Reader
 
 	inCache, cached, err := lab.ReadCache(cacheKey)

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
 	lab "github.com/zaquestion/lab/internal/gitlab"
+	git "github.com/zaquestion/lab/internal/git"
 )
 
 var mrShowCmd = &cobra.Command{
@@ -22,6 +23,27 @@ var mrShowCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+                if int(mrNum) <= 0 {
+			currentBranch, err := git.CurrentBranch()
+			if err != nil {
+				log.Fatal(err)
+			}
+			mrs, err := lab.MRList(rn, gitlab.ListProjectMergeRequestsOptions{
+				ListOptions: gitlab.ListOptions{
+					PerPage: 10,
+				},
+				Labels:       mrLabels,
+				State:        &mrState,
+				OrderBy:      gitlab.String("updated_at"),
+				SourceBranch: gitlab.String(currentBranch),
+			}, -1)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if len(mrs) > 0 {
+				mrNum = int64(mrs[0].IID)
+			}
+                }
 		mr, err := lab.MRGet(rn, int(mrNum))
 		if err != nil {
 			log.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/rivo/tview v0.0.0-20190721135419-23dc8a0944e4
 	github.com/russross/blackfriday v1.5.1 // indirect
+	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/sirupsen/logrus v1.2.0 // indirect
 	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
 	github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,17 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/derekparker/delve v1.1.0
 	github.com/gdamore/tcell v1.1.4
+	github.com/fatih/color v1.7.0
+	github.com/gdamore/encoding v0.0.0-20151215212835-b23993cbb635 // indirect
+	github.com/gdamore/tcell v0.0.0-20180416163743-2f258105ca8c
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jtolds/gls v4.2.1+incompatible // indirect
 	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a
 	github.com/magiconair/properties v1.7.6 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-runewidth v0.0.2 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238 // indirect
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/pelletier/go-toml v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,8 @@ require (
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/derekparker/delve v1.1.0
-	github.com/gdamore/tcell v1.1.4
 	github.com/fatih/color v1.7.0
-	github.com/gdamore/encoding v0.0.0-20151215212835-b23993cbb635 // indirect
-	github.com/gdamore/tcell v0.0.0-20180416163743-2f258105ca8c
+	github.com/gdamore/tcell v1.1.4
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -17,7 +15,6 @@ require (
 	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a
 	github.com/magiconair/properties v1.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
-	github.com/mattn/go-runewidth v0.0.2 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238 // indirect
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/pelletier/go-toml v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/derekparker/delve v1.1.0 h1:icd65nMp7s2HiLz6y/6RCVXBdoED3xxYLwX09EMaRCc=
 github.com/derekparker/delve v1.1.0/go.mod h1:pMSZMfp0Nhbm8qdZJkuE/yPGOkLpGXLS1I4poXQpuJU=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gdamore/encoding v0.0.0-20151215212835-b23993cbb635 h1:hheUEMzaOie/wKeIc1WPa7CDVuIO5hqQxjS+dwTQEnI=
@@ -48,6 +50,10 @@ github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBF
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.7.6 h1:U+1DqNen04MdEPgFiIwdOUiqZ8qPa37xgogX/sd3+54=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.2 h1:UnlwIPBGaTZfPQ6T1IGzPI0EkYAQmT9fAEJ/poFC63o=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/rsteube/cobra v0.0.1-zsh-completion-custom h1:Hqbid4kBOEu78syaZ8hCAIj
 github.com/rsteube/cobra v0.0.1-zsh-completion-custom/go.mod h1:pAlNXnbm7kUeUgr/8AEn0Lv+VrT1T6obUvI1mC8KlvA=
 github.com/russross/blackfriday v1.5.1 h1:B8ZN6pD4PVofmlDCDUdELeYrbsVIDM/bpjW3v3zgcRc=
 github.com/russross/blackfriday v1.5.1/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0 h1:Xuk8ma/ibJ1fOy4Ee11vHhUFHQNpHhrBneOCNHVXS5w=
+github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0/go.mod h1:7AwjWCpdPhkSmNAgUv5C7EJ4AbmjEB3r047r3DXWu3Y=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756 h1:9nuHUbU8dRnRRfj9KjWUVrJeoexdbeMjttk6Oh1rD10=
 golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	configdir "github.com/shibukawa/configdir"
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/git"
 )
@@ -55,12 +56,31 @@ func Init(_host, _user, _token string) {
 	token = _token
 	lab = gitlab.NewClient(nil, token)
 	lab.SetBaseURL(host + "/api/v4")
+	configDirs := configdir.New("zaquestion", "lab-cli")
+	cacheDir = configDirs.QueryCacheFolder()
+}
+
+func ReadCache(fileName string) (bool, []byte, error) {
+	if !cacheDir.Exists(fileName) {
+		return false, nil, nil
+	}
+	b, err := cacheDir.ReadFile(fileName)
+	return true, b, err
+}
+
+func WriteCache(fileName string, buffer []byte) error {
+	return cacheDir.WriteFile(fileName, buffer)
 }
 
 // Defines filepath for default GitLab templates
 const (
 	TmplMR    = "merge_request_templates/default.md"
 	TmplIssue = "issue_templates/default.md"
+)
+
+// Cache directory
+var (
+	cacheDir *configdir.Config
 )
 
 // LoadGitLabTmpl loads gitlab templates for use in creating Issues and MRs

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -41,6 +41,10 @@ func User() string {
 	return user
 }
 
+func Client() *gitlab.Client {
+	return lab
+}
+
 // Init initializes a gitlab client for use throughout lab.
 func Init(_host, _user, _token string) {
 	if len(_host) > 0 && _host[len(_host)-1 : len(_host)][0] == '/' {
@@ -170,18 +174,18 @@ func MRCreate(project string, opts *gitlab.CreateMergeRequestOptions) (string, e
 
 // MRCreateNote adds a note to a merge request on GitLab
 func MRCreateNote(project string, mrNum int, opts *gitlab.CreateMergeRequestNoteOptions) (string, error) {
-        p, err := FindProject(project)
-        if err != nil {
-                return "", err
-        }
+	p, err := FindProject(project)
+	if err != nil {
+		return "", err
+	}
 
-        note, _, err := lab.Notes.CreateMergeRequestNote(p.ID, mrNum, opts)
-        if err != nil {
-                return "", err
-        }
-        // Unlike MR, Note has no WebURL property, so we have to create it
-        // ourselves from the project, noteable id and note id
-        return fmt.Sprintf("%s/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+	note, _, err := lab.Notes.CreateMergeRequestNote(p.ID, mrNum, opts)
+	if err != nil {
+		return "", err
+	}
+	// Unlike MR, Note has no WebURL property, so we have to create it
+	// ourselves from the project, noteable id and note id
+	return fmt.Sprintf("%s/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }
 
 // MRGet retrieves the merge request from GitLab project


### PR DESCRIPTION
This adds several useful features that I am using on a daily basis:

* allow selecting a trace job by ID
* colours for different statuses
* adding job ID to output so I can easily integrate status and trace commands
* flags for filtering output (only show failures, only show summary)
* nicer summary layout
* display start times and duration
* select the current MR by default in `mr show`

For our workflow, where our pipeline takes over an hour, and has 122 jobs, these features have proved invaluable.

No tests added yet - but since the testdata repo does not have any CI jobs, this is going to be difficult - @zaquestion: could you please add some MRs with CI jobs? Finished ones are fine, ideally with some failed jobs though!


