### PR TITLE
ci_status_test: Reverse expected output

### DIFF
--- a/cmd/ci_status_test.go
+++ b/cmd/ci_status_test.go
@@ -41,25 +41,25 @@ func Test_ciStatus(t *testing.T) {
 	}
 	out := string(b)
 	assert.Contains(t, out, `Stage:  Name                           - Status
-build:  build1                         - success
-build:  build2                         - success
-build:  build2:fails                   - failed
-test:   test1                          - success
-test:   test2                          - success
-test:   test2:really_a_long_name_for   - success
-test:   test2:no_suffix:test           - success
-test:   test3                          - success
-deploy: deploy1                        - success
-deploy: deploy2                        - manual
-deploy: deploy3:no_sufix:deploy        - success
-deploy: deploy4                        - success
-deploy: deploy5:really_a_long_name_for - success
-deploy: deploy5                        - success
-deploy: deploy6                        - success
-deploy: deploy7                        - success
-deploy: deploy8                        - success
+deploy: deploy10                       - success
 deploy: deploy9                        - success
-deploy: deploy10                       - success`)
+deploy: deploy8                        - success
+deploy: deploy7                        - success
+deploy: deploy6                        - success
+deploy: deploy5                        - success
+deploy: deploy5:really_a_long_name_for - success
+deploy: deploy4                        - success
+deploy: deploy3:no_sufix:deploy        - success
+deploy: deploy2                        - manual
+deploy: deploy1                        - success
+test:   test3                          - success
+test:   test2:no_suffix:test           - success
+test:   test2:really_a_long_name_for   - success
+test:   test2                          - success
+test:   test1                          - success
+build:  build2:fails                   - failed
+build:  build2                         - success
+build:  build1                         - success`)
 
 	assert.Contains(t, out, "Pipeline Status: success")
 }

--- a/cmd/ci_trace_test.go
+++ b/cmd/ci_trace_test.go
@@ -40,7 +40,7 @@ func Test_ciTrace(t *testing.T) {
 			desc: "noargs",
 			args: []string{},
 			assertContains: func(t *testing.T, out string) {
-				assert.Contains(t, out, "Showing logs for deploy10")
+				assert.Contains(t, out, "Showing logs for build1")
 				assert.Contains(t, out, "Checking out 09b519cb as ci_test_pipeline...")
 				assert.Contains(t, out, "For example you might run an update here or install a build dependency")
 				assert.Contains(t, out, "$ echo \"Or perhaps you might print out some debugging details\"")


### PR DESCRIPTION
The Travis CI results are now reversed and are causing ci_status_test
to fail when checking the expected output.

Reverse the excepted output.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>