### PR TITLE
README.md: Update to require go 13 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Head to the [releases](https://github.com/zaquestion/lab/releases) page and down
 ### Source
 
 Required
-* [Go 1.12+](https://golang.org/doc/install)
+* [Go 1.13+](https://golang.org/doc/install)
 
 ```
 git clone git@github.com:zaquestion/lab


### PR DESCRIPTION
When building with go 1.12 you will receive the following error:

internal/gitlab/gitlab.go:65:4: unknown field 'ForceAttemptHTTP2' in struct literal of type http.Transport
internal/gitlab/gitlab.go:100:4: unknown field 'ForceAttemptHTTP2' in struct literal of type http.Transport
note: module requires Go 1.13
Makefile:5: recipe for target 'build' failed
make: *** [build] Error 2

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>