### PR TITLE
Support namespace/groups for project create

### DIFF
--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -49,8 +49,7 @@ lab project create -g mygroup myproject    # mygroup/myproject named myproject`,
 			log.Fatal("path or name must be set")
 		}
 		if g != "" && group != "" {
-
-			log.Fatalf("group can be passed by flag or in path not both\n%s", labUsageFormat(cmd))
+			log.Fatalf("group can be passed by flag or in path, but not both\n%s", labUsageFormat(cmd))
 		}
 		if g != "" {
 			group = g

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -58,16 +58,11 @@ lab project create -g mygroup myproject    # mygroup/myproject named myproject`,
 
 		var namespaceID *int
 		if group != "" {
-			list, err := lab.GroupSearch(group)
+			groupObj, err := lab.GroupSearch(group)
 			if err != nil {
 				log.Fatal(err)
 			}
-
-			if len(list) == 0 {
-				log.Fatalf("no namespace found with such name: %s", group)
-			}
-
-			namespaceID = &list[0].ID
+			namespaceID = &groupObj.ID
 		}
 
 		// set the default visibility

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -78,6 +78,8 @@ lab project create -g mygroup myproject    # mygroup/myproject named myproject`,
 		}
 
 		opts := gitlab.CreateProjectOptions{
+			// if namespaceID is nil, the project will be created in user's
+			// namespace
 			NamespaceID:          namespaceID,
 			Path:                 gitlab.String(path),
 			Name:                 gitlab.String(name),

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -31,17 +31,35 @@ lab project create                         # user/<curr dir> named <curr dir>
                                            # (above only works w/i git repo)
 lab project create myproject               # user/myproject named myproject
 lab project create myproject -n "new proj" # user/myproject named "new proj"
-lab project create -n "new proj"           # user/new-proj named "new proj"`,
+lab project create -n "new proj"           # user/new-proj named "new proj"
+
+lab project create -g mygroup myproject    # mygroup/myproject named myproject`,
 	Args:             cobra.MaximumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
-			name, _ = cmd.Flags().GetString("name")
-			desc, _ = cmd.Flags().GetString("description")
+			name, _  = cmd.Flags().GetString("name")
+			desc, _  = cmd.Flags().GetString("description")
+			group, _ = cmd.Flags().GetString("group")
 		)
+
 		path := determinePath(args, name)
 		if path == "" && name == "" {
 			log.Fatal("path or name must be set")
+		}
+
+		var namespaceID *int
+		if group != "" {
+			list, err := lab.NamespaceSearch(group)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if len(list) < 0 {
+				log.Fatalf("no namespace found with such name: %s", group)
+			}
+
+			namespaceID = &list[0].ID
 		}
 
 		// set the default visibility
