### PR TITLE
readme: warn before aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,17 @@ fpath=(/path/to/script_directory $fpath)
 
 # Aliasing
 
-Like hub, lab feels best when aliased as `git`. In your `.bashrc` or `.bash_profile`
+Like hub, lab feels best when aliased as `git`. In your `.bashrc` or `.bash_profile`:
+
 ```
 alias git=lab
+```
+
+NOTE: before aliasing, if you use git in your shell prompt command, be sure lab works by it's own first:
+
+```
+$ lab
+Enter GitLab host (default: https://gitlab.com):
 ```
 
 <p align="center"><img src="https://user-images.githubusercontent.com/2358914/34196973-420d389a-e519-11e7-92e6-3a1486d6b280.png" align="center"></p>


### PR DESCRIPTION
the aliasing is very dangerous, it can kill your terminal:

![image](https://user-images.githubusercontent.com/199095/77882241-4439e980-7269-11ea-9fa5-49d94660bd6e.png)

the problem is that my shell prompt executes git commands to draw prompt. yet lab is pretty aggressive about it's configuration. maybe it's problem on it's own that it should ask for gitlab credentials ONLY when these are needed, proxying things if they are missing.

I've debugged and found the command that my prompt used to be:

```
[~/scm/tmp/castnow (master)★] ➔ alias git='_git() { echo >&2 "git $*"; git "$@"; }; _git'
[~/scm/tmp/castnow (master)★] ➔ cd .
git rev-parse @
[~/scm/tmp/castnow (master)★] ➔
```

```
[~/scm/tmp/castnow (master)★] ➔ lab rev-parse @
Enter GitLab host (default: https://gitlab.com): ^C
```