### PR TITLE
Revert commit 1285411b8584 ("config: Fix missing core.user entry")

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,9 +132,8 @@ func loadConfig() (string, string, string, bool) {
 	}
 	if user == "" {
 		user = getUser(host, token, tlsSkipVerify)
-		viper.Set("core.user", user)
-		viper.WriteConfigAs(path.Join(confpath, "lab.hcl"))
 	}
+	viper.Set("core.user", user)
 	return host, user, token, tlsSkipVerify
 }
 


### PR DESCRIPTION
lab commit 1285411b8584 attempted to fix the missing core.user entry in
~/.config/lab.hcl, however, it seems to have caused more problems than
it fixed [1].

I'm reworking the config code and have noticed several other odd issues so
reverting this isn't a major step backward.

Reported-by: Bruno Meneguele <bmeneg@redhat.com>
Signed-off-by: Prarit Bhargava <prarit@redhat.com>

[1] https://github.com/zaquestion/lab/issues/411