@@ -60,6 +78,7 @@ lab project create -n "new proj"           # user/new-proj named "new proj"`,
 		}
 
 		opts := gitlab.CreateProjectOptions{
+			NamespaceID:          namespaceID,
 			Path:                 gitlab.String(path),
 			Name:                 gitlab.String(name),
 			Description:          gitlab.String(desc),
@@ -99,6 +118,7 @@ func determinePath(args []string, name string) string {
 
 func init() {
 	projectCreateCmd.Flags().StringP("name", "n", "", "name of the new project")
+	projectCreateCmd.Flags().StringP("group", "g", "", "group name (also known as namespace)")
 	projectCreateCmd.Flags().StringP("description", "d", "", "description of the new project")
 	projectCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "make project private: visible only to project members")
 	projectCreateCmd.Flags().BoolVar(&public, "public", false, "make project public: visible without any authentication")

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -21,7 +21,7 @@ var (
 var projectCreateCmd = &cobra.Command{
 	Use:   "create [path]",
 	Short: "Create a new project on GitLab",
-	Long: `Create a new project on GitLab in your user namespace.
+	Long: `Create a new project on GitLab.
 
 path refers to the path on GitLab not including the group/namespace. If no path
 or name is provided and the current directory is a git repo, the name of the

--- a/cmd/project_create_test.go
+++ b/cmd/project_create_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
@@ -52,26 +53,31 @@ func Test_projectCreateCmd(t *testing.T) {
 	}
 }
 
-func Test_determinePath(t *testing.T) {
+func Test_determineNamespacePath(t *testing.T) {
 	t.Parallel()
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
 	}
 	tests := []struct {
-		desc     string
-		args     []string
-		expected string
+		desc              string
+		args              []string
+		expectedNamespace string
+		expectedPath      string
 	}{
-		{"arguemnt", []string{"new_project"}, "new_project"},
-		{"git working dir", []string{}, filepath.Base(wd)},
+		{"arg", []string{"new_project"}, "", "new_project"},
+		{"git working dir", []string{}, "", filepath.Base(wd)},
+		{"namespace", []string{"group/new_project"}, "group", "new_project"},
+		{"namespace", []string{"company/group/new_project"}, "company/group", "new_project"},
 	}
 
 	for _, test := range tests {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, test.expected, determinePath(test.args, ""))
+			group, path := determineNamespacePath(test.args, "")
+			assert.Equal(t, test.expectedNamespace, group)
+			assert.Equal(t, test.expectedPath, path)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/tcnksm/go-gitconfig v0.1.2
+	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad // indirect
 	github.com/xanzy/go-gitlab v0.39.0
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	github.com/yuin/goldmark v1.2.1 // indirect
@@ -55,6 +56,7 @@ require (
 	golang.org/x/sys v0.0.0-20201109165425-215b40eba54c // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	golang.org/x/tools v0.0.0-20200930213115-e57f6d466a48 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -480,6 +480,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/xanzy/go-gitlab v0.33.1-0.20200713191942-71ea998bed24 h1:WmX8fdQSu32qQpsPZ6/h90HK930NhUmoh+yLDItvmYw=
 github.com/xanzy/go-gitlab v0.33.1-0.20200713191942-71ea998bed24/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/go-gitlab v0.38.1 h1:st5/Ag4h8CqVfp3LpOWW0Jd4jYHTGETwu0KksYDPnYE=
@@ -716,6 +717,7 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200930213115-e57f6d466a48/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -936,9 +936,9 @@ func (s JobSorter) Less(i, j int) bool {
 	return time.Time(*s.Jobs[i].CreatedAt).Before(time.Time(*s.Jobs[j].CreatedAt))
 }
 
-// NamespaceSearch searches for a namespace on GitLab
-func NamespaceSearch(query string) ([]*gitlab.Namespace, error) {
-	list, _, err := lab.Namespaces.SearchNamespace(query)
+// GroupSearch searches for a namespace on GitLab
+func GroupSearch(query string) ([]*gitlab.Group, error) {
+	list, _, err := lab.Groups.SearchGroup(query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -937,13 +937,34 @@ func (s JobSorter) Less(i, j int) bool {
 }
 
 // GroupSearch searches for a namespace on GitLab
-func GroupSearch(query string) ([]*gitlab.Group, error) {
-	list, _, err := lab.Groups.SearchGroup(query)
+func GroupSearch(query string) (*gitlab.Group, error) {
+	if query == "" {
+		return nil, errors.New("query is empty")
+	}
+	groups := strings.Split(query, "/")
+	list, _, err := lab.Groups.SearchGroup(groups[0])
+	if err != nil {
+		return nil, err
+	}
+	// if we found a group and we aren't looking for a subgroup
+	if len(list) > 0 && len(groups) == 1 {
+		return list[0], nil
+	}
+	list, _, err = lab.Groups.ListDescendantGroups(list[0].ID, &gitlab.ListDescendantGroupsOptions{
+		Search: gitlab.String(groups[len(groups)-1]),
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	return list, nil
+	for _, g := range list {
+		fmt.Println(g.FullPath)
+		if g.FullPath == query {
+			return g, nil
+		}
+	}
+
+	return nil, errors.Errorf("Group '%s' not found", query)
 }
 
 // CIJobs returns a list of jobs in the pipeline with given id. The jobs are
@@ -1080,12 +1101,6 @@ func UserIDFromUsername(username string) (int, error) {
 		return -1, err
 	}
 	return us[0].ID, nil
-}
-
-// Labels converts a []string into a non-nil *gitlab.Labels.
-func Labels(labels []string) *gitlab.Labels {
-	l := gitlab.Labels(labels)
-	return &l
 }
 
 // AddMRDiscussionNote adds a note to an existing MR discussion on GitLab

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -24,10 +24,8 @@ import (
 	"github.com/zaquestion/lab/internal/git"
 )
 
-var (
-	// ErrProjectNotFound is returned when a GitLab project cannot be found.
-	ErrProjectNotFound = errors.New("gitlab project not found, verify you have access to the requested resource")
-)
+// ErrProjectNotFound is returned when a GitLab project cannot be found.
+var ErrProjectNotFound = errors.New("gitlab project not found, verify you have access to the requested resource")
 
 var (
 	lab   *gitlab.Client
@@ -169,9 +167,7 @@ func LoadGitLabTmpl(tmplName string) string {
 	return strings.TrimSpace(string(tmpl))
 }
 
-var (
-	localProjects map[string]*gitlab.Project = make(map[string]*gitlab.Project)
-)
+var localProjects map[string]*gitlab.Project = make(map[string]*gitlab.Project)
 
 // GetProject looks up a Gitlab project by ID.
 func GetProject(projectID interface{}) (*gitlab.Project, error) {
@@ -938,6 +934,16 @@ func (s JobSorter) Len() int      { return len(s.Jobs) }
 func (s JobSorter) Swap(i, j int) { s.Jobs[i], s.Jobs[j] = s.Jobs[j], s.Jobs[i] }
 func (s JobSorter) Less(i, j int) bool {
 	return time.Time(*s.Jobs[i].CreatedAt).Before(time.Time(*s.Jobs[j].CreatedAt))
+}
+
+// NamespaceSearch searches for a namespace on GitLab
+func NamespaceSearch(query string) ([]*gitlab.Namespace, error) {
+	list, _, err := lab.Namespaces.SearchNamespace(query)
+	if err != nil {
+		return nil, err
+	}
+
+	return list, nil
 }
 
 // CIJobs returns a list of jobs in the pipeline with given id. The jobs are

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -24,8 +24,12 @@ import (
 	"github.com/zaquestion/lab/internal/git"
 )
 
-// ErrProjectNotFound is returned when a GitLab project cannot be found.
-var ErrProjectNotFound = errors.New("gitlab project not found, verify you have access to the requested resource")
+var (
+	// ErrProjectNotFound is returned when a GitLab project cannot be found.
+	ErrProjectNotFound = errors.New("gitlab project not found, verify you have access to the requested resource")
+	// ErrGroupNotFound is returned when a GitLab group cannot be found.
+	ErrGroupNotFound = errors.New("gitlab group not found")
+)
 
 var (
 	lab   *gitlab.Client
@@ -945,6 +949,11 @@ func GroupSearch(query string) (*gitlab.Group, error) {
 	list, _, err := lab.Groups.SearchGroup(groups[0])
 	if err != nil {
 		return nil, err
+	}
+	// SearchGroup doesn't return error if group isn't found. We need to do
+	// it ourselves.
+	if len(list) == 0 {
+		return nil, ErrGroupNotFound
 	}
 	// if we found a group and we aren't looking for a subgroup
 	if len(list) > 0 && len(groups) == 1 {


### PR DESCRIPTION
Depends on https://github.com/xanzy/go-gitlab/pull/950

Manually tested:
```
lab project create lab-cli-testgroup/labproject5 # in group
lab project create lab-cli-testgroup/sub/labproject5 # in sub group
lab project create lab-cli-testgroup/sub/deeper/labproject5 # in nested subgroup
```
Special handling required for each case.