### PR TITLE
config: Provide better PAT information message

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,13 +84,13 @@ func New(confpath string, r io.Reader) error {
 var readPassword = func(reader bufio.Reader) (string, string, error) {
 	var loadToken string
 
-	tokenURL, err := url.Parse(viper.GetString("core.host"))
+	tokenURL, err := url.Parse(MainConfig.GetString("core.host"))
 	if err != nil {
 		return "", "", err
 	}
 	tokenURL.Path = "profile/personal_access_tokens"
 
-	fmt.Printf("Create a token here: %s\nEnter default GitLab token (scope: api), or leave blank to provide a command to load the token: ", tokenURL.String())
+	fmt.Printf("Create a token with scope 'api' here: %s\nEnter default GitLab token, or leave blank to provide a command to load the token: ", tokenURL.String())
 	byteToken, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
When running 'lab' for the first time users see the message

Create a token here: profile/personal_access_tokens

This does not indicate the scope of the token and the URL is incorrect.

Fix the URL and output a better token creation message.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>
Reported-by: David Arcari <darcari@redhat.com>