### PR TITLE
Add commit discussion functionality

### DIFF
--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"log"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,6 +17,7 @@ import (
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/action"
 	"github.com/zaquestion/lab/internal/config"
+	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
@@ -118,6 +122,135 @@ WebURL: %s
 	)
 }
 
+// maxPadding returns the max value of two string numbers
+func maxPadding(xstr string, ystr string) int {
+	x, _ := strconv.Atoi(xstr)
+	y, _ := strconv.Atoi(ystr)
+	if x > y {
+		return len(xstr)
+	}
+	return len(ystr)
+}
+
+// printDiffLine does a color print of a diff lines.  Red lines are removals
+// and green lines are additions.
+func printDiffLine(strColor string, maxChars int, sOld string, sNew string, ltext string) {
+
+	switch strColor {
+	case "":
+		fmt.Printf("%*s %*s %s\n", maxChars, sOld, maxChars, sNew, ltext)
+	case "green":
+		color.Green("%*s %*s %s\n", maxChars, sOld, maxChars, sNew, ltext)
+	case "red":
+		color.Red("%*s %*s %s\n", maxChars, sOld, maxChars, sNew, ltext)
+	}
+}
+
+// displayDiff displays the diff referenced in a discussion
+func displayDiff(diff string, chunkNum int, newLine int, oldLine int) {
+	var (
+		diffChunkNum int = -1
+		oldLineNum   int = 0
+		newLineNum   int = 0
+		maxChars     int
+	)
+
+	scanner := bufio.NewScanner(strings.NewReader(diff))
+	for scanner.Scan() {
+		if regexp.MustCompile(`^@@`).MatchString(scanner.Text()) {
+			diffChunkNum++
+			s := strings.Split(scanner.Text(), " ")
+			dOld := strings.Split(s[1], ",")
+			dNew := strings.Split(s[2], ",")
+
+			// The patch can have, for example, either
+			// @@ -1 +1 @@
+			// or
+			// @@ -1272,6 +1272,8 @@
+			// so (len - 1) makes sense in both cases.
+			maxChars = maxPadding(dOld[len(dOld)-1], dNew[len(dNew)-1]) + 1
+			if diffChunkNum == chunkNum {
+				continue
+			}
+			if diffChunkNum > chunkNum {
+				break
+			}
+		}
+
+		if diffChunkNum == chunkNum {
+			var (
+				sOld string
+				sNew string
+			)
+			strColor := ""
+			ltext := scanner.Text()
+			ltag := string(ltext[0])
+			switch ltag {
+			case " ":
+				strColor = ""
+				oldLineNum++
+				newLineNum++
+				sOld = strconv.Itoa(oldLineNum)
+				sNew = strconv.Itoa(newLineNum)
+			case "-":
+				strColor = "red"
+				oldLineNum++
+				sOld = strconv.Itoa(oldLineNum)
+				sNew = " "
+			case "+":
+				strColor = "green"
+				newLineNum++
+				sOld = " "
+				sNew = strconv.Itoa(newLineNum)
+			}
+
+			// output line
+			if mrShowNoColorDiff {
+				strColor = ""
+			}
+			if newLine != 0 {
+				if newLineNum <= newLine && newLineNum >= (newLine-4) {
+					printDiffLine(strColor, maxChars, sOld, sNew, ltext)
+				}
+			} else if oldLineNum <= oldLine && oldLineNum >= (oldLine-4) {
+				printDiffLine(strColor, maxChars, sOld, sNew, ltext)
+			}
+		}
+	}
+}
+
+func displayCommitDiscussion(idNum int, note *gitlab.Note) {
+
+	// The GitLab API only supports showing comments on the entire
+	// changeset and not per-commit.  IOW, all diffs are shown against
+	// HEAD.  This is confusing in some scenarios, however it's what the
+	// API provides.
+
+	// Get a unified diff for the entire file
+	diff, err := git.GetUnifiedDiff(note.Position.BaseSHA, note.Position.HeadSHA, note.Position.OldPath, note.Position.NewPath)
+	if err != nil {
+		fmt.Printf("    Could not get unified diff: Execute 'lab mr checkout %d; git checkout master' and try again.\n", idNum)
+		return
+	}
+
+	if diff == "" {
+		fmt.Println("    Could not find 'git diff' command.")
+		return
+	}
+
+	// In general, only have to display the NewPath, however there
+	// are some unusual cases where the OldPath may be displayed
+	if note.Position.NewPath == note.Position.OldPath {
+		fmt.Println("File:" + note.Position.NewPath)
+	} else {
+		fmt.Println("Files[old:" + note.Position.OldPath + " new:" + note.Position.NewPath + "]")
+	}
+
+	displayDiff(diff, 0, note.Position.NewLine, note.Position.OldLine)
+	fmt.Println("")
+	fmt.Println("")
+}
+
 func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr string, idNum int) {
 	NewAccessTime := time.Now().UTC()
 
@@ -159,6 +292,9 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 
 				if i == 0 {
 					commented = "started a discussion"
+					if note.Position != nil {
+						commented = "started a commit discussion"
+					}
 				} else {
 					indentHeader = "    "
 				}
@@ -175,9 +311,14 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 			printit(`
 %s#%d: %s %s at %s
 
-%s%s
 `,
-				indentHeader, note.ID, note.Author.Username, commented, time.Time(*note.UpdatedAt).String(),
+				indentHeader, note.ID, note.Author.Username, commented, time.Time(*note.UpdatedAt).String())
+			if note.Position != nil && i == 0 {
+				displayCommitDiscussion(idNum, note)
+			}
+			printit(`%s%s
+`,
+
 				indentNote, noteBody)
 		}
 	}

