### PR TITLE
main: skip config initialization for --version and --help

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,10 @@ func skipInit() bool {
 		return false
 	}
 	switch os.Args[1] {
+	case "--version", "version":
+		return true
+	case "--help", "help":
+		return true
 	case "completion":
 		return true
 	case "_carapace":


### PR DESCRIPTION
Resolves issue #374 by skipping config initialization for `--version` and `--help` options passed directly to `lab` command.