### PR TITLE
lab: Add --force-linebreak option

### DIFF
--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -65,6 +65,11 @@ var issueCreateCmd = &cobra.Command{
 			log.Fatal("aborting issue due to empty issue msg")
 		}
 
+		linebreak, _ := cmd.Flags().GetBool("force-linebreak")
+		if linebreak {
+			body = textToMarkdown(body)
+		}
+
 		assigneeIDs := make([]int, len(assignees))
 		for i, a := range assignees {
 			assigneeIDs[i] = *getAssigneeID(a)
@@ -138,6 +143,7 @@ func init() {
 	issueCreateCmd.Flags().StringSliceP("label", "l", []string{}, "Set the given label(s) on the created issue")
 	issueCreateCmd.Flags().StringSliceP("assignees", "a", []string{}, "Set assignees by username")
 	issueCreateCmd.Flags().StringP("template", "t", "default", "use the given issue template")
+	issueCreateCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 
 	issueCmd.AddCommand(issueCreateCmd)
 	carapace.Gen(issueCreateCmd).PositionalCompletion(

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -66,6 +66,11 @@ lab issue edit <id> -l newlabel --unlabel oldlabel # relabel issue`,
 			log.Fatal("aborting: no changes")
 		}
 
+		linebreak, _ := cmd.Flags().GetBool("force-linebreak")
+		if linebreak {
+			body = textToMarkdown(body)
+		}
+
 		opts := &gitlab.UpdateIssueOptions{
 			Title:       &title,
 			Description: &body,
@@ -278,6 +283,7 @@ func issueEditCmdAddFlags(flags *pflag.FlagSet) *pflag.FlagSet {
 	flags.StringSliceP("unlabel", "", []string{}, "Remove the given label(s) from the issue")
 	flags.StringSliceP("assign", "a", []string{}, "Add an assignee by username")
 	flags.StringSliceP("unassign", "", []string{}, "Remove an assigne by username")
+	flags.Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	return flags
 }
 

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -43,6 +43,11 @@ var issueCreateNoteCmd = &cobra.Command{
 			log.Fatal("aborting note due to empty note msg")
 		}
 
+		linebreak, _ := cmd.Flags().GetBool("force-linebreak")
+		if linebreak {
+			body = textToMarkdown(body)
+		}
+
 		noteURL, err := lab.IssueCreateNote(rn, int(issueNum), &gitlab.CreateIssueNoteOptions{
 			Body: &body,
 		})
@@ -97,6 +102,7 @@ func noteText() (string, error) {
 
 func init() {
 	issueCreateNoteCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	issueCreateNoteCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 
 	issueCmd.AddCommand(issueCreateNoteCmd)
 	carapace.Gen(issueCreateCmd).PositionalCompletion(

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -41,6 +41,7 @@ func init() {
 	mrCreateCmd.Flags().Bool("allow-collaboration", false, "Allow commits from other members")
 	mrCreateCmd.Flags().Int("milestone", -1, "Set milestone by milestone ID")
 	mrCreateCmd.Flags().StringP("file", "F", "", "Use the given file as the Description")
+	mrCreateCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	mergeRequestCmd.Flags().AddFlagSet(mrCreateCmd.Flags())
 
 	mrCmd.AddCommand(mrCreateCmd)
@@ -177,6 +178,11 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 			_, f, l, _ := runtime.Caller(0)
 			log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
 		}
+	}
+
+	linebreak, _ := cmd.Flags().GetBool("force-linebreak")
+	if linebreak {
+		body = textToMarkdown(body)
 	}
 
 	removeSourceBranch, _ := cmd.Flags().GetBool("remove-source-branch")

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -59,6 +59,11 @@ var mrCreateNoteCmd = &cobra.Command{
 			log.Fatal("aborting note due to empty note msg")
 		}
 
+		linebreak, _ := cmd.Flags().GetBool("force-linebreak")
+		if linebreak {
+			body = textToMarkdown(body)
+		}
+
 		noteURL, err := lab.MRCreateNote(rn, int(mrNum), &gitlab.CreateMergeRequestNoteOptions{
 			Body: &body,
 		})
@@ -113,6 +118,7 @@ func mrNoteText() (string, error) {
 func init() {
 	mrCreateNoteCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	mrCreateNoteCmd.Flags().StringP("file", "F", "", "Use the given file as the message")
+	mrCreateNoteCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 
 	mrCmd.AddCommand(mrCreateNoteCmd)
 	carapace.Gen(mrCreateNoteCmd).PositionalCompletion(

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,0 +1,13 @@
+// This file contains common functions that are shared in the lab package
+package cmd
+
+import (
+	"strings"
+)
+
+// textToMarkdown converts text with markdown friendly line breaks
+// See https://gist.github.com/shaunlebron/746476e6e7a4d698b373 for more info.
+func textToMarkdown(text string) string {
+	text = strings.Replace(text, "\n", "  \n", -1)
+	return text
+}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_textToMarkdown(t *testing.T) {
+	basestring := "This string should have two spaces at the end."
+	teststring := basestring + "\n"
+	newteststring := textToMarkdown(teststring)
+	assert.Equal(t, basestring+"  \n", newteststring)
+}


### PR DESCRIPTION
FIXME: needs testing fixes
FIXME: needs better option and text

The default gitlab formatting will mangle some types of text by default.

For example, if the text entered as the Description contains

This is sentence one and should not be
On the same line as sentence two

then gitlab would merge these lines together as

This is sentence one and should not be On the same line as sentence two.

To fix this add an option to replace line breaks, "\n", with "  \n" [1]

Signed-off-by: Prarit Bhargava <prarit@redhat.com>

[1] https://gist.github.com/shaunlebron/746476e6e7a4d698b373.