### PR TITLE
Merge Request edit functionality

### DIFF
--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -277,19 +277,14 @@ func same(a, b []string) bool {
 	return true
 }
 
-// issueEditCmdAddFlags adds various flags to the `lab issue edit` command
-func issueEditCmdAddFlags(flags *pflag.FlagSet) *pflag.FlagSet {
-	flags.StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
-	flags.StringSliceP("label", "l", []string{}, "Add the given label(s) to the issue")
-	flags.StringSliceP("unlabel", "", []string{}, "Remove the given label(s) from the issue")
-	flags.StringSliceP("assign", "a", []string{}, "Add an assignee by username")
-	flags.StringSliceP("unassign", "", []string{}, "Remove an assignee by username")
-	flags.Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
-	return flags
-}
-
 func init() {
-	issueEditCmdAddFlags(issueEditCmd.Flags())
+	issueEditCmd.Flags().StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	issueEditCmd.Flags().StringSliceP("label", "l", []string{}, "Add the given label(s) to the issue")
+	issueEditCmd.Flags().StringSliceP("unlabel", "", []string{}, "Remove the given label(s) from the issue")
+	issueEditCmd.Flags().StringSliceP("assign", "a", []string{}, "Add an assignee by username")
+	issueEditCmd.Flags().StringSliceP("unassign", "", []string{}, "Remove an assignee by username")
+	issueEditCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
+
 	issueCmd.AddCommand(issueEditCmd)
 	carapace.Gen(issueEditCmd).PositionalCompletion(
 		action.Remotes(),

--- a/cmd/issue_edit_test.go
+++ b/cmd/issue_edit_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -142,7 +141,7 @@ func Test_issueEditGetTitleAndDescription(t *testing.T) {
 				Title:       "old title",
 				Description: "old body",
 			},
-			Args:                []string{"-m", "new title", "-m", "new body 1", "-m", "new body 2"},
+			Args:                []string{"new title", "new body 1", "new body 2"},
 			ExpectedTitle:       "new title",
 			ExpectedDescription: "new body 1\n\nnew body 2",
 		},
@@ -152,7 +151,7 @@ func Test_issueEditGetTitleAndDescription(t *testing.T) {
 				Title:       "old title",
 				Description: "old body",
 			},
-			Args:                []string{"-m", "new title"},
+			Args:                []string{"new title"},
 			ExpectedTitle:       "new title",
 			ExpectedDescription: "old body",
 		},
@@ -171,13 +170,11 @@ func Test_issueEditGetTitleAndDescription(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			test := test
 			t.Parallel()
-			flags := issueEditCmdAddFlags(pflag.NewFlagSet(test.Name, pflag.ContinueOnError))
-			flags.Parse(test.Args)
-
-			title, body, err := issueEditGetTitleDescription(test.Issue, flags)
+			title, body, err := editGetTitleDescription(test.Issue.Title, test.Issue.Description, test.Args, len(test.Args))
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			assert.Equal(t, test.ExpectedTitle, title)
 			assert.Equal(t, test.ExpectedDescription, body)
 		})
