### PR TITLE
(gitlab-ci) add release jobs for goreleaser and docs gen

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ workflow:
 
 stages:
   - test
+  - release
 
 default:
   image: golang:1.15
@@ -60,7 +61,7 @@ code_navigation:
     - echo -e "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDkTcgXnHuqR0gbwegnr9Zxz4hTkjjV/SpgJNPJz7mo/HKNbx0rqjj1P0yGR053R9GSFFim2ut4NK9DPPUkQdyucw+DoLkYRHJmlJ4BNa9NTCD0sl+eSXO2969kZojCYSOgbmkCJx8mdgTwhzdgE/jhBrsY0hPE6pRTlU+H68/zeNdJUAIJf0LLXOm3hpTKLA19VICltl/j9VvBJpgRHdBylXEyL8HokYpjkQQk1ZXj3m7Nlo8yDdg4VcljOJWC+Xh8kxRMfK5x/VRVsYKCQXN5QlzKeqf7USRDUS/7mFoPUBW+d4kwKtGxRsWuIL2yeqzifZUTOgsh9+ZWAWxWffQZ your_email@example.com" > ~/.ssh/id_rsa.pub
     - echo -e "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA5E3IF5x7qkdIG8HoJ6/Wcc+IU5I41f0qYCTTyc+5qPxyjW8d\nK6o49T9MhkdOd0fRkhRYptrreDSvQzz1JEHcrnMPg6C5GERyZpSeATWvTUwg9LJf\nnklztvevZGaIwmEjoG5pAicfJnYE8Ic3YBP44Qa7GNITxOqUU5VPh+vP83jXSVAC\nCX9Cy1zpt4aUyiwNfVSApbZf4/VbwSaYER3QcpVxMi/B6JGKY5EEJNWV495uzZaP\nMg3YOFXJYziVgvl4fJMUTHyucf1UVbGCgkFzeUJcynqn+1EkQ1Ev+5haD1AVvneJ\nMCrRsUbFriC9snqs4n2VEzoLIffmVgFsVn30GQIDAQABAoIBAQDPQm2sQbti0mN8\nD4Uawl8D40v30n8WhUa7EbPTOmlqKAQ2sfDhex9KRbTLEmEBmImA/Eee8o9iCTIy\n8Fv8Fm6pUHt9G6Pti/XvemwW3Q3QNpSUkHqN0FDkgecQVqVBEb6uHo3mDm4RFINX\neOmkp30BjIK9/blEw1D0sFALLOEUPaDdPMwiXtFgqfrFSgpDET3TvQIwZ2LxxTm0\ncNmP3sCSlZHJNkZI4hBEWaaXR+V5/+C1qblDCo5blAWTcX3UzqrwUUJgFi6VnBuh\n7S9Q6+CEIU+4JRyWQNmY8YgZFaAp6IOr/kyfPxTP1+UEVVgcLn3WDYwfG9og0tmz\nfzlruAgBAoGBAPfz73Pey86tNZEanhJhbX8gVjzy2hvyhT0paHg0q/H6c1VWOtUH\nOwZ3Ns2xAZqJhlDqCHnQYSCZDly042U/theP4N8zo1APb4Yg4qdmXF9QE1+2M03r\nkS6138gU/CSCLf8pCYa6pA/GmsaXxloeJGLvT4fzOZRsVav80/92XHRhAoGBAOu2\nmKh4Gr1EjgN9QNbk9cQTSFDtlBEqO/0pTepvL73UvNp/BAn4iYZFU4WnklFVBSWc\nL84Sc732xU12TAbTTUsa6E7W29pS8u7zVTxlIdQIIU5pzDyU1pNNk2kpxzte5p3Y\nPDtniPFsoYLWoH0LpsKL93t2pLAj+IOkE6f3XBq5AoGAIKaYo5N1FxQr952frx/x\nQUpK0N/R5Ng8v18SiLG26rhmM5iVSrQXC7TrHI7wfR8a9tC6qP/NqnM9NuwC/bQ0\nEEo7/GhaWxKNRwZRkmWiSFLNGk9t1hbtGU+N1lUdFtmloPIQdRNiw0kN3JTj474Q\nYI7O1EItFORnK6yxZfR6HEECgYEA1CT7MGUoa8APsMRCXyaiq15Pb8bjxK8mXquW\nHLEFXuzhLCW1FORDoj0y9s/iuKC0iS0ROX8R/J7k5NrbgikbH8WP36UxKkYNr1IC\nHOFImPTYRSKjVsL+fIUNb1DSp3S6SsYbL7v3XJJQqtlQiDq8U8x1aQFXJ9C4EoLR\nzhKrKsECgYBtU/TSF/TATZY5XtrN9O+HX1Fbz70Ci8XgvioheVI2fezOcXPRzDcC\nOYPaCMNKA5E8gHdg4s0TN7uDvKTJ+KhSg2V7gZ39A28dHrJaRX7Nz4k6t2uEBjX9\na1JidpAIbJ+3w7+hj6L299tVZvS+Y/6Dz/uuEQGXfJg/l/5CCvQPsA==\n-----END RSA PRIVATE KEY-----" > ~/.ssh/id_rsa
     - chmod 600 ~/.ssh/id_rsa*
