### PR TITLE
mr_create: parse & abide cli positional args

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -72,15 +72,35 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	branch, err := git.CurrentBranch()
-	if err != nil {
-		log.Fatal(err)
+
+	var sourceRemote, sourceProjectName string
+	// If we have args attempt to get sourceProjectName and branch from args
+	if len(args) > 0 {
+		sourceProjectName, branch, err = parseArgsRemoteString(args)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
-	sourceRemote := determineSourceRemote(branch)
-	sourceProjectName, err := git.PathWithNameSpace(sourceRemote)
-	if err != nil {
-		log.Fatal(err)
+	// If we didn't get the branch name from args, get it from git context
+	if branch == "" {
+		branch, err = git.CurrentBranch()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// If we didn't get sourceProjectName from args, get it from git context
+	if sourceProjectName == "" {
+		sourceRemote = determineSourceRemote(branch)
+
+		sourceProjectName, err = git.PathWithNameSpace(sourceRemote)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		// Since we got sourceProjectName from args, set sourceRemote from args also for the benefit of following logic
+		sourceRemote = args[0]
 	}
 
 	p, err := lab.FindProject(sourceProjectName)


### PR DESCRIPTION
According to the command help `lab mr create` accepts positional CLI args for both the `remote` and the `branch` name. However, in practice it doesn't appear to actually do that.

I ran into issues where I wanted to specify my own remote as an easy way to get around the fact that lab doesn't appear to be able to parse dot-repository remotes for branches (i.e. `remote = .`). However, when I tried to specify my own remote (`lab mr create <remote_name>`) I noticed that lab doesn't actually do anything with the arguments that are passed.

This PR should fix this problem, accepting both the remote name and the branch name from the arguments provided.