@@ -186,7 +183,7 @@ func Test_issueEditGetTitleAndDescription(t *testing.T) {
 
 func Test_issueEditText(t *testing.T) {
 	t.Parallel()
-	text, err := issueEditText("old title", "old body")
+	text, err := editText("old title", "old body")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,8 +191,8 @@ func Test_issueEditText(t *testing.T) {
 
 old body
 
-# Edit the title and/or description of this issue. The first
-# block of text is the title and the rest is the description.`, text)
+# Edit the title and/or description. The first block of text
+# is the title and the rest is the description.`, text)
 
 }
 

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -74,7 +74,7 @@ func NoteRunFn(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		replyNote(rn, isMR, int(idNum), reply, quote, filename, linebreak)
+		replyNote(rn, isMR, int(idNum), reply, quote, true, filename, linebreak)
 		return
 	}
 
@@ -172,7 +172,7 @@ func noteText(body string) (string, error) {
 	return b.String(), nil
 }
 
-func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, filename string, linebreak bool) {
+func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, update bool, filename string, linebreak bool) {
 
 	var (
 		discussions []*gitlab.Discussion
@@ -211,7 +211,9 @@ func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, filename 
 				if quote {
 					noteBody = note.Body
 					noteBody = strings.Replace(noteBody, "\n", "\n>", -1)
-					noteBody = ">" + noteBody + "\n"
+					if !update {
+						noteBody = ">" + noteBody + "\n"
+					}
 				}
 				body, err = noteMsg([]string{}, isMR, noteBody)
 				if err != nil {
@@ -228,16 +230,18 @@ func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, filename 
 				body = textToMarkdown(body)
 			}
 
-			if isMR {
-				opts := &gitlab.AddMergeRequestDiscussionNoteOptions{
-					Body: &body,
+			if update {
+				if isMR {
+					NoteURL, err = lab.UpdateMRDiscussionNote(rn, idNum, discussion.ID, note.ID, body)
+				} else {
+					NoteURL, err = lab.UpdateIssueDiscussionNote(rn, idNum, discussion.ID, note.ID, body)
 				}
-				NoteURL, err = lab.AddMRDiscussionNote(rn, idNum, discussion.ID, opts)
 			} else {
-				opts := &gitlab.AddIssueDiscussionNoteOptions{
-					Body: &body,
+				if isMR {
+					NoteURL, err = lab.AddMRDiscussionNote(rn, idNum, discussion.ID, body)
+				} else {
+					NoteURL, err = lab.AddIssueDiscussionNote(rn, idNum, discussion.ID, body)
 				}
-				NoteURL, err = lab.AddIssueDiscussionNote(rn, idNum, discussion.ID, opts)
 			}
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -74,14 +74,14 @@ func NoteRunFn(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		ReplyNote(rn, isMR, int(idNum), reply, quote, filename, linebreak)
+		replyNote(rn, isMR, int(idNum), reply, quote, filename, linebreak)
 		return
 	}
 
-	CreateNote(rn, isMR, int(idNum), msgs, filename, linebreak)
+	createNote(rn, isMR, int(idNum), msgs, filename, linebreak)
 }
 
-func CreateNote(rn string, isMR bool, idNum int, msgs []string, filename string, linebreak bool) {
+func createNote(rn string, isMR bool, idNum int, msgs []string, filename string, linebreak bool) {
 
 	var err error
 
@@ -172,7 +172,7 @@ func noteText(body string) (string, error) {
 	return b.String(), nil
 }
 
-func ReplyNote(rn string, isMR bool, idNum int, reply int, quote bool, filename string, linebreak bool) {
+func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, filename string, linebreak bool) {
 
 	var (
 		discussions []*gitlab.Discussion

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"runtime"
+	"strconv"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	gitlab "github.com/xanzy/go-gitlab"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var mrEditCmd = &cobra.Command{
+	Use:     "edit [remote] <id>",
+	Aliases: []string{"update"},
+	Short:   "Edit or update an MR",
+	Long:    ``,
+	Example: `lab MR edit <id>                                # update MR via $EDITOR
+lab MR update <id>                              # same as above
+lab MR edit <id> -m "new title"                 # update title
+lab MR edit <id> -m "new title" -m "new desc"   # update title & description
+lab MR edit <id> -l newlabel --unlabel oldlabel # relabel MR`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, mrNum, err := parseArgs(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		mr, err := lab.MRGet(rn, int(mrNum))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		labels, err := cmd.Flags().GetStringSlice("label")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// get the labels to remove
+		unlabels, err := cmd.Flags().GetStringSlice("unlabel")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		labels, labelsChanged, err := editGetLabels(mr.Labels, labels, unlabels)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// get the assignees to add
+		assignees, err := cmd.Flags().GetStringSlice("assign")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// get the assignees to remove
+		unassignees, err := cmd.Flags().GetStringSlice("unassign")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		currentAssignees := mrGetCurrentAssignees(mr)
+		assigneeIDs, assigneesChanged, err := getUpdateAssignees(currentAssignees, assignees, unassignees)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// get all of the "message" flags
+		msgs, err := cmd.Flags().GetStringSlice("message")
+		if err != nil {
+			log.Fatal(err)
+		}
+		title, body, err := editGetTitleDescription(mr.Title, mr.Description, msgs, cmd.Flags().NFlag())
+		if err != nil {
+			_, f, l, _ := runtime.Caller(0)
+			log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
+		}
+		if title == "" {
+			log.Fatal("aborting: empty mr title")
+		}
+
+		abortUpdate := title == mr.Title && body == mr.Description && !labelsChanged && !assigneesChanged
+		if abortUpdate {
+			log.Fatal("aborting: no changes")
+		}
+
+		linebreak, _ := cmd.Flags().GetBool("force-linebreak")
+		if linebreak {
+			body = textToMarkdown(body)
+		}
+
+		opts := &gitlab.UpdateMergeRequestOptions{
+			Title:       &title,
+			Description: &body,
+		}
+
+		if labelsChanged {
+			opts.Labels = lab.Labels(labels)
+		}
+
+		if assigneesChanged {
+			opts.AssigneeIDs = assigneeIDs
+		}
+
+		mrURL, err := lab.MRUpdate(rn, int(mrNum), opts)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(mrURL)
+	},
+}
+
+// mrGetCurrentAssignees returns a string slice of the current assignees'
+// usernames
+func mrGetCurrentAssignees(mr *gitlab.MergeRequest) []string {
+	currentAssignees := make([]string, len(mr.Assignees))
+	if len(mr.Assignees) > 0 && mr.Assignees[0].Username != "" {
+		for i, a := range mr.Assignees {
+			currentAssignees[i] = a.Username
+		}
+	}
+	return currentAssignees
+}
+
+func init() {
+	mrEditCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	mrEditCmd.Flags().StringSliceP("label", "l", []string{}, "Add the given label(s) to the merge request")
+	mrEditCmd.Flags().StringSliceP("unlabel", "", []string{}, "Remove the given label(s) from the merge request")
+	mrEditCmd.Flags().StringSliceP("assign", "a", []string{}, "Add an assignee by username")
+	mrEditCmd.Flags().StringSliceP("unassign", "", []string{}, "Remove an assigne by username")
+	mrEditCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
+
+	mrCmd.AddCommand(mrEditCmd)
+	carapace.Gen(mrEditCmd).PositionalCompletion(
+		action.Remotes(),
+		action.MergeRequests(mrList),
+	)
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -921,10 +921,14 @@ func Labels(labels []string) *gitlab.Labels {
 }
 
 // AddMRDiscussionNote adds a note to an existing MR discussion on GitLab
-func AddMRDiscussionNote(project string, mrNum int, discussionID string, opts *gitlab.AddMergeRequestDiscussionNoteOptions) (string, error) {
+func AddMRDiscussionNote(project string, mrNum int, discussionID string, body string) (string, error) {
 	p, err := FindProject(project)
 	if err != nil {
 		return "", err
+	}
+
+	opts := &gitlab.AddMergeRequestDiscussionNoteOptions{
+		Body: &body,
 	}
 
 	note, _, err := lab.Discussions.AddMergeRequestDiscussionNote(p.ID, mrNum, discussionID, opts)
@@ -935,10 +939,14 @@ func AddMRDiscussionNote(project string, mrNum int, discussionID string, opts *g
 }
 
 // AddIssueDiscussionNote adds a note to an existing issue discussion on GitLab
-func AddIssueDiscussionNote(project string, issueNum int, discussionID string, opts *gitlab.AddIssueDiscussionNoteOptions) (string, error) {
+func AddIssueDiscussionNote(project string, issueNum int, discussionID string, body string) (string, error) {
 	p, err := FindProject(project)
 	if err != nil {
 		return "", err
+	}
+
+	opts := &gitlab.AddIssueDiscussionNoteOptions{
+		Body: &body,
 	}
 
 	note, _, err := lab.Discussions.AddIssueDiscussionNote(p.ID, issueNum, discussionID, opts)
@@ -946,4 +954,36 @@ func AddIssueDiscussionNote(project string, issueNum int, discussionID string, o
 		return "", err
 	}
 	return fmt.Sprintf("%s/issues/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+}
+
+func UpdateIssueDiscussionNote(project string, issueNum int, discussionID string, noteID int, body string) (string, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return "", err
+	}
+	opts := &gitlab.UpdateIssueDiscussionNoteOptions{
+		Body: &body,
+	}
+
+	note, _, err := lab.Discussions.UpdateIssueDiscussionNote(p.ID, issueNum, discussionID, noteID, opts)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/issues/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+}
+
+func UpdateMRDiscussionNote(project string, issueNum int, discussionID string, noteID int, body string) (string, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return "", err
+	}
+	opts := &gitlab.UpdateMergeRequestDiscussionNoteOptions{
+		Body: &body,
+	}
+
+	note, _, err := lab.Discussions.UpdateMergeRequestDiscussionNote(p.ID, issueNum, discussionID, noteID, opts)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -270,6 +270,20 @@ func MRCreateDiscussion(project string, mrNum int, opts *gitlab.CreateMergeReque
 	return fmt.Sprintf("%s/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }
 
+// MRUpdate edits an merge request on a GitLab project
+func MRUpdate(project string, mrNum int, opts *gitlab.UpdateMergeRequestOptions) (string, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return "", err
+	}
+
+	issue, _, err := lab.MergeRequests.UpdateMergeRequest(p.ID, mrNum, opts)
+	if err != nil {
+		return "", err
+	}
+	return issue.WebURL, nil
+}
+
 // MRCreateNote adds a note to a merge request on GitLab
 func MRCreateNote(project string, mrNum int, opts *gitlab.CreateMergeRequestNoteOptions) (string, error) {
 	p, err := FindProject(project)


### PR DESCRIPTION
Add the ability to edit Merge Request descriptions and comments.  As a bonus, this also allows the editing of Issue comments.