### PR TITLE
mr show: Fix 'mr show' for unassigned Merge Requests

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -49,7 +49,8 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 		"closed": "Closed",
 		"merged": "Merged",
 	}[mr.State]
-	if mr.Assignee.Username != "" {
+
+	if mr.Assignee != nil && mr.Assignee.Username != "" {
 		assignee = mr.Assignee.Username
 	}
 	if mr.Milestone != nil {


### PR DESCRIPTION
If a merge request is unassigned 'mr show' panics [1] because the
mr.Assignee field is nil.

Check mr.Assignee for nil prior to dereferencing it's memory.

Fixes: b0b8ee22492b ("alec/multiple-assignees")
Resolves #389
Signed-off-by: Prarit Bhargava <prarit@redhat.com>
Cc: Alec Benzer <alec@level.com>

[1] trace of 'mr show':

[prarit@prarit kernel-test]$ ~/git-kernel/github/lab/lab mr show 9
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x4d259a]

goroutine 1 [running]:
cmd.printMR
	/home/prarit/git-kernel/github/lab/cmd/mr_show.go:50
cmd.func30
	/home/prarit/git-kernel/github/lab/cmd/mr_show.go:37
github.x2ecom..z2fspf13..z2fcobra.Command.execute
	/home/prarit/go/pkg/mod/github.com/rsteube/cobra@v0.0.1-zsh-completion-custom/command.go:769
github.x2ecom..z2fspf13..z2fcobra.Command.ExecuteC
	/home/prarit/go/pkg/mod/github.com/rsteube/cobra@v0.0.1-zsh-completion-custom/command.go:855
github.x2ecom..z2fspf13..z2fcobra.Command.Execute
	/home/prarit/go/pkg/mod/github.com/rsteube/cobra@v0.0.1-zsh-completion-custom/command.go:803
github.x2ecom..z2fzaquestion..z2flab..z2fcmd.Execute
	/home/prarit/git-kernel/github/lab/cmd/root.go:319
main.main
	/home/prarit/git-kernel/github/lab/main.go:196