### PR TITLE
mr list: Add --mine and --assignee options

### DIFF
--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_mrListAssignedTo(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "mr", "list", "--assignee=zaquestion")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mrs := strings.Split(string(b), "\n")
+	t.Log(mrs)
+	require.Contains(t, mrs, "#1 Test MR for lab list")
+	require.NotContains(t, mrs, "#3")
+	require.NotContains(t, mrs, "filtering with labels and lists")
+}
+
 func Test_mrList(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -45,6 +45,33 @@ func User() string {
 	return user
 }
 
+func UserID() (int, error) {
+	u, _, err := lab.Users.CurrentUser()
+	if err != nil {
+		return 0, err
+	} else {
+		return u.ID, nil
+	}
+}
+
+func UserIDByUserName(username string) (int, error) {
+	opts := gitlab.ListUsersOptions{
+		ListOptions: gitlab.ListOptions{
+			PerPage: 1,
+		},
+		Username: &username,
+	}
+	users, _, err := lab.Users.ListUsers(&opts)
+	if err != nil {
+		return 0, err
+	} else {
+		for _, user := range users {
+			return user.ID, nil
+		}
+	}
+	return 0, errors.New("No user found with username " + username)
+}
+
 // Init initializes a gitlab client for use throughout lab.
 func Init(_host, _user, _token string, allowInsecure bool) {
 	if len(_host) > 0 && _host[len(_host)-1 : len(_host)][0] == '/' {


### PR DESCRIPTION
On large projects it would be nice to find my merge requests or
someone else's merge requests.  While coding I came across this
old patchset from Alex Kalderimis and I have simply rebased it
to top-of-tree and squashed his two commits together.

Original commit message from Alex:

"Fixes #249, allowing MRs to be listed by assignee

This adds two new flags to the MR list command:

* --mine: list only MRs assigned to me
* --assignee=username: list only MRs assigned to a particular user"

Developed-by: Alex Kalderimis <alex.kalderimis@gmail.com>
Tested-by: Prarit Bhargava <prarit@redhat.com>
Signed-off-by: Prarit Bhargava <prarit@redhat.com>