### PR TITLE
mr_checkout: fix usage message

### DIFF
--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -25,7 +25,7 @@ var (
 
 // listCmd represents the list command
 var checkoutCmd = &cobra.Command{
-	Use:   "checkout",
+	Use:   "checkout <id>",
 	Short: "Checkout an open merge request",
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),

--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -28,7 +28,7 @@ var checkoutCmd = &cobra.Command{
 	Use:   "checkout <id>",
 	Short: "Checkout an open merge request",
 	Long:  ``,
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrID, err := parseArgs(args)
 		if err != nil {


### PR DESCRIPTION
This merge request is pretty simple, only adds the '<id>' text to the `lab mr checkout -h` command.
No issue opened for that.