### PR TITLE
[PATCH] Add `--patch` option to `mr show`

### DIFF
--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -45,3 +45,31 @@ WebURL: https://gitlab.com/zaquestion/test/-/merge_requests/1
 	require.Contains(t, string(b), `commented at`)
 	require.Contains(t, string(b), `updated comment at`)
 }
+
+func Test_mrShow_patch(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "mr", "show", "origin", "1", "--patch")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	out := string(b)
+	out = stripansi.Strip(out)
+	// The index line below has been stripped as it is dependent on
+	// the git version and pretty defaults.
+	require.Contains(t, out, `commit 54fd49a2ac60aeeef5ddc75efecd49f85f7ba9b0
+Author: Zaq? Wiedmann <zaquestion@gmail.com>
+Date:   Tue Sep 19 03:55:16 2017 +0000
+
+    Test file for MR test
+
+diff --git a/mrtest b/mrtest
+new file mode 100644
+`)
+
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -248,3 +248,38 @@ func InsideGitRepo() bool {
 	out, _ := cmd.CombinedOutput()
 	return bytes.Contains(out, []byte("true\n"))
 }
+
+// Fetch a commit from a given remote
+func Fetch(remote, commit string) error {
+	gitcmd := []string{"fetch", remote, commit}
+	cmd := New(gitcmd...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	err := cmd.Run()
+	if err != nil {
+		return errors.Errorf("Can't fetch git commit %s from remote %s", commit, remote)
+	}
+	return nil
+}
+
+// Show all the commits between 2 git commits
+func Show(commit1, commit2 string, reverse bool) {
+	gitcmd := []string{"show"}
+	if reverse {
+		gitcmd = append(gitcmd, "--reverse")
+	}
+	gitcmd = append(gitcmd, fmt.Sprintf("%s..%s", commit1, commit2))
+	New(gitcmd...).Run()
+}
+
+// GetLocalRemotes returns a string of local remote names and URLs
+func GetLocalRemotes() (string, error) {
+	cmd := New("remote", "-v")
+	cmd.Stdout = nil
+	remotes, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return string(remotes), nil
+}


### PR DESCRIPTION
Fixes #277 which requests functionality that provides the patches
for an MR in 'git show' format.  This is useful for users that want
to quickly look at a patchset without checking out a branch.

The original patch provided by Eric required users to provide the
target remote, even if the target remote was "origin".  The additional
code provided by Prarit uses the fetch remote name in 'git remote -v'
by default unless the user specifies a specific remote.

Original patch from Eric, with modifications to automatically find the
target remote by Prarit.

Add '--patch' option to 'mr show' that displays the patches for a merge
request in 'git show' format.

Co-Developed-by: Eric Engestrom <eric.engestrom@intel.com>
Signed-off-by: Prarit Bhargava <prarit@redhat.com>