### PR TITLE
lab: Add --comments flag to 'mr show'

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/glamour"
 	"github.com/rsteube/carapace"
@@ -37,6 +38,16 @@ var mrShowCmd = &cobra.Command{
 		renderMarkdown := !noMarkdown
 
 		printMR(mr, rn, renderMarkdown)
+
+		showComments, _ := cmd.Flags().GetBool("comments")
+		if showComments {
+			discussions, err := lab.MRListDiscussions(rn, int(mrNum))
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			printMRDiscussions(discussions)
+		}
 	},
 }
 
@@ -86,8 +97,47 @@ WebURL: %s
 		mr.Author.Username, milestone, labels, mr.WebURL)
 }
 
+func printMRDiscussions(discussions []*gitlab.Discussion) {
+	// for available fields, see
+	// https://godoc.org/github.com/xanzy/go-gitlab#Note
+	// https://godoc.org/github.com/xanzy/go-gitlab#Discussion
+	for _, discussion := range discussions {
+		for i, note := range discussion.Notes {
+
+			// skip system notes
+			if note.System {
+				continue
+			}
+
+			indentHeader, indentNote := "", ""
+			commented := "commented"
+
+			if !discussion.IndividualNote {
+				indentNote = "    "
+
+				if i == 0 {
+					commented = "started a discussion"
+				} else {
+					indentHeader = "    "
+				}
+			}
+
+			fmt.Printf(`
+%s-----------------------------------
+%s%s %s at %s
+
+%s%s
+`,
+				indentHeader,
+				indentHeader, note.Author.Username, commented, time.Time(*note.CreatedAt).String(),
+				indentNote, note.Body)
+		}
+	}
+}
+
 func init() {
 	mrShowCmd.Flags().BoolP("no-markdown", "M", false, "Don't use markdown renderer to print the issue description")
+	mrShowCmd.Flags().BoolP("comments", "c", false, "Show comments for the merge request")
 	mrCmd.AddCommand(mrShowCmd)
 	carapace.Gen(mrShowCmd).PositionalCompletion(
 		action.Remotes(),

--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -11,7 +11,9 @@ import (
 func Test_mrShow(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
-	cmd := exec.Command(labBinaryPath, "mr", "1")
+	// a comment has been added to
+	// https://gitlab.com/zaquestion/test/-/merge_requests/1 for this test
+	cmd := exec.Command(labBinaryPath, "mr", "show", "1", "--comments")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()
@@ -39,4 +41,6 @@ Milestone: 1.0
 Labels: documentation
 WebURL: https://gitlab.com/zaquestion/test/-/merge_requests/1
 `)
+
+	require.Contains(t, string(b), `commented at`)
 }

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -310,6 +310,21 @@ func MRClose(pid interface{}, id int) error {
 	return nil
 }
 
+// MRListDiscussions retrieves the discussions (aka notes & comments) for a merge request
+func MRListDiscussions(project string, mrNum int) ([]*gitlab.Discussion, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return nil, err
+	}
+
+	discussions, _, err := lab.Discussions.ListMergeRequestDiscussions(p.ID, mrNum, &gitlab.ListMergeRequestDiscussionsOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return discussions, nil
+}
+
 // MRRebase merges an mr on a GitLab project
 func MRRebase(pid interface{}, id int) error {
 	_, err := lab.MergeRequests.RebaseMergeRequest(pid, int(id))


### PR DESCRIPTION
The 'issue show' command has a --comments flag to show all the comments
on an issue.  The same command is useful for the merge request command
'mr show'.

Add a --comments flag to 'mr show' that displays all the comments made
on a merge request.

Minor fix: Also fix a typo with the mr no-markdown flag.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>