### PR TITLE
Config rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,18 @@ See the [contribution guide](CONTRIBUTING.md).
 instance. There are several ways to provide this information to `lab`:
 
 1. environment variables: `LAB_CORE_HOST`, `LAB_CORE_TOKEN`;
+    - If these variables are set, the config files will not be updated.
 2. environment variables: `CI_PROJECT_URL`, `CI_JOB_TOKEN`;
     - Note: these are meant for when `lab` is running within a GitLab CI pipeline
-3. directory-specific configuration file in [Tom's Obvious, Minimal Language (TOML)](https://github.com/toml-lang/toml): `./lab.toml`;
+    - If these variables are set, the config files will not be updated.
+3. local configuration file in [Tom's Obvious, Minimal Language (TOML)](https://github.com/toml-lang/toml): `./lab.toml`;
+    - No other config files will be used as overrides if a local configuration file is specified
 4. user-specific configuration file in TOML: `~/.config/lab/lab.toml`.
+5. work-tree configuration file in TOML: `.git/lab/lab.toml`.  The values in
+this file will override any values set in the user-specific configuration file.
 
-These are checked in order. If no suitable config values are found, `lab` will
-prompt for your GitLab information and save it into `~/.config/lab/lab.toml`.
+If no suitable config values are found, `lab` will prompt for your GitLab
+information and save it into `~/.config/lab/lab.toml`.
 For example:
 ```
 $ lab
@@ -101,10 +106,11 @@ Enter default GitLab host (default: https://gitlab.com):
 Enter default GitLab token:
 ```
 
-Additionally, there are command-specific configuration files in TOML: .git/lab/[command]-metadata.toml which provide users the ability to override some command line options:
+Command-specific flags can be set in the config files.
 
 ```
-comments = true # sets --comments on 'mr show' commands
+[mr_show]
+  comments = true # sets --comments on 'mr show' commands
 
 ```
 # Completions

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -11,16 +11,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/action"
 	"github.com/zaquestion/lab/internal/config"
 	lab "github.com/zaquestion/lab/internal/gitlab"
-)
-
-var (
-	issueShowConfig *viper.Viper
-	issueShowPrefix string = "issue_show."
 )
 
 var issueShowCmd = &cobra.Command{
@@ -30,6 +24,9 @@ var issueShowCmd = &cobra.Command{
 	Short:      "Describe an issue",
 	Long:       ``,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		setCommandPrefix()
+
 		rn, issueNum, err := parseArgs(args)
 		if err != nil {
 			log.Fatal(err)
@@ -39,8 +36,6 @@ var issueShowCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		issueShowConfig = config.LoadConfig("", "")
 
 		noMarkdown, _ := cmd.Flags().GetBool("no-markdown")
 		if err != nil {
@@ -52,7 +47,7 @@ var issueShowCmd = &cobra.Command{
 
 		showComments, _ := cmd.Flags().GetBool("comments")
 		if showComments == false {
-			showComments = issueShowConfig.GetBool(issueShowPrefix + "comments")
+			showComments = getMainConfig().GetBool(CommandPrefix + "comments")
 		}
 		if showComments {
 			discussions, err := lab.IssueListDiscussions(rn, int(issueNum))
@@ -139,7 +134,7 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, issueNum i
 	)
 	CompareTime, err = dateparse.ParseLocal(since)
 	if err != nil || CompareTime.IsZero() {
-		CompareTime = issueShowConfig.GetTime(issueShowPrefix + issueEntry)
+		CompareTime = getMainConfig().GetTime(CommandPrefix + issueEntry)
 		if CompareTime.IsZero() {
 			CompareTime = time.Now().UTC()
 		}
@@ -190,7 +185,7 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, issueNum i
 	}
 
 	if sinceIsSet == false {
-		config.WriteConfigEntry(issueShowPrefix+issueEntry, NewAccessTime, "", "")
+		config.WriteConfigEntry(CommandPrefix+issueEntry, NewAccessTime, "", "")
 	}
 }
 

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -20,6 +20,7 @@ import (
 
 var (
 	issueShowConfig *viper.Viper
+	issueShowPrefix string = "issue_show."
 )
 
 var issueShowCmd = &cobra.Command{
@@ -39,7 +40,7 @@ var issueShowCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		issueShowConfig = config.LoadConfig("", "show_metadata")
+		issueShowConfig = config.LoadConfig("", "")
 
 		noMarkdown, _ := cmd.Flags().GetBool("no-markdown")
 		if err != nil {
@@ -51,7 +52,7 @@ var issueShowCmd = &cobra.Command{
 
 		showComments, _ := cmd.Flags().GetBool("comments")
 		if showComments == false {
-			showComments = issueShowConfig.GetBool("comments")
+			showComments = issueShowConfig.GetBool(issueShowPrefix + "comments")
 		}
 		if showComments {
 			discussions, err := lab.IssueListDiscussions(rn, int(issueNum))
@@ -138,7 +139,7 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, issueNum i
 	)
 	CompareTime, err = dateparse.ParseLocal(since)
 	if err != nil || CompareTime.IsZero() {
-		CompareTime = issueShowConfig.GetTime(issueEntry)
+		CompareTime = issueShowConfig.GetTime(issueShowPrefix + issueEntry)
 		if CompareTime.IsZero() {
 			CompareTime = time.Now().UTC()
 		}
@@ -189,7 +190,7 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, issueNum i
 	}
 
 	if sinceIsSet == false {
-		config.WriteConfigEntry(issueEntry, NewAccessTime, "", "show_metadata")
+		config.WriteConfigEntry(issueShowPrefix+issueEntry, NewAccessTime, "", "")
 	}
 }
 

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -23,6 +23,7 @@ var (
 	mrShowPatch        bool
 	mrShowPatchReverse bool
 	mrShowConfig       *viper.Viper
+	mrShowPrefix       string = "mr_show."
 )
 
 var mrShowCmd = &cobra.Command{
@@ -42,7 +43,7 @@ var mrShowCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		mrShowConfig = config.LoadConfig("", "show_metadata")
+		mrShowConfig = config.LoadConfig("", "")
 
 		noMarkdown, _ := cmd.Flags().GetBool("no-markdown")
 		if err != nil {
@@ -72,7 +73,7 @@ var mrShowCmd = &cobra.Command{
 
 		showComments, _ := cmd.Flags().GetBool("comments")
 		if showComments == false {
-			showComments = mrShowConfig.GetBool("comments")
+			showComments = mrShowConfig.GetBool(mrShowPrefix + "comments")
 		}
 		if showComments {
 			discussions, err := lab.MRListDiscussions(rn, int(mrNum))
@@ -179,7 +180,7 @@ func printMRDiscussions(discussions []*gitlab.Discussion, since string, mrNum in
 	)
 	CompareTime, err = dateparse.ParseLocal(since)
 	if err != nil || CompareTime.IsZero() {
-		CompareTime = mrShowConfig.GetTime(mrEntry)
+		CompareTime = mrShowConfig.GetTime(mrShowPrefix + mrEntry)
 		if CompareTime.IsZero() {
 			CompareTime = time.Now().UTC()
 		}
@@ -231,7 +232,7 @@ func printMRDiscussions(discussions []*gitlab.Discussion, since string, mrNum in
 	}
 
 	if sinceIsSet == false {
-		config.WriteConfigEntry("show."+mrEntry, NewAccessTime, "", "show_metadata")
+		config.WriteConfigEntry(mrShowPrefix+mrEntry, NewAccessTime, "", "")
 	}
 }
 

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/action"
 	"github.com/zaquestion/lab/internal/config"
@@ -22,8 +21,6 @@ import (
 var (
 	mrShowPatch        bool
 	mrShowPatchReverse bool
-	mrShowConfig       *viper.Viper
-	mrShowPrefix       string = "mr_show."
 )
 
 var mrShowCmd = &cobra.Command{
@@ -33,6 +30,9 @@ var mrShowCmd = &cobra.Command{
 	Short:      "Describe a merge request",
 	Long:       ``,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		setCommandPrefix()
+
 		rn, mrNum, err := parseArgs(args)
 		if err != nil {
 			log.Fatal(err)
@@ -42,8 +42,6 @@ var mrShowCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		mrShowConfig = config.LoadConfig("", "")
 
 		noMarkdown, _ := cmd.Flags().GetBool("no-markdown")
 		if err != nil {
@@ -73,7 +71,7 @@ var mrShowCmd = &cobra.Command{
 
 		showComments, _ := cmd.Flags().GetBool("comments")
 		if showComments == false {
-			showComments = mrShowConfig.GetBool(mrShowPrefix + "comments")
+			showComments = getMainConfig().GetBool(CommandPrefix + "comments")
 		}
 		if showComments {
 			discussions, err := lab.MRListDiscussions(rn, int(mrNum))
@@ -180,7 +178,7 @@ func printMRDiscussions(discussions []*gitlab.Discussion, since string, mrNum in
 	)
 	CompareTime, err = dateparse.ParseLocal(since)
 	if err != nil || CompareTime.IsZero() {
-		CompareTime = mrShowConfig.GetTime(mrShowPrefix + mrEntry)
+		CompareTime = getMainConfig().GetTime(CommandPrefix + mrEntry)
 		if CompareTime.IsZero() {
 			CompareTime = time.Now().UTC()
 		}
@@ -232,7 +230,7 @@ func printMRDiscussions(discussions []*gitlab.Discussion, since string, mrNum in
 	}
 
 	if sinceIsSet == false {
-		config.WriteConfigEntry(mrShowPrefix+mrEntry, NewAccessTime, "", "")
+		config.WriteConfigEntry(CommandPrefix+mrEntry, NewAccessTime, "", "")
 	}
 }
 

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -22,6 +22,7 @@ import (
 var (
 	mrShowPatch        bool
 	mrShowPatchReverse bool
+	mrShowConfig       *viper.Viper
 )
 
 var mrShowCmd = &cobra.Command{
@@ -41,7 +42,7 @@ var mrShowCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		config.LoadWorkTreeConfig("show")
+		mrShowConfig = config.LoadConfig("", "show_metadata")
 
 		noMarkdown, _ := cmd.Flags().GetBool("no-markdown")
 		if err != nil {
@@ -71,7 +72,7 @@ var mrShowCmd = &cobra.Command{
 
 		showComments, _ := cmd.Flags().GetBool("comments")
 		if showComments == false {
-			showComments = viper.GetBool("comments")
+			showComments = mrShowConfig.GetBool("comments")
 		}
 		if showComments {
 			discussions, err := lab.MRListDiscussions(rn, int(mrNum))
@@ -86,7 +87,6 @@ var mrShowCmd = &cobra.Command{
 
 			printMRDiscussions(discussions, since, int(mrNum))
 		}
-		config.FinishWorkTreeConfig()
 	},
 }
 
@@ -179,7 +179,7 @@ func printMRDiscussions(discussions []*gitlab.Discussion, since string, mrNum in
 	)
 	CompareTime, err = dateparse.ParseLocal(since)
 	if err != nil || CompareTime.IsZero() {
-		CompareTime = viper.GetTime(mrEntry)
+		CompareTime = mrShowConfig.GetTime(mrEntry)
 		if CompareTime.IsZero() {
 			CompareTime = time.Now().UTC()
 		}
@@ -231,8 +231,7 @@ func printMRDiscussions(discussions []*gitlab.Discussion, since string, mrNum in
 	}
 
 	if sinceIsSet == false {
-		viper.Set(mrEntry, NewAccessTime)
-		config.WriteWorkTreeConfig("show")
+		config.WriteConfigEntry("show."+mrEntry, NewAccessTime, "", "show_metadata")
 	}
 }
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,8 +2,34 @@
 package cmd
 
 import (
+	"path"
+	"runtime"
 	"strings"
+
+	"github.com/spf13/viper"
+	"github.com/zaquestion/lab/internal/config"
 )
+
+var (
+	CommandPrefix string
+)
+
+// getMainConfig returns the merged config of ~/.config/lab/lab.toml and
+// .git/lab/lab.toml
+func getMainConfig() *viper.Viper {
+	return config.MainConfig
+}
+
+// setCommandPrefix sets command name that is used in the config
+// files to set per-command options.  For example, the "lab issue show"
+// command has a prefix of "issue_show.", and "lab mr list" as a
+// prefix of "mr_list."
+func setCommandPrefix() {
+	_, file, _, _ := runtime.Caller(1)
+	_, filename := path.Split(file)
+	s := strings.Split(filename, ".")
+	CommandPrefix = s[0] + "."
+}
 
 // textToMarkdown converts text with markdown friendly line breaks
 // See https://gist.github.com/shaunlebron/746476e6e7a4d698b373 for more info.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/rivo/tview v0.0.0-20191129065140-82b05c9fb329
 	github.com/rsteube/carapace v0.0.16
+	github.com/spf13/afero v1.1.2
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -208,9 +208,9 @@ func GetToken() string {
 	return token
 }
 
-// LoadConfig() loads the main config file and returns a tuple of
+// LoadMainConfig() loads the main config file and returns a tuple of
 //  host, user, token, ca_file, skipVerify
-func LoadConfig() (string, string, string, string, bool) {
+func LoadMainConfig() (string, string, string, string, bool) {
 
 	// Attempt to auto-configure for GitLab CI.
 	// Always do this before reading in the config file o/w CI will end up

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	cmd.Version = version
 	if !skipInit() {
-		h, u, t, ca, skipVerify := config.LoadConfig()
+		h, u, t, ca, skipVerify := config.LoadMainConfig()
 
 		if ca != "" {
 			lab.InitWithCustomCA(h, u, t, ca)


### PR DESCRIPTION


The lab config heirarchy is:
    1. ENV variables (LAB_CORE_TOKEN, LAB_CORE_HOST)
            - if specified, core.token and core.host values in
              config files are not updated.
    2. "dot" . user specified config
            - if specified, lower order config files will not override
              the user specified config
    3.  .config/lab/lab.toml (global config)
    4.  .git/lab/lab/toml (worktree config)

Values from the worktree config will override any global config settings.
