### PR TITLE
show: Mark updated comments

### DIFF
--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -122,6 +122,9 @@ func printDiscussions(discussions []*gitlab.Discussion) {
 
 			indentHeader, indentNote := "", ""
 			commented := "commented"
+			if ! time.Time(*note.CreatedAt).Equal(time.Time(*note.UpdatedAt)) {
+				commented = "updated comment"
+			}
 
 			if !discussion.IndividualNote {
 				indentNote = "    "
@@ -140,7 +143,7 @@ func printDiscussions(discussions []*gitlab.Discussion) {
 %s%s
 `,
 				indentHeader,
-				indentHeader, note.Author.Username, commented, time.Time(*note.CreatedAt).String(),
+				indentHeader, note.Author.Username, commented, time.Time(*note.UpdatedAt).String(),
 				indentNote, note.Body)
 		}
 	}

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -112,6 +112,9 @@ func printMRDiscussions(discussions []*gitlab.Discussion) {
 
 			indentHeader, indentNote := "", ""
 			commented := "commented"
+			if ! time.Time(*note.CreatedAt).Equal(time.Time(*note.UpdatedAt)) {
+				commented = "updated comment"
+			}
 
 			if !discussion.IndividualNote {
 				indentNote = "    "
@@ -130,7 +133,7 @@ func printMRDiscussions(discussions []*gitlab.Discussion) {
 %s%s
 `,
 				indentHeader,
-				indentHeader, note.Author.Username, commented, time.Time(*note.CreatedAt).String(),
+				indentHeader, note.Author.Username, commented, time.Time(*note.UpdatedAt).String(),
 				indentNote, note.Body)
 		}
 	}


### PR DESCRIPTION
Currently updated comments look like other comments.  It is useful to
note that a comment has been updated.

Update 'issue show' and 'mr show' to show the updated comment date and
output a message indicated that the comment was updated.

[Note: gitlab sets the note's UpdatedAt equal to CreatedAt at the time
of creation so it is okay to make the UpdateAt to CreatedAt comparison
and only use UpdatedAt in the output.]

Signed-off-by: Prarit Bhargava <prarit@redhat.com>