### PR TITLE
base changes for issue #338

### DIFF
--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -46,11 +46,11 @@ lab ci status --wait`,
 			log.Fatal(err)
 		}
 		pid := rn
-		branch, err := lab.GetBranch(pid, branchName)
+		commit, err := lab.GetCommit(pid, branchName)
 		if err != nil {
 			log.Fatal(err)
 		}
-		commitSHA = branch.Commit.ID
+		commitSHA = commit.ID
 
 		w := tabwriter.NewWriter(os.Stdout, 2, 4, 1, byte(' '), 0)
 

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -59,11 +59,11 @@ var ciTraceCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		projectID = project.ID
-		branch, err := lab.GetBranch(projectID, branchName)
+		commit, err := lab.GetCommit(projectID, branchName)
 		if err != nil {
 			log.Fatal(err)
 		}
-		commitSHA = branch.Commit.ID
+		commitSHA = commit.ID
 
 		err = doTrace(context.Background(), os.Stdout, project.ID, commitSHA, jobName)
 		if err != nil {

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -56,6 +56,7 @@ Feedback Encouraged!: https://github.com/zaquestion/lab/issues`,
 		}
 
 		if len(args) > 1 {
+			// branchName may also be a tag
 			branchName = args[1]
 		}
 		remote = determineSourceRemote(branchName)
@@ -78,11 +79,11 @@ Feedback Encouraged!: https://github.com/zaquestion/lab/issues`,
 			log.Fatal(err)
 		}
 		projectID = project.ID
-		branch, err := lab.GetBranch(projectID, branchName)
+		commit, err := lab.GetCommit(projectID, branchName)
 		if err != nil {
 			log.Fatal(err)
 		}
