### PR TITLE
clone: fix folder name used for operations after clonning

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -50,7 +50,7 @@ var cloneCmd = &cobra.Command{
 			if len(args) > 1 {
 				dir = args[1]
 			} else {
-				dir = project.Name
+				dir = project.Path
 			}
 			ffProject, err := gitlab.FindProject(project.ForkedFromProject.PathWithNamespace)
 			if err != nil {


### PR DESCRIPTION
Solves issue #426 that uses project's name instead of project's path as the directory name.