--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -135,5 +135,5 @@ func Test_mrListByTargetBranch(t *testing.T) {
 	}
 
 	mrs := strings.Split(string(b), "\n")
-	require.Equal(t, "#1 Test MR for lab list", mrs[0])
+	require.Equal(t, "#1 Test MR for lab list", mrs[1])
 }

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -17,6 +17,7 @@ import (
 var (
 	mrShowPatch        bool
 	mrShowPatchReverse bool
+	mrShowNoColorDiff  bool
 )
 
 var mrShowCmd = &cobra.Command{
@@ -164,6 +165,7 @@ func init() {
 	mrShowCmd.Flags().StringP("since", "s", "", "Show comments since specified date (format: 2020-08-21 14:57:46.808 +0000 UTC)")
 	mrShowCmd.Flags().BoolVarP(&mrShowPatch, "patch", "p", false, "Show MR patches")
 	mrShowCmd.Flags().BoolVarP(&mrShowPatchReverse, "reverse", "", false, "Reverse order when showing MR patches (chronological instead of anti-chronological)")
+	mrShowCmd.Flags().BoolVarP(&mrShowNoColorDiff, "no-color-diff", "", false, "Show color diffs in comments")
 	mrCmd.AddCommand(mrShowCmd)
 	carapace.Gen(mrShowCmd).PositionalCompletion(
 		action.Remotes(),

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -300,3 +300,16 @@ func GetLocalRemotesFromFile() (string, error) {
 
 	return string(remotes), nil
 }
+
+func GetUnifiedDiff(BaseSHA string, HeadSHA string, oldPath string, newPath string) (string, error) {
+	// I hate magic numbers as much as the next person but I cannot
+	// figure out a better way to get a unified diff for an entire file.
+	cmd := New("diff", "-U99999999", "--no-renames", BaseSHA, HeadSHA, "--", oldPath, "--", newPath)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	diff, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(diff), nil
+}


### PR DESCRIPTION
The GitLab UI provides the ability to show comments that were made on
patches, and this functionality is missing from lab.
    
Enhance 'lab mr show' to display the diffs and add a --color-diff option
to show the diffs in color (red for removals, green for additions).

Note that due to the design of the GitLab API, not all diffs are viewable.
    
example of output:

```
-----------------------------------
#419174696: prarit started a discussion at 2020-09-26 19:07:34.121 +0000 UTC

    this is a comment

    -----------------------------------
    #419174735: prarit commented at 2020-09-26 19:07:34.074 +0000 UTC

    This is a reply to the comment.

-----------------------------------
#419174767: prarit commented at 2020-09-26 19:07:52.391 +0000 UTC

This is another comment.  No replies.

-----------------------------------
#419174816: prarit started a commit discussion at 2020-09-26 19:08:33.58 +0000 UTC

File:makefile
  6   8  # this section is needed in order to make O= to work
  7   9  ifeq ("$(origin O)", "command line")
  8  10    _OUTPUT := "$(abspath $(O))"
  9  11    _EXTRA_ARGS := O=$(_OUTPUT)
 10  12  endif


    This is a comment on the third patch 186e0968.

```