### PR TITLE
mr create: Update 'mr create' output and add --cover-letter option

### DIFF
--- a/cmd/mr_create_test.go
+++ b/cmd/mr_create_test.go
@@ -9,13 +9,12 @@ import (
 // MR Create is tested in cmd/mr_test.go
 
 func Test_mrText(t *testing.T) {
-	t.Parallel()
-	text, err := mrText("master", "mrtest", "lab-testing", "origin")
+	text, err := mrText("master", "mrtest", "lab-testing", "origin", false)
 	if err != nil {
 		t.Log(text)
 		t.Fatal(err)
 	}
-	require.Contains(t, text, `(ci) jobs with interleaved sleeps and prints
+	require.Contains(t, text, `
 
 I am the default merge request template for lab
 # Requesting a merge into origin:master from lab-testing:mrtest
@@ -26,5 +25,26 @@ I am the default merge request template for lab
 # Changes:
 #
 # 54fd49a (Zaq? Wiedmann`)
+
+}
+
+func Test_mrText_CoverLetter(t *testing.T) {
+	coverLetter, err := mrText("master", "mrtest", "lab-testing", "origin", true)
+	if err != nil {
+		t.Log(coverLetter)
+		t.Fatal(err)
+	}
+	require.Contains(t, coverLetter, `
+
+I am the default merge request template for lab
+# Requesting a merge into origin:master from lab-testing:mrtest
+#
+# Write a message for this merge request. The first block
+# of text is the title and the rest is the description.
+#
+# Changes:
+#
+
+54fd49a (Zaq? Wiedmann`)
 
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -102,7 +102,7 @@ func Log(sha1, sha2 string) (string, error) {
 	cmd := New("-c", "log.showSignature=false",
 		"log",
 		"--no-color",
-		"--format=%h (%aN, %ar)%n%w(78,3,3)%s%n",
+		"--format=%h (%aN)%n%w(78,3,3)%s%n",
 		"--cherry",
 		fmt.Sprintf("%s...%s", sha1, sha2))
 	cmd.Stdout = nil
@@ -111,7 +111,13 @@ func Log(sha1, sha2 string) (string, error) {
 		return "", errors.Errorf("Can't load git log %s..%s", sha1, sha2)
 	}
 
-	return string(outputs), nil
+	diffCmd := New("diff", "--stat", sha1)
+	diffCmd.Stdout = nil
+	diffOutput, err := diffCmd.Output()
+	if err != nil {
+		return "", errors.Errorf("Can't load diffstat")
+	}
+	return string(outputs) + string(diffOutput), nil
 }
 
 // CurrentBranch returns the currently checked out branch

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -319,3 +319,16 @@ func GetUnifiedDiff(BaseSHA string, HeadSHA string, oldPath string, newPath stri
 	}
 	return string(diff), nil
 }
+
+func NumberCommits(sha1, sha2 string) int {
+	cmd := New("log", "--oneline", fmt.Sprintf("%s...%s", sha1, sha2))
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	CmdOut, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("There are no commits between %s and %s", sha2, sha2)
+		log.Fatal(err)
+	}
+	numLines := strings.Count(string(CmdOut), "\n")
+	return numLines
+}


### PR DESCRIPTION
    The 'lab mr create' command provides changelog output as part of the
    default commit message in which each commit, author, and age of commit
    is displayed.  The output does not contain a diffstat and some
    users find diffstat useful for both commit verification and for code
    review.
    
    Remove the age of the commits from the output and provide the diffstat
    output in the create output.  Like the rest of the changelog, the new
    diffstat output is commented so it is not included in the merge request
    description by default.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>