### PR TITLE
.gitignore: Add internal go files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ _test
 coverage*
 vendor
 
+# go metadata
+go.sum
+go.mod
+
 # The testdata-* copies created by the unit tests must be ignored or the tests
 # will encounter write errors as Git attempts to add the dirs to its index.
 testdata-*


### PR DESCRIPTION
Ignore go.sum and go.mod.  These are metadata files for go and can
be safely ignored.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>