-		commitSHA = branch.Commit.ID
+		commitSHA = commit.ID
 		root := tview.NewPages()
 		root.SetBorderPadding(1, 1, 2, 2)
 

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -19,14 +19,13 @@ import (
 	"github.com/lunixbochs/vtclean"
 	gitlab "github.com/xanzy/go-gitlab"
 
-	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
 var (
-	projectID  int
-	branchName string
-	commitSHA  string
+	projectID int
+	refName   string
+	commitSHA string
 )
 
 // ciViewCmd represents the ci command
@@ -47,39 +46,21 @@ Feedback Encouraged!: https://github.com/zaquestion/lab/issues`,
 		a := tview.NewApplication()
 		defer recoverPanic(a)
 		var (
-			remote string
-			err    error
+			rn  string
+			err error
 		)
-		branchName, err = git.CurrentBranch()
+
+		rn, refName, err = parseArgsRemoteRef(args)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		if len(args) > 1 {
-			// branchName may also be a tag
-			branchName = args[1]
-		}
-		remote = determineSourceRemote(branchName)
-		if len(args) > 0 {
-			ok, err := git.IsRemote(args[0])
-			if err != nil || !ok {
-				log.Fatal(args[0], " is not a remote:", err)
-			}
-			remote = args[0]
-		}
-
-		// See if we're in a git repo or if global is set to determine
-		// if this should be a personal snippet
-		rn, err := git.PathWithNameSpace(remote)
-		if err != nil {
-			log.Fatal(err)
-		}
 		project, err := lab.FindProject(rn)
 		if err != nil {
 			log.Fatal(err)
 		}
 		projectID = project.ID
-		commit, err := lab.GetCommit(projectID, branchName)
+		commit, err := lab.GetCommit(projectID, refName)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -96,8 +96,12 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if !lab.BranchPushed(p.ID, branch) {
-		log.Fatalf("aborting MR, source branch %s not present on remote %s. did you forget to push?", branch, sourceRemote)
+	if _, err := lab.GetBranch(p.ID, branch); err != nil {
+		err = errors.Wrapf(
+			err,
+			"aborting MR, source branch %s not present on remote %s. did you forget to push?",
+			branch, sourceRemote)
+		log.Fatal(err)
 	}
 
 	targetRemote := forkedFromRemote
@@ -117,10 +121,14 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 	targetBranch := "master"
-	if len(args) > 1 {
+	if len(args) > 1 && targetBranch != args[1] {
 		targetBranch = args[1]
-		if !lab.BranchPushed(targetProject.ID, targetBranch) {
-			log.Fatalf("aborting MR, target branch %s not present on remote %s. did you forget to push?", targetBranch, targetRemote)
+		if _, err := lab.GetBranch(targetProject.ID, targetBranch); err != nil {
+			err = errors.Wrapf(
+				err,
+				"aborting MR, target branch %s not present on remote %s. did you forget to push?",
+				targetBranch, targetRemote)
+			log.Fatal(err)
 		}
 	}
 

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -96,7 +96,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if _, err := lab.GetBranch(p.ID, branch); err != nil {
+	if _, err := lab.GetCommit(p.ID, branch); err != nil {
 		err = errors.Wrapf(
 			err,
 			"aborting MR, source branch %s not present on remote %s. did you forget to push?",
@@ -123,7 +123,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	targetBranch := "master"
 	if len(args) > 1 && targetBranch != args[1] {
 		targetBranch = args[1]
-		if _, err := lab.GetBranch(targetProject.ID, targetBranch); err != nil {
+		if _, err := lab.GetCommit(targetProject.ID, targetBranch); err != nil {
 			err = errors.Wrapf(
 				err,
 				"aborting MR, target branch %s not present on remote %s. did you forget to push?",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -212,6 +212,23 @@ func parseArgsRemoteString(args []string) (string, string, error) {
 	return remote, str, nil
 }
 
+// parseArgsRemoteRef returns a remote name and a ref name (default: current branch).
+// Like parseArgsRemoteString where second argument defaults to current branch.
+func parseArgsRemoteRef(args []string) (string, string, error) {
+	rn, name, err := parseArgsRemoteString(args)
+	if err != nil {
+		return "", "", err
+	}
+	if name == "" {
+		name, err = git.CurrentBranch()
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	return rn, name, nil
+}
+
 var (
 	// Will be updated to upstream in Execute() if "upstream" remote exists
 	forkedFromRemote = "origin"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -404,6 +404,73 @@ func Test_parseArgsRemoteString(t *testing.T) {
 	}
 }
 
+func Test_parseArgsRemoteRef(t *testing.T) {
+	tests := []struct {
+		Name           string
+		Args           []string
+		ExpectedRemote string
+		ExpectedRef    string
+		ExpectedErr    string
+	}{
+		{
+			Name:           "No Args",
+			Args:           nil,
+			ExpectedRemote: "zaquestion/test",
+			ExpectedRef:    "master",
+			ExpectedErr:    "",
+		},
+		{
+			Name:           "1 arg remote",
+			Args:           []string{"lab-testing"},
+			ExpectedRemote: "lab-testing/test",
+			ExpectedRef:    "master",
+			ExpectedErr:    "",
+		},
+		{
+			Name:           "1 arg non remote",
+			Args:           []string{"foo123"},
+			ExpectedRemote: "zaquestion/test",
+			ExpectedRef:    "foo123",
+			ExpectedErr:    "",
+		},
+		{
+			Name:           "1 arg num",
+			Args:           []string{"100"},
+			ExpectedRemote: "zaquestion/test",
+			ExpectedRef:    "100",
+			ExpectedErr:    "",
+		},
+		{
+			Name:           "2 arg remote and string",
+			Args:           []string{"origin", "foo123"},
+			ExpectedRemote: "zaquestion/test",
+			ExpectedRef:    "foo123",
+			ExpectedErr:    "",
+		},
+		{
+			Name:           "2 arg invalid remote and string",
+			Args:           []string{"foo", "string123"},
+			ExpectedRemote: "",
+			ExpectedRef:    "",
+			ExpectedErr:    "foo is not a valid remote",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test := test
+			t.Parallel()
+			r, s, err := parseArgsRemoteRef(test.Args)
+			if test.ExpectedErr != "" {
+				assert.EqualError(t, err, test.ExpectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.ExpectedRemote, r)
+			assert.Equal(t, test.ExpectedRef, s)
+		})
+	}
+}
+
 type fatalLogger interface {
 	Fatal(...interface{})
 }

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -506,13 +506,13 @@ func IssueListDiscussions(project string, issueNum int) ([]*gitlab.Discussion, e
 	return discussions, nil
 }
 
-// BranchPushed checks if a branch exists on a GitLab project
-func BranchPushed(pid interface{}, branch string) bool {
+// GetBranch looks up a Gitlab Branch by name.
+func GetBranch(pid interface{}, branch string) (*gitlab.Branch, error) {
 	b, _, err := lab.Branches.GetBranch(pid, branch)
 	if err != nil {
-		return false
+		return nil, err
 	}
-	return b != nil
+	return b, nil
 }
 
 // LabelList gets a list of labels on a GitLab Project
@@ -698,9 +698,9 @@ func ProjectList(opts gitlab.ListProjectsOptions, n int) ([]*gitlab.Project, err
 
 // CIJobs returns a list of jobs in a pipeline for a given sha. The jobs are
 // returned sorted by their CreatedAt time
-func CIJobs(pid interface{}, branch string) ([]*gitlab.Job, error) {
+func CIJobs(pid interface{}, sha string) ([]*gitlab.Job, error) {
 	pipelines, _, err := lab.Pipelines.ListProjectPipelines(pid, &gitlab.ListProjectPipelinesOptions{
-		Ref: gitlab.String(branch),
+		SHA: gitlab.String(sha),
 	})
 	if len(pipelines) == 0 || err != nil {
 		return nil, err
@@ -739,8 +739,8 @@ func CIJobs(pid interface{}, branch string) ([]*gitlab.Job, error) {
 // 1. Last Running Job
 // 2. First Pending Job
 // 3. Last Job in Pipeline
-func CITrace(pid interface{}, branch, name string) (io.Reader, *gitlab.Job, error) {
-	jobs, err := CIJobs(pid, branch)
+func CITrace(pid interface{}, sha, name string) (io.Reader, *gitlab.Job, error) {
+	jobs, err := CIJobs(pid, sha)
 	if len(jobs) == 0 || err != nil {
 		return nil, nil, err
 	}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -506,13 +506,13 @@ func IssueListDiscussions(project string, issueNum int) ([]*gitlab.Discussion, e
 	return discussions, nil
 }
 
-// GetBranch looks up a Gitlab Branch by name.
-func GetBranch(pid interface{}, branch string) (*gitlab.Branch, error) {
-	b, _, err := lab.Branches.GetBranch(pid, branch)
+// GetCommit returns top Commit by ref (hash, branch or tag).
+func GetCommit(pid interface{}, ref string) (*gitlab.Commit, error) {
+	c, _, err := lab.Commits.GetCommit(pid, ref)
 	if err != nil {
 		return nil, err
 	}
-	return b, nil
+	return c, nil
 }
 
 // LabelList gets a list of labels on a GitLab Project

--- a/internal/gitlab/gitlab_test.go
+++ b/internal/gitlab/gitlab_test.go
@@ -111,14 +111,19 @@ func TestLint(t *testing.T) {
 	}
 }
 
-func TestBranchPushed(t *testing.T) {
+func TestGetBranch(t *testing.T) {
 	tests := []struct {
-		desc     string
-		branch   string
-		expected bool
+		desc   string
+		branch string
+		ok     bool
 	}{
 		{
-			"alpha is pushed",
+			"branch not pushed",
+			"not_a_branch",
+			false,
+		},
+		{
+			"branch is pushed",
 			"mrtest",
 			true,
 		},
@@ -127,18 +132,19 @@ func TestBranchPushed(t *testing.T) {
 			"needs/encode",
 			true,
 		},
-		{
-			"alpha not pushed",
-			"not_a_branch",
-			false,
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			test := test
 			t.Parallel()
-			ok := BranchPushed(4181224, test.branch)
-			require.Equal(t, test.expected, ok)
+			b, err := GetBranch(4181224, test.branch)
+			if test.ok {
+				require.NoError(t, err)
+				require.Equal(t, test.branch, b.Name)
+			} else {
+				require.Error(t, err)
+				require.Nil(t, b)
+			}
 		})
 	}
 }

--- a/internal/gitlab/gitlab_test.go
+++ b/internal/gitlab/gitlab_test.go
@@ -111,36 +111,46 @@ func TestLint(t *testing.T) {
 	}
 }
 
-func TestGetBranch(t *testing.T) {
+func TestGetCommit(t *testing.T) {
 	tests := []struct {
-		desc   string
-		branch string
-		ok     bool
+		desc     string
+		ref      string
+		ok       bool
+		expectID string
 	}{
 		{
-			"branch not pushed",
+			"not pushed",
 			"not_a_branch",
 			false,
+			"",
 		},
 		{
-			"branch is pushed",
-			"mrtest",
+			"pushed branch",
+			"mrtest", // branch name
 			true,
+			"54fd49a2ac60aeeef5ddc75efecd49f85f7ba9b0",
 		},
 		{
-			"needs encoding is pushed",
-			"needs/encode",
+			"pushed branch, neeeds encoding",
+			"needs/encode", // branch name
 			true,
+			"381f2b123dd404e8046ea42d5785061aa3b6674b",
+		},
+		{
+			"pushed sha",
+			"700e056463504690c11d63727bf25a380f303be9",
+			true,
+			"700e056463504690c11d63727bf25a380f303be9",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			test := test
 			t.Parallel()
-			b, err := GetBranch(4181224, test.branch)
+			b, err := GetCommit(4181224, test.ref)
 			if test.ok {
 				require.NoError(t, err)
-				require.Equal(t, test.branch, b.Name)
+				require.Equal(t, test.expectID, b.ID)
 			} else {
 				require.Error(t, err)
 				require.Nil(t, b)


### PR DESCRIPTION
For issue https://github.com/zaquestion/lab/issues/338

## main changes 
- use of `sha` instead of `ref/branchName` https://docs.gitlab.com/ee/api/pipelines.html#list-project-pipelines is more correct with detached pipelines ( via `only: merge_requests` )
- use `sha` of upstream (not local)

## additionally  
- add `GetBranch` and remove/replace `BranchPushed`  
- `cmd` parse args unification
  - use `parseArgsRemoteString`
  - add `parseArgsRemoteRef` (helper)


