### PR TITLE
mr_create: add git-config options as possible source remotes

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -230,8 +230,18 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 }
 
 func determineSourceRemote(branch string) string {
-	// Check if the branch is being tracked
-	r, err := gitconfig.Local("branch." + branch + ".remote")
+	// There is a precendence of options that should be considered here:
+	// branch.<name>.pushRemote > remote.pushDefault > branch.<name>.remote
+	// This rule is placed in git-config(1) manpage
+	r, err := gitconfig.Local("branch." + branch + ".pushRemote")
+	if err == nil {
+		return r
+	}
+	r, err = gitconfig.Local("remote.pushDefault")
+	if err == nil {
+		return r
+	}
+	r, err = gitconfig.Local("branch." + branch + ".remote")
 	if err == nil {
 		return r
 	}

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/acarl005/stripansi"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -218,4 +220,73 @@ func Test_mrCmd_noArgs(t *testing.T) {
 	require.Contains(t, string(b), `Usage:
   lab mr [flags]
   lab mr [command]`)
+}
+
+func Test_determineSourceRemote(t *testing.T) {
+	tests := []struct {
+		desc     string
+		branch   string
+		expected string
+	}{
+		{
+			desc:     "branch.<name>.remote",
+			branch:   "mrtest",
+			expected: "lab-testing",
+		},
+		{
+			desc:     "branch.<name>.pushRemote",
+			branch:   "mrtest-pushRemote",
+			expected: "lab-testing",
+		},
+		{
+			desc:     "pushDefault without pushRemote set",
+			branch:   "mrtest",
+			expected: "garbageurl",
+		},
+		{
+			desc:     "pushDefault with pushRemote set",
+			branch:   "mrtest-pushRemote",
+			expected: "lab-testing",
+		},
+	}
+
+	// The function being tested here depends on being in the test
+	// directory, where 'git config --local' can retrieve the correct
+	// info from
+	repo := copyTestRepo(t)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Log(err)
+	}
+	os.Chdir(repo)
+
+	var remoteModified bool
+	for _, test := range tests {
+		test := test
+		if strings.Contains(test.desc, "pushDefault") && !remoteModified {
+			git := exec.Command("git", "config", "--local", "remote.pushDefault", "garbageurl")
+			git.Dir = repo
+			b, err := git.CombinedOutput()
+			if err != nil {
+				t.Log(string(b))
+				t.Fatal(err)
+			}
+			remoteModified = true
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			sourceRemote := determineSourceRemote(test.branch)
+			assert.Equal(t, test.expected, sourceRemote)
+		})
+	}
+	// Remove the added option to avoid messing with other tests
+	git := exec.Command("git", "config", "--local", "--unset", "remote.pushDefault")
+	git.Dir = repo
+	b, err := git.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+	// And move back to the workdir we were before the test
+	os.Chdir(oldWd)
 }

--- a/testdata/test.git/config
+++ b/testdata/test.git/config
@@ -17,6 +17,10 @@
 [branch "mrtest"]
 	remote = lab-testing
 	merge = refs/heads/mrtest
+[branch "mrtest-pushRemote"]
+    remote = garbageurl
+    pushRemote = lab-testing
+    merge = refs/heads/mrtest-pushRemote
 
 # Other formats for testing in internal/git/git_test.go
 # https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a


### PR DESCRIPTION
Solves issue #466 by adding `remote.pushDefault` and `branch.<name>.pushRemote` as possible source remote options.
Also, the patch also adds a test case for the function.