### PR TITLE
edit: Fix GIT_EDITOR evaluation

### DIFF
--- a/internal/git/edit.go
+++ b/internal/git/edit.go
@@ -82,8 +82,9 @@ func editorCMD(editorPath, filePath string) *exec.Cmd {
 	if r.MatchString(editorPath) {
 		args = append(args, "--cmd", "set ft=gitcommit tw=0 wrap lbr")
 	}
-	args = append(args, parts[1:]...)
-	args = append(args, filePath)
+	argparts := strings.Join(parts[1:], " ")
+	argparts = strings.Replace(argparts, "'", "\"", -1)
+	args = append(args, argparts, filePath)
 	cmd := exec.Command(parts[0], args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
The command 'lab mr note <id>' fails when the GIT_EDITOR variable contains
single quotes.  For example, if GIT_EDITOR is 'vim -c 'set tw=74' -c 'set
noai' -c 'set wrap' the 'lab mr note' command attempts to open 4 different
files (tw=74, noai, wrap, and MR_NOTE_EDITMSG).  If the single quotes
are replaced by double quotes the 'lab mr note' command completes as
expected; only MR_NOTE_EDITMSG is modified.

Replace single quotes in the GIT_EDITOR environment variable with double
quotes.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>