### PR TITLE
Mr show config comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ instance. There are several ways to provide this information to `lab`:
 2. environment variables: `CI_PROJECT_URL`, `CI_JOB_TOKEN`;
     - Note: these are meant for when `lab` is running within a GitLab CI pipeline
 3. directory-specific configuration file in [Tom's Obvious, Minimal Language (TOML)](https://github.com/toml-lang/toml): `./lab.toml`;
-4. user-specific configuration file in HCL: `~/.config/lab/lab.toml`.
+4. user-specific configuration file in TOML: `~/.config/lab/lab.toml`.
 
 These are checked in order. If no suitable config values are found, `lab` will
 prompt for your GitLab information and save it into `~/.config/lab/lab.toml`.
@@ -99,6 +99,13 @@ For example:
 $ lab
 Enter default GitLab host (default: https://gitlab.com):
 Enter default GitLab token:
+```
+
+Additionally, there are command-specific configuration files in TOML: .git/lab/[command]-metadata.toml which provide users the ability to override some command line options:
+
+```
+comments = true # sets --comments on 'mr show' commands
+
 ```
 # Completions
 

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -35,6 +35,27 @@ var issueShowCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		viper.Reset()
+		viper.AddConfigPath(".git/lab")
+		viper.SetConfigName("show_metadata")
+		viper.SetConfigType("toml")
+		// write data
+		if _, ok := viper.ReadInConfig().(viper.ConfigFileNotFoundError); ok {
+			if _, err := os.Stat(".git/lab"); os.IsNotExist(err) {
+				os.MkdirAll(".git/lab", os.ModePerm)
+			}
+			if err := viper.WriteConfigAs(metadatafile); err != nil {
+				log.Fatal(err)
+			}
+			if err := viper.ReadInConfig(); err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			if err := viper.ReadInConfig(); err != nil {
+				log.Fatal(err)
+			}
+		}
+
 		noMarkdown, _ := cmd.Flags().GetBool("no-markdown")
 		if err != nil {
 			log.Fatal(err)
@@ -57,6 +78,7 @@ var issueShowCmd = &cobra.Command{
 
 			printDiscussions(discussions, since, int(issueNum))
 		}
+		viper.Reset()
 	},
 }
 
@@ -122,27 +144,6 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, issueNum i
 
 	// default path for metadata config file
 	metadatafile := ".git/lab/show_metadata.toml"
-
-	viper.Reset()
-	viper.AddConfigPath(".git/lab")
-	viper.SetConfigName("show_metadata")
-	viper.SetConfigType("toml")
-	// write data
-	if _, ok := viper.ReadInConfig().(viper.ConfigFileNotFoundError); ok {
-		if _, err := os.Stat(".git/lab"); os.IsNotExist(err) {
-			os.MkdirAll(".git/lab", os.ModePerm)
-		}
-		if err := viper.WriteConfigAs(metadatafile); err != nil {
-			log.Fatal(err)
-		}
-		if err := viper.ReadInConfig(); err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		if err := viper.ReadInConfig(); err != nil {
-			log.Fatal(err)
-		}
-	}
 
 	issueEntry := fmt.Sprintf("issue%d", issueNum)
 	// if specified on command line use that, o/w use config, o/w Now

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -65,6 +65,9 @@ var issueShowCmd = &cobra.Command{
 		printIssue(issue, rn, renderMarkdown)
 
 		showComments, _ := cmd.Flags().GetBool("comments")
+		if showComments == false {
+			showComments = viper.GetBool("comments")
+		}
 		if showComments {
 			discussions, err := lab.IssueListDiscussions(rn, int(issueNum))
 			if err != nil {

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -92,6 +92,9 @@ var mrShowCmd = &cobra.Command{
 		}
 
 		showComments, _ := cmd.Flags().GetBool("comments")
+		if showComments == false {
+			showComments = viper.GetBool("comments")
+		}
 		if showComments {
 			discussions, err := lab.MRListDiscussions(rn, int(mrNum))
 			if err != nil {


### PR DESCRIPTION
Add a local "comments" config option that always sets "--comments" for the mr and issue show commands.