-    - eval `ssh-agent -s`
+    - eval $(ssh-agent -s)
     - ssh-add ~/.ssh/id_rsa
   script:
     - go version
@@ -71,3 +72,24 @@ test:
   stage: test
   extends: .test
   image: golang:1.15
+
+release:
+  stage: release
+  image: golang:1.15
+  only:
+    refs:
+      - tags
+  variables:
+    GITHUB_TOKEN: $GITHUB_TOKEN
+  script: |
+    curl -sL https://git.io/goreleaser | GO111MODULE=on bash
+
+docs:
+  stage: release
+  image: golang:1.15
+  only:
+    refs:
+      - tags
+  script: |
+    sed -i "s|lab version.\+$|lab version $(echo ${CI_COMMIT_TAG} | tr -d 'v')|" README.md
+    DEPLOY=1 docs/build.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,23 +4,26 @@ release:
     owner: zaquestion
     name: lab
   name_template: '{{.Tag}}'
-brew:
-  description: "Lab wraps Git or Hub, making it simple to clone, fork, and interact with repositories on GitLab"
-  homepage: "https://github.com/zaquestion/lab"
-  github:
-    owner: zaquestion
-    name: homebrew-tap
-  commit_author:
-    name: goreleaserbot
-    email: goreleaser@carlosbecker.com
-  install: bin.install "lab"
-  test: |
-    system "git", "init"
-    %w[haunted house].each { |f| touch testpath/f }
-    system "git", "add", "haunted", "house"
-    system "git", "commit", "-a", "-m", "Initial Commit"
-    lab_env_config = "LAB_CORE_HOST=foo LAB_CORE_USER=bar LAB_CORE_TOKEN=baz"
-    assert_equal "haunted\nhouse", shell_output("#{lab_env_config} #{bin}/lab ls-files").strip
+
+brews:
+  -
+    description: "Lab wraps Git or Hub, making it simple to clone, fork, and interact with repositories on GitLab"
+    homepage: "https://github.com/zaquestion/lab"
+    tap:
+      owner: zaquestion
+      name: homebrew-tap
+    commit_author:
+      name: goreleaserbot
+      email: goreleaser@carlosbecker.com
+    install: bin.install "lab"
+    test: |
+      system "git", "init"
+      %w[haunted house].each { |f| touch testpath/f }
+      system "git", "add", "haunted", "house"
+      system "git", "commit", "-a", "-m", "Initial Commit"
+      lab_env_config = "LAB_CORE_HOST=foo LAB_CORE_USER=bar LAB_CORE_TOKEN=baz"
+      assert_equal "haunted\nhouse", shell_output("#{lab_env_config} #{bin}/lab ls-files").strip
+
 scoop:
   bucket:
     owner: zaquestion
@@ -46,10 +49,11 @@ builds:
   main: .
   ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
   binary: lab
-archive:
-  format: tar.gz
-  name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{
-    .Arm }}{{ end }}'
+archives:
+  -
+    format: tar.gz
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{
+      .Arm }}{{ end }}'
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}
 checksum:

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -8,5 +8,5 @@ set -x
 if [ ! -z ${DEPLOY} ]; then
 	git config --global user.email "travis@travis-ci.org" && git config --global user.name "Travis CI"
 	git remote add origin-lab https://${GITHUB_TOKEN}@github.com/zaquestion/lab.git > /dev/null 2>&1
-	git fetch origin-lab && git checkout master && git add docs && git add README.md && git commit -m "(docs) ${TRAVIS_TAG}" && git push origin-lab master
+	git fetch origin-lab && git checkout master && git add docs && git add README.md && git commit -m "(docs) ${CI_COMMIT_TAG}" && git push origin-lab master
 fi


### PR DESCRIPTION
note: for docs to work on gitlab themselves we will need to get a jeckyll/markdown renderer rigged up, but this much will keep the files up to date