### PR TITLE
issue,mr: remove markdown flag from parent command

### DIFF
--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -37,6 +37,5 @@ func init() {
 	issueCmd.Flags().BoolP("list", "l", false, "List issues on a remote")
 	issueCmd.Flags().BoolP("browse", "b", false, "View issue <id> in a browser")
 	issueCmd.Flags().StringP("close", "d", "", "Close issue <id> on remote")
-	issueCmd.Flags().BoolP("no-markdown", "M", false, "Don't use markdown renderer to print the issue description")
 	RootCmd.AddCommand(issueCmd)
 }

--- a/cmd/mr.go
+++ b/cmd/mr.go
@@ -38,6 +38,5 @@ func init() {
 	mrCmd.Flags().BoolP("list", "l", false, "List merge requests on a remote")
 	mrCmd.Flags().BoolP("browse", "b", false, "View merge request <id> in a browser")
 	mrCmd.Flags().StringP("close", "d", "", "Close merge request <id> on remote")
-	mrCmd.Flags().BoolP("no-markdown", "M", false, "Don't use markdown renderer to print the issue description")
 	RootCmd.AddCommand(mrCmd)
 }


### PR DESCRIPTION
Resolves issue #422 that reports confusion in the -M|--no-markdown flag usage in parent commands.