### PR TITLE
flags: fix "message" string handling

### DIFF
--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -25,7 +25,7 @@ var issueCreateCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		msgs, err := cmd.Flags().GetStringSlice("message")
+		msgs, err := cmd.Flags().GetStringArray("message")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -139,7 +139,7 @@ func issueText(templateName string) (string, error) {
 }
 
 func init() {
-	issueCreateCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	issueCreateCmd.Flags().StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	issueCreateCmd.Flags().StringSliceP("label", "l", []string{}, "Set the given label(s) on the created issue")
 	issueCreateCmd.Flags().StringSliceP("assignees", "a", []string{}, "Set assignees by username")
 	issueCreateCmd.Flags().StringP("template", "t", "default", "use the given issue template")

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -164,7 +164,7 @@ func issueEditGetTitleDescription(issue *gitlab.Issue, flags *pflag.FlagSet) (st
 	title, body := issue.Title, issue.Description
 
 	// get all of the "message" flags
-	msgs, err := flags.GetStringSlice("message")
+	msgs, err := flags.GetStringArray("message")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func same(a, b []string) bool {
 
 // issueEditCmdAddFlags adds various flags to the `lab issue edit` command
 func issueEditCmdAddFlags(flags *pflag.FlagSet) *pflag.FlagSet {
-	flags.StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	flags.StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	flags.StringSliceP("label", "l", []string{}, "Add the given label(s) to the issue")
 	flags.StringSliceP("unlabel", "", []string{}, "Remove the given label(s) from the issue")
 	flags.StringSliceP("assign", "a", []string{}, "Add an assignee by username")

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -29,7 +29,7 @@ var issueCreateNoteCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		msgs, err := cmd.Flags().GetStringSlice("message")
+		msgs, err := cmd.Flags().GetStringArray("message")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -101,7 +101,7 @@ func noteText() (string, error) {
 }
 
 func init() {
-	issueCreateNoteCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	issueCreateNoteCmd.Flags().StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	issueCreateNoteCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 
 	issueCmd.AddCommand(issueCreateNoteCmd)

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -33,7 +33,7 @@ var mrCreateCmd = &cobra.Command{
 }
 
 func init() {
-	mrCreateCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	mrCreateCmd.Flags().StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	mrCreateCmd.Flags().StringSliceP("assignee", "a", []string{}, "Set assignee by username; can be specified multiple times for multiple assignees")
 	mrCreateCmd.Flags().StringSliceP("label", "l", []string{}, "Add label <label>; can be specified multiple times for multiple labels")
 	mrCreateCmd.Flags().BoolP("remove-source-branch", "d", false, "Remove source branch from remote after merge")
@@ -80,7 +80,7 @@ func getAssigneeIDs(assignees []string) []int {
 }
 
 func runMRCreate(cmd *cobra.Command, args []string) {
-	msgs, err := cmd.Flags().GetStringSlice("message")
+	msgs, err := cmd.Flags().GetStringArray("message")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -30,7 +30,7 @@ var mrCreateNoteCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		msgs, err := cmd.Flags().GetStringSlice("message")
+		msgs, err := cmd.Flags().GetStringArray("message")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -116,7 +116,7 @@ func mrNoteText() (string, error) {
 }
 
 func init() {
-	mrCreateNoteCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	mrCreateNoteCmd.Flags().StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	mrCreateNoteCmd.Flags().StringP("file", "F", "", "Use the given file as the message")
 	mrCreateNoteCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -35,7 +35,7 @@ var snippetCreateCmd = &cobra.Command{
 Source snippets from stdin, file, or in editor from scratch
 Optionally add a title & description with -m`,
 	Run: func(cmd *cobra.Command, args []string) {
-		msgs, err := cmd.Flags().GetStringSlice("message")
+		msgs, err := cmd.Flags().GetStringArray("message")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -171,7 +171,7 @@ func init() {
 	snippetCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "Make snippet private; visible only to project members (default: internal)")
 	snippetCreateCmd.Flags().BoolVar(&public, "public", false, "Make snippet public; can be accessed without any authentication (default: internal)")
 	snippetCreateCmd.Flags().StringVarP(&name, "name", "n", "", "(optional) Name snippet to add code highlighting, e.g. potato.go for GoLang")
-	snippetCreateCmd.Flags().StringSliceP("message", "m", []string{"-"}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	snippetCreateCmd.Flags().StringArrayP("message", "m", []string{"-"}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	snippetCmd.Flags().AddFlagSet(snippetCreateCmd.Flags())
 
 	snippetCmd.AddCommand(snippetCreateCmd)

--- a/cmd/snippet_create_test.go
+++ b/cmd/snippet_create_test.go
@@ -97,7 +97,7 @@ func Test_snippetCreate_Global(t *testing.T) {
 }
 
 func Test_snipMsg(t *testing.T) {
-	msgs, err := snippetCreateCmd.Flags().GetStringSlice("message")
+	msgs, err := snippetCreateCmd.Flags().GetStringArray("message")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Solves issue #376 wrt string handling in `--message | -m` flags.