### PR TITLE
Merge Flags and Configs

### DIFF
--- a/cmd/ci_lint.go
+++ b/cmd/ci_lint.go
@@ -14,9 +14,10 @@ import (
 
 // ciLintCmd represents the lint command
 var ciLintCmd = &cobra.Command{
-	Use:   "lint",
-	Short: "Validate .gitlab-ci.yml against GitLab",
-	Long:  ``,
+	Use:              "lint",
+	Short:            "Validate .gitlab-ci.yml against GitLab",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		path := ".gitlab-ci.yml"
 		if len(args) == 1 {

--- a/cmd/ci_run.go
+++ b/cmd/ci_run.go
@@ -27,6 +27,7 @@ Project will be inferred from branch if not provided
 Note: "lab ci create" differs from "lab ci trigger" which is a different API`,
 	Example: `lab ci create feature_branch
 lab ci create -p engineering/integration_tests master`,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, branch, err := getCIRunOptions(cmd, args)
 		if err != nil {
@@ -55,6 +56,7 @@ Note: "lab ci trigger" differs from "lab ci create" which is a different API`,
 	Example: `lab ci trigger feature_branch
 lab ci trigger -p engineering/integration_tests master
 lab ci trigger -p engineering/integration_tests -v foo=bar master`,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, branch, err := getCIRunOptions(cmd, args)
 		if err != nil {

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -23,7 +23,8 @@ var ciStatusCmd = &cobra.Command{
 	Long:    ``,
 	Example: `lab ci status
 lab ci status --wait`,
-	RunE: nil,
+	RunE:             nil,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
 			rn  string

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -21,10 +21,11 @@ import (
 
 // ciLintCmd represents the lint command
 var ciTraceCmd = &cobra.Command{
-	Use:     "trace [remote [[branch:]job]]",
-	Aliases: []string{"logs"},
-	Short:   "Trace the output of a ci job",
-	Long:    `If a job is not specified the latest running job or last job in the pipeline is used`,
+	Use:              "trace [remote [[branch:]job]]",
+	Aliases:          []string{"logs"},
+	Short:            "Trace the output of a ci job",
+	Long:             `If a job is not specified the latest running job or last job in the pipeline is used`,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
 			rn      string

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -20,6 +20,7 @@ var cloneCmd = &cobra.Command{
 - repo
 - namespace/repo
 - namespace/group/repo`,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		project, err := gitlab.FindProject(args[0])
 		if err == gitlab.ErrProjectNotFound {

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -14,10 +14,11 @@ var skipClone = false
 
 // forkCmd represents the fork command
 var forkCmd = &cobra.Command{
-	Use:   "fork [upstream-to-fork]",
-	Short: "Fork a remote repository on GitLab and add as remote",
-	Long:  ``,
-	Args:  cobra.MaximumNArgs(1),
+	Use:              "fork [upstream-to-fork]",
+	Short:            "Fork a remote repository on GitLab and add as remote",
+	Long:             ``,
+	Args:             cobra.MaximumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		skipClone, _ = cmd.Flags().GetBool("skip-clone")
 		if len(args) == 1 {

--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -5,9 +5,10 @@ import (
 )
 
 var issueCmd = &cobra.Command{
-	Use:   "issue",
-	Short: `Describe, list, and create issues`,
-	Long:  ``,
+	Use:              "issue",
+	Short:            `Describe, list, and create issues`,
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if list, _ := cmd.Flags().GetBool("list"); list {
 			issueListCmd.Run(cmd, args)

--- a/cmd/issue_browse.go
+++ b/cmd/issue_browse.go
@@ -14,10 +14,11 @@ import (
 var browse = browser.Open
 
 var issueBrowseCmd = &cobra.Command{
-	Use:     "browse [remote] <id>",
-	Aliases: []string{"b"},
-	Short:   "View issue in a browser",
-	Long:    ``,
+	Use:              "browse [remote] <id>",
+	Aliases:          []string{"b"},
+	Short:            "View issue in a browser",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, num, err := parseArgs(args)
 		if err != nil {

--- a/cmd/issue_close.go
+++ b/cmd/issue_close.go
@@ -11,11 +11,12 @@ import (
 )
 
 var issueCloseCmd = &cobra.Command{
-	Use:     "close [remote] <id>",
-	Aliases: []string{"delete"},
-	Short:   "Close issue by id",
-	Long:    ``,
-	Args:    cobra.MinimumNArgs(1),
+	Use:              "close [remote] <id>",
+	Aliases:          []string{"delete"},
+	Short:            "Close issue by id",
+	Long:             ``,
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgs(args)
 		if err != nil {

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -19,11 +19,12 @@ import (
 )
 
 var issueCreateCmd = &cobra.Command{
-	Use:     "create [remote]",
-	Aliases: []string{"new"},
-	Short:   "Open an issue on GitLab",
-	Long:    ``,
-	Args:    cobra.MaximumNArgs(1),
+	Use:              "create [remote]",
+	Aliases:          []string{"new"},
+	Short:            "Open an issue on GitLab",
+	Long:             ``,
+	Args:             cobra.MaximumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		msgs, err := cmd.Flags().GetStringArray("message")
 		if err != nil {

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -28,7 +28,8 @@ lab issue update <id>                              # same as above
 lab issue edit <id> -m "new title"                 # update title
 lab issue edit <id> -m "new title" -m "new desc"   # update title & description
 lab issue edit <id> -l newlabel --unlabel oldlabel # relabel issue`,
-	Args: cobra.MinimumNArgs(1),
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		// get remote and issue from cmd arguments
 		rn, issueNum, err := parseArgs(args)

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -28,6 +28,7 @@ var issueListCmd = &cobra.Command{
 lab issue list "search terms"         # search issues for "search terms"
 lab issue search "search terms"       # same as above
 lab issue list remote "search terms"  # search "remote" for issues with "search terms"`,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		issues, err := issueList(args)
 		if err != nil {

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -18,11 +18,12 @@ import (
 )
 
 var issueCreateNoteCmd = &cobra.Command{
-	Use:     "note [remote] <id>",
-	Aliases: []string{"comment"},
-	Short:   "Add a note or comment to an issue on GitLab",
-	Long:    ``,
-	Args:    cobra.MinimumNArgs(1),
+	Use:              "note [remote] <id>",
+	Aliases:          []string{"comment"},
+	Short:            "Add a note or comment to an issue on GitLab",
+	Long:             ``,
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, issueNum, err := parseArgs(args)
 		if err != nil {

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -18,11 +18,12 @@ import (
 )
 
 var issueShowCmd = &cobra.Command{
-	Use:        "show [remote] <id>",
-	Aliases:    []string{"get"},
-	ArgAliases: []string{"s"},
-	Short:      "Describe an issue",
-	Long:       ``,
+	Use:              "show [remote] <id>",
+	Aliases:          []string{"get"},
+	ArgAliases:       []string{"s"},
+	Short:            "Describe an issue",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		rn, issueNum, err := parseArgs(args)
@@ -44,9 +45,6 @@ var issueShowCmd = &cobra.Command{
 		printIssue(issue, rn, renderMarkdown)
 
 		showComments, _ := cmd.Flags().GetBool("comments")
-		if showComments == false {
-			showComments = getMainConfig().GetBool(CommandPrefix + "comments")
-		}
 		if showComments {
 			discussions, err := lab.IssueListDiscussions(rn, int(issueNum))
 			if err != nil {

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -25,8 +25,6 @@ var issueShowCmd = &cobra.Command{
 	Long:       ``,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		setCommandPrefix()
-
 		rn, issueNum, err := parseArgs(args)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/label.go
+++ b/cmd/label.go
@@ -5,9 +5,10 @@ import (
 )
 
 var labelCmd = &cobra.Command{
-	Use:   "label",
-	Short: `List and search labels`,
-	Long:  ``,
+	Use:              "label",
+	Short:            `List and search labels`,
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 		return

--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -20,6 +20,7 @@ var labelListCmd = &cobra.Command{
 lab label list "search term"         # search labels for "search term"
 lab label search "search term"       # same as above
 lab label list remote "search term"  # search "remote" for labels with "search term"`,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, labelSearch, err := parseArgsRemoteString(args)
 		if err != nil {

--- a/cmd/merge_request.go
+++ b/cmd/merge_request.go
@@ -7,10 +7,11 @@ import (
 )
 
 var mergeRequestCmd = &cobra.Command{
-	Use:   "merge-request [remote [branch]]",
-	Short: mrCreateCmd.Short,
-	Long:  mrCreateCmd.Long,
-	Args:  mrCreateCmd.Args,
+	Use:              "merge-request [remote [branch]]",
+	Short:            mrCreateCmd.Short,
+	Long:             mrCreateCmd.Long,
+	Args:             mrCreateCmd.Args,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		runMRCreate(cmd, args)
 	},

--- a/cmd/mr.go
+++ b/cmd/mr.go
@@ -6,9 +6,10 @@ import (
 
 // mrCmd represents the mr command
 var mrCmd = &cobra.Command{
-	Use:   "mr",
-	Short: `Describe, list, and create merge requests`,
-	Long:  ``,
+	Use:              "mr",
+	Short:            `Describe, list, and create merge requests`,
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if list, _ := cmd.Flags().GetBool("list"); list {
 			listCmd.Run(cmd, args)

--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -11,11 +11,12 @@ import (
 )
 
 var mrApproveCmd = &cobra.Command{
-	Use:     "approve [remote] <id>",
-	Aliases: []string{},
-	Short:   "Approve merge request",
-	Long:    ``,
-	Args:    cobra.MinimumNArgs(1),
+	Use:              "approve [remote] <id>",
+	Aliases:          []string{},
+	Short:            "Approve merge request",
+	Long:             ``,
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgs(args)
 		if err != nil {

--- a/cmd/mr_browse.go
+++ b/cmd/mr_browse.go
@@ -15,10 +15,11 @@ import (
 )
 
 var mrBrowseCmd = &cobra.Command{
-	Use:     "browse [remote] <id>",
-	Aliases: []string{"b"},
-	Short:   "View merge request in a browser",
-	Long:    ``,
+	Use:              "browse [remote] <id>",
+	Aliases:          []string{"b"},
+	Short:            "View merge request in a browser",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, num, err := parseArgs(args)
 		if err != nil {

--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -25,10 +25,11 @@ var (
 
 // listCmd represents the list command
 var checkoutCmd = &cobra.Command{
-	Use:   "checkout <id>",
-	Short: "Checkout an open merge request",
-	Long:  ``,
-	Args:  cobra.MinimumNArgs(1),
+	Use:              "checkout <id>",
+	Short:            "Checkout an open merge request",
+	Long:             ``,
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrID, err := parseArgs(args)
 		if err != nil {

--- a/cmd/mr_close.go
+++ b/cmd/mr_close.go
@@ -11,11 +11,12 @@ import (
 )
 
 var mrCloseCmd = &cobra.Command{
-	Use:     "close [remote] <id>",
-	Aliases: []string{"delete"},
-	Short:   "Close merge request",
-	Long:    ``,
-	Args:    cobra.MinimumNArgs(1),
+	Use:              "close [remote] <id>",
+	Aliases:          []string{"delete"},
+	Short:            "Close merge request",
+	Long:             ``,
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgs(args)
 		if err != nil {

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -24,12 +24,13 @@ import (
 
 // mrCmd represents the mr command
 var mrCreateCmd = &cobra.Command{
-	Use:     "create [remote [branch]]",
-	Aliases: []string{"new"},
-	Short:   "Open a merge request on GitLab",
-	Long:    `Creates a merge request (default: MR created on default branch of origin)`,
-	Args:    cobra.MaximumNArgs(2),
-	Run:     runMRCreate,
+	Use:              "create [remote [branch]]",
+	Aliases:          []string{"new"},
+	Short:            "Open a merge request on GitLab",
+	Long:             `Creates a merge request (default: MR created on default branch of origin)`,
+	Args:             cobra.MaximumNArgs(2),
+	PersistentPreRun: LabPersistentPreRun,
+	Run:              runMRCreate,
 }
 
 func init() {

--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -19,11 +19,12 @@ import (
 )
 
 var mrCreateDiscussionCmd = &cobra.Command{
-	Use:     "discussion [remote] <id>",
-	Aliases: []string{"comment"},
-	Short:   "Start a discussion on an MR on GitLab",
-	Long:    ``,
-	Args:    cobra.MinimumNArgs(1),
+	Use:              "discussion [remote] <id>",
+	Aliases:          []string{"comment"},
+	Short:            "Start a discussion on an MR on GitLab",
+	Long:             ``,
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrNum, err := parseArgs(args)
 		if err != nil {

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -24,11 +24,12 @@ var (
 
 // listCmd represents the list command
 var listCmd = &cobra.Command{
-	Use:     "list [remote]",
-	Aliases: []string{"ls"},
-	Short:   "List merge requests",
-	Long:    ``,
-	Args:    cobra.MaximumNArgs(1),
+	Use:              "list [remote]",
+	Aliases:          []string{"ls"},
+	Short:            "List merge requests",
+	Long:             ``,
+	Args:             cobra.MaximumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		mrs, err := mrList(args)
 		if err != nil {

--- a/cmd/mr_merge.go
+++ b/cmd/mr_merge.go
@@ -10,11 +10,12 @@ import (
 )
 
 var mrMergeCmd = &cobra.Command{
-	Use:     "merge [remote] <id>",
-	Aliases: []string{"delete"},
-	Short:   "Merge an open merge request",
-	Long:    `If the pipeline for the mr is still running, lab sets merge on success`,
-	Args:    cobra.MinimumNArgs(1),
+	Use:              "merge [remote] <id>",
+	Aliases:          []string{"delete"},
+	Short:            "Merge an open merge request",
+	Long:             `If the pipeline for the mr is still running, lab sets merge on success`,
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgs(args)
 		if err != nil {

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -19,11 +19,12 @@ import (
 )
 
 var mrCreateNoteCmd = &cobra.Command{
-	Use:     "note [remote] <id>",
-	Aliases: []string{"comment"},
-	Short:   "Add a note or comment to an MR on GitLab",
-	Long:    ``,
-	Args:    cobra.MinimumNArgs(1),
+	Use:              "note [remote] <id>",
+	Aliases:          []string{"comment"},
+	Short:            "Add a note or comment to an MR on GitLab",
+	Long:             ``,
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrNum, err := parseArgs(args)
 		if err != nil {

--- a/cmd/mr_rebase.go
+++ b/cmd/mr_rebase.go
@@ -10,10 +10,11 @@ import (
 )
 
 var mrRebaseCmd = &cobra.Command{
-	Use:     "rebase [remote] <id>",
-	Aliases: []string{"delete"},
-	Short:   "Rebase an open merge request",
-	Args:    cobra.MinimumNArgs(1),
+	Use:              "rebase [remote] <id>",
+	Aliases:          []string{"delete"},
+	Short:            "Rebase an open merge request",
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgs(args)
 		if err != nil {

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -31,8 +31,6 @@ var mrShowCmd = &cobra.Command{
 	Long:       ``,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		setCommandPrefix()
-
 		rn, mrNum, err := parseArgs(args)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -24,11 +24,12 @@ var (
 )
 
 var mrShowCmd = &cobra.Command{
-	Use:        "show [remote] <id>",
-	Aliases:    []string{"get"},
-	ArgAliases: []string{"s"},
-	Short:      "Describe a merge request",
-	Long:       ``,
+	Use:              "show [remote] <id>",
+	Aliases:          []string{"get"},
+	ArgAliases:       []string{"s"},
+	Short:            "Describe a merge request",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		rn, mrNum, err := parseArgs(args)
@@ -68,9 +69,6 @@ var mrShowCmd = &cobra.Command{
 		}
 
 		showComments, _ := cmd.Flags().GetBool("comments")
-		if showComments == false {
-			showComments = getMainConfig().GetBool(CommandPrefix + "comments")
-		}
 		if showComments {
 			discussions, err := lab.MRListDiscussions(rn, int(mrNum))
 			if err != nil {

--- a/cmd/mr_thumb.go
+++ b/cmd/mr_thumb.go
@@ -11,17 +11,19 @@ import (
 )
 
 var mrThumbCmd = &cobra.Command{
-	Use:     "thumb",
-	Aliases: []string{},
-	Short:   "Thumb operations on merge requests",
-	Long:    ``,
+	Use:              "thumb",
+	Aliases:          []string{},
+	Short:            "Thumb operations on merge requests",
+	PersistentPreRun: LabPersistentPreRun,
+	Long:             ``,
 }
 
 var mrThumbUpCmd = &cobra.Command{
-	Use:     "up [remote] <id>",
-	Aliases: []string{},
-	Short:   "Thumb up merge request",
-	Long:    ``,
+	Use:              "up [remote] <id>",
+	Aliases:          []string{},
+	Short:            "Thumb up merge request",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgs(args)
 		if err != nil {

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -6,10 +6,11 @@ import (
 
 // repoCmd represents the repo command
 var projectCmd = &cobra.Command{
-	Use:     "project",
-	Aliases: []string{"repo"},
-	Short:   "Perform project level operations on GitLab",
-	Long:    ``,
+	Use:              "project",
+	Aliases:          []string{"repo"},
+	Short:            "Perform project level operations on GitLab",
+	PersistentPreRun: LabPersistentPreRun,
+	Long:             ``,
 	//Run: func(cmd *cobra.Command, args []string) {},
 }
 

--- a/cmd/project_browse.go
+++ b/cmd/project_browse.go
@@ -8,10 +8,11 @@ import (
 )
 
 var projectBrowseCmd = &cobra.Command{
-	Use:     "browse [remote]",
-	Aliases: []string{"b"},
-	Short:   "View project in a browser",
-	Long:    ``,
+	Use:              "browse [remote]",
+	Aliases:          []string{"b"},
+	Short:            "View project in a browser",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, _, err := parseArgs(args)
 

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -29,7 +29,8 @@ lab project create                         # user/<curr dir> named <curr dir>
 lab project create myproject               # user/myproject named myproject
 lab project create myproject -n "new proj" # user/myproject named "new proj"
 lab project create -n "new proj"           # user/new-proj named "new proj"`,
-	Args: cobra.MaximumNArgs(1),
+	Args:             cobra.MaximumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
 			name, _ = cmd.Flags().GetString("name")

--- a/cmd/project_list.go
+++ b/cmd/project_list.go
@@ -19,9 +19,10 @@ var projectListConfig struct {
 }
 
 var projectListCmd = &cobra.Command{
-	Use:     "list [search]",
-	Aliases: []string{"ls", "search"},
-	Short:   "List your projects",
+	Use:              "list [search]",
+	Aliases:          []string{"ls", "search"},
+	Short:            "List your projects",
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		search, _, err := parseArgsStr(args)
 		if err != nil {

--- a/cmd/snippet.go
+++ b/cmd/snippet.go
@@ -8,10 +8,11 @@ import (
 
 // snippetCmd represents the snippet command
 var snippetCmd = &cobra.Command{
-	Use:     "snippet",
-	Aliases: []string{"snip"},
-	Short:   snippetCreateCmd.Short,
-	Long:    snippetCreateCmd.Long,
+	Use:              "snippet",
+	Aliases:          []string{"snip"},
+	Short:            snippetCreateCmd.Short,
+	Long:             snippetCreateCmd.Long,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if list, _ := cmd.Flags().GetBool("list"); list {
 			snippetListCmd.Run(cmd, args)

--- a/cmd/snippet_browse.go
+++ b/cmd/snippet_browse.go
@@ -13,9 +13,10 @@ import (
 )
 
 var snippetBrowseCmd = &cobra.Command{
-	Use:   "browse [remote] <id>",
-	Short: "View personal or project snippet in a browser",
-	Long:  ``,
+	Use:              "browse [remote] <id>",
+	Short:            "View personal or project snippet in a browser",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgs(args)
 		if err != nil {

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -34,6 +34,7 @@ var snippetCreateCmd = &cobra.Command{
 	Long: `
 Source snippets from stdin, file, or in editor from scratch
 Optionally add a title & description with -m`,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		msgs, err := cmd.Flags().GetStringArray("message")
 		if err != nil {

--- a/cmd/snippet_list.go
+++ b/cmd/snippet_list.go
@@ -18,10 +18,11 @@ var snippetListConfig struct {
 
 // snippetListCmd represents the snippetList command
 var snippetListCmd = &cobra.Command{
-	Use:     "list [remote]",
-	Aliases: []string{"ls"},
-	Short:   "List personal or project snippets",
-	Long:    ``,
+	Use:              "list [remote]",
+	Aliases:          []string{"ls"},
+	Short:            "List personal or project snippets",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		snips, err := snippetList(args)
 		if err != nil {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,10 +2,11 @@
 package cmd
 
 import (
-	"path"
-	"runtime"
+	"log"
+	"strconv"
 	"strings"
 
+	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/zaquestion/lab/internal/config"
 )
@@ -14,21 +15,52 @@ var (
 	CommandPrefix string
 )
 
+// flagConfig compares command line flags and the flags set in the config
+// files.  The command line value will always override any value set in the
+// config files.
+func flagConfig(fs *flag.FlagSet) {
+	fs.VisitAll(func(f *flag.Flag) {
+		var (
+			configValue  interface{}
+			configString string
+		)
+
+		switch f.Value.Type() {
+		case "bool":
+			configValue = getMainConfig().GetBool(CommandPrefix + f.Name)
+			configString = strconv.FormatBool(configValue.(bool))
+		case "string":
+			configValue = getMainConfig().GetString(CommandPrefix + f.Name)
+			configString = configValue.(string)
+		case "stringSlice":
+			configValue = getMainConfig().GetStringSlice(CommandPrefix + f.Name)
+			configString = strings.Join(configValue.([]string), " ")
+
+		case "int":
+			configValue = getMainConfig().GetInt64(CommandPrefix + f.Name)
+			configString = strconv.FormatInt(configValue.(int64), 10)
+		case "stringArray":
+			// viper does not have support for stringArray
+			configString = ""
+		default:
+			log.Fatal("ERROR: found unidentified flag: ", f.Value.Type(), f)
+		}
+
+		// if set, always use the command line option (flag) value
+		if f.Value.String() != f.DefValue {
+			return
+		}
+		// o/w use the value in the configfile
+		if configString != "" && configString != f.DefValue {
+			f.Value.Set(configString)
+		}
+	})
+}
+
 // getMainConfig returns the merged config of ~/.config/lab/lab.toml and
 // .git/lab/lab.toml
 func getMainConfig() *viper.Viper {
 	return config.MainConfig
-}
-
-// setCommandPrefix sets command name that is used in the config
-// files to set per-command options.  For example, the "lab issue show"
-// command has a prefix of "issue_show.", and "lab mr list" as a
-// prefix of "mr_list."
-func setCommandPrefix() {
-	_, file, _, _ := runtime.Caller(1)
-	_, filename := path.Split(file)
-	s := strings.Split(filename, ".")
-	CommandPrefix = s[0] + "."
 }
 
 // textToMarkdown converts text with markdown friendly line breaks

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/zaquestion/lab/internal/config"
@@ -68,4 +69,8 @@ func getMainConfig() *viper.Viper {
 func textToMarkdown(text string) string {
 	text = strings.Replace(text, "\n", "  \n", -1)
 	return text
+}
+
+func LabPersistentPreRun(cmd *cobra.Command, args []string) {
+	flagConfig(cmd.Flags())
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,9 +12,10 @@ var Version string
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "",
-	Long:  ``,
+	Use:              "version",
+	Short:            "",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		git := git.New("version")
 		git.Stdout = nil

--- a/go.sum
+++ b/go.sum
@@ -346,4 +346,6 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Merge the flags and configs so that a user can override any config setting on the command line.  For example if the lab config file contained

[mr_foo]
  clioption = false

then by default, 'lab mr fool' would have clioption 'false' unless '--clioption true' was specified.
