### PR TITLE
git: consider pushurl gitconfig option

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -129,9 +129,12 @@ func CurrentBranch() (string, error) {
 // Such as zaquestion/lab
 // Respects GitLab subgroups (https://docs.gitlab.com/ce/user/group/subgroups/)
 func PathWithNameSpace(remote string) (string, error) {
-	remoteURL, err := gitconfig.Local("remote." + remote + ".url")
+	remoteURL, err := gitconfig.Local("remote." + remote + ".pushurl")
 	if err != nil {
-		return "", err
+		remoteURL, err = gitconfig.Local("remote." + remote + ".url")
+		if err != nil {
+			return "", err
+		}
 	}
 
 	parts := strings.Split(remoteURL, "//")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -120,6 +120,12 @@ func TestPathWithNameSpace(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			desc:        "pushurl",
+			remote:      "origin-pushurl",
+			expected:    "zaquestion/test",
+			expectedErr: "",
+		},
+		{
 			desc:        "https://token@gitlab.com/org/repo",
 			remote:      "origin-https-token",
 			expected:    "zaquestion/test",

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -264,11 +264,32 @@ func TestGetLocalRemotesFromFile(t *testing.T) {
 	}
 	remotesList := strings.Split(string(res), "\n")
 
+	// Create an array (the ordering matters) to place all unique
+	// remote names
+	var remoteNames []string
+	for _, remote := range remotesList {
+		if len(remote) == 0 {
+			continue
+		}
+
+		name := strings.Split(remote, ".")[1]
+		// Check if name is unique
+		var found bool
+		for _, placedName := range remoteNames {
+			if name == placedName {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		remoteNames = append(remoteNames, name)
+	}
+
+	// Check if remote exists and is in order
 	for i, match := range reMatches {
-		// GetLocalRemotesFromFile return both .url and .fetch
-		// info, but we only need to check one of them.
-		remoteName := strings.Split(remotesList[i*2], ".")
-		require.Equal(t, match[1], remoteName[1])
+		require.Equal(t, match[1], remoteNames[i])
 	}
 }
 

--- a/testdata/test.git/config
+++ b/testdata/test.git/config
@@ -26,6 +26,10 @@
 [remote "origin-https"]
 	url = https://gitlab.com/zaquestion/test.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "origin-pushurl"]
+	url = garbageurl
+	pushurl = https://gitlab.com/zaquestion/test.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
 [remote "origin-https-token"]
 	url = https://token@gitlab.com/zaquestion/test.git
 	fetch = +refs/heads/*:refs/remotes/origin/*


### PR DESCRIPTION
Solves issue #456 by checking `remote.<name>.pushurl` before `remote.<name>.url`.