### PR TITLE
add fallthrough path for forkedFromRemote

### DIFF
--- a/cmd/issue_show_test.go
+++ b/cmd/issue_show_test.go
@@ -36,7 +36,7 @@ Assignees: zaquestion, lab-testing
 Author: lab-testing
 Milestone: 1.0
 Due Date: 2018-01-01 00:00:00 +0000 UTC
-Time Stats: Estimated 1w, Spent 1d
+Time Stats: Estimated 40h, Spent 8h
 Labels: bug
 WebURL: https://gitlab.com/zaquestion/test/-/issues/1
 `)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -253,9 +253,9 @@ func setCommandPrefix(scmd *cobra.Command) {
 
 var (
 	// Will be updated to upstream in Execute() if "upstream" remote exists
-	forkedFromRemote = "origin"
+	forkedFromRemote = ""
 	// Will be updated to lab.User() in Execute() if forkedFrom is "origin"
-	forkRemote = "origin"
+	forkRemote = ""
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -265,21 +265,28 @@ func Execute() {
 	if err == nil {
 		forkedFromRemote = "upstream"
 	}
+	_, err = gitconfig.Local("remote.origin.url")
+	if err == nil {
+		forkedFromRemote = "origin"
+	}
+
 	if forkedFromRemote == "" {
-		// use the remote tracked by the branch if set
-		masterRemote, err := gitconfig.Local("branch.master.remote")
-		if err == nil {
-			forkedFromRemote = masterRemote
+		// use the remote tracked by the default branch if set
+		if remote, err := gitconfig.Local("branch.main.remote"); err == nil {
+			forkedFromRemote = remote
+		} else if remote, err = gitconfig.Local("branch.master.remote"); err == nil {
+			forkedFromRemote = remote
 		}
 	}
 
-	if forkedFromRemote == "origin" {
-		// Check if the user fork exists
-		_, err := gitconfig.Local("remote." + lab.User() + ".url")
-		if err == nil {
-			forkRemote = lab.User()
-		}
+	// Check if the user fork exists
+	_, err = gitconfig.Local("remote." + lab.User() + ".url")
+	if err == nil {
+		forkRemote = lab.User()
+	} else {
+		forkRemote = forkedFromRemote
 	}
+
 	// Check if the user is calling a lab command or if we should passthrough
 	// NOTE: The help command won't be found by Find, which we are counting on
 	cmd, _, err := RootCmd.Find(os.Args[1:])

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -160,7 +160,7 @@ func parseArgsRemoteInt(args []string) (string, int64, error) {
 			return "", 0, errors.Errorf("%s is not a valid remote", args[0])
 		}
 	}
-	if err != nil || remote == "" {
+	if remote == "" {
 		remote = forkedFromRemote
 	}
 	rn, err := git.PathWithNameSpace(remote)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -276,6 +276,18 @@ func Execute() {
 			forkedFromRemote = remote
 		} else if remote, err = gitconfig.Local("branch.master.remote"); err == nil {
 			forkedFromRemote = remote
+		} else {
+			// use the first remote added to .git/config file, which, usually, is
+			// the one from which the repo was clonned
+			remotesStr, err := git.GetLocalRemotesFromFile()
+			if err == nil {
+				remotes := strings.Split(remotesStr, "\n")
+				// remotes format: remote.<name>.<url|fetch>
+				remoteName := strings.Split(remotes[0], ".")[1]
+				forkedFromRemote = remoteName
+			} else {
+				log.Println("No default remote found")
+			}
 		}
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -69,6 +69,11 @@ func TestMain(m *testing.M) {
 	}
 	lab.Init(host, u.Username, token, false)
 
+	// Make "origin" the default remote for test cases calling
+	// cmd.Run() directly, instead of launching the labBinaryPath
+	// for getting these vars correctly set through Execute().
+	forkedFromRemote = "origin"
+	forkRemote = "origin"
 	code := m.Run()
 
 	if err := os.Chdir(originalWd); err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -283,3 +283,17 @@ func GetLocalRemotes() (string, error) {
 
 	return string(remotes), nil
 }
+
+// GetLocalRemotesFromFile returns a string of local remote names and URLs based
+// on their placement within .git/config file, which holds a different ordering
+// compared to the alternatives presented by Remotes() and GetLocalRemotes().
+func GetLocalRemotesFromFile() (string, error) {
+	cmd := New("config", "--local", "--name-only", "--get-regex", "^remote.*")
+	cmd.Stdout = nil
+	remotes, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return string(remotes), nil
+}


### PR DESCRIPTION
Mostly related to issue #438, this patchset fix the discovery of the remote the user forked from and also adds a fallthrough path in case none of the default options are met.

A test code was added to the new internal/git/git.go:GetLocalRemotesFromFile() function: although not entirely necessary we need to make sure the `git config --get-regex` behavior doesn't change over time. 