### PR TITLE
config: Add a better user authentication error message

### DIFF
--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/action"
+	"github.com/zaquestion/lab/internal/config"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
@@ -33,7 +34,8 @@ var listCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		mrs, err := mrList(args)
 		if err != nil {
-			log.Fatal(err)
+			log.Print(err)
+			config.UserConfigError()
 		}
 		for _, mr := range mrs {
 			fmt.Printf("#%d %s\n", mr.IID, mr.Title)


### PR DESCRIPTION
The user authentication can fail if the token or load_token field is
incorrect.  lab fails with, for example,

2020/10/13 13:29:46 config.go:194: GET https://gitlab.com/api/v4/user: 401 {message: 401 Unauthorized}

which is not human-readable.

Output a better and human friendly authentication error message.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>