### PR TITLE
mr show: tests for updated comments

### DIFF
--- a/cmd/issue_show_test.go
+++ b/cmd/issue_show_test.go
@@ -43,3 +43,21 @@ WebURL: https://gitlab.com/zaquestion/test/-/issues/1
 
 	require.Contains(t, string(b), `commented at`)
 }
+
+func Test_issueShow_updated_comments(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "issue", "show", "8", "--comments")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	out := string(b)
+	out = stripansi.Strip(out) // This is required because glamour adds a lot of ansi chars
+
+	require.Contains(t, string(b), `updated comment at`)
+}

--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -43,4 +43,5 @@ WebURL: https://gitlab.com/zaquestion/test/-/merge_requests/1
 `)
 
 	require.Contains(t, string(b), `commented at`)
+	require.Contains(t, string(b), `updated comment at`)
 }


### PR DESCRIPTION
lab commit 690015ebd3e4 ("show: Mark updated comments") shows updated
comments as 'updated comment at <time>" in 'lab mr show --comments'.

I have added and updated test repo merge request and issue comments
[1][2].

Add tests for updated comments.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>

[1] https://gitlab.com/zaquestion/test/-/issues/8#note_400362614
[2] https://gitlab.com/zaquestion/test/-/merge_requests/1#note_400375984