### PR TITLE
.goreleaser.yml: Create arm/arm64 binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,6 +38,8 @@ builds:
   - windows
   goarch:
   - amd64
+  - arm
+  - arm64
   - "386"
   goarm:
   - "6"


### PR DESCRIPTION
It would be nice to have arm/arm64 binaries created by goreleaser on next release.