### PR TITLE
Add MR contextual command support for issue 204

### DIFF
--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -54,6 +54,14 @@ func NoteRunFn(cmd *cobra.Command, args []string) {
 		idNum, _ = strconv.Atoi(idString)
 	}
 
+	if isMR && idNum == 0 {
+		idNum = getCurrentBranchMR(rn)
+		if idNum == 0 {
+			fmt.Println("Error: Cannot determine MR id.")
+			os.Exit(1)
+		}
+	}
+
 	msgs, err := cmd.Flags().GetStringArray("message")
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -18,7 +18,7 @@ var mrApproveCmd = &cobra.Command{
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, id, err := parseArgs(args)
+		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_browse.go
+++ b/cmd/mr_browse.go
@@ -8,9 +8,7 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
-	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/action"
-	git "github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
@@ -21,7 +19,7 @@ var mrBrowseCmd = &cobra.Command{
 	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, num, err := parseArgs(args)
+		rn, num, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -32,30 +30,7 @@ var mrBrowseCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		hostURL.Path = path.Join(hostURL.Path, rn, "merge_requests")
-		if num > 0 {
-			hostURL.Path = path.Join(hostURL.Path, strconv.FormatInt(num, 10))
-		} else {
-			currentBranch, err := git.CurrentBranch()
-			if err != nil {
-				log.Fatal(err)
-			}
-			mrs, err := lab.MRList(rn, gitlab.ListProjectMergeRequestsOptions{
-				ListOptions: gitlab.ListOptions{
-					PerPage: 10,
-				},
-				Labels:       lab.Labels(mrLabels),
-				State:        &mrState,
-				OrderBy:      gitlab.String("updated_at"),
-				SourceBranch: gitlab.String(currentBranch),
-			}, -1)
-			if err != nil {
-				log.Fatal(err)
-			}
-			if len(mrs) > 0 {
-				num = int64(mrs[0].IID)
-				hostURL.Path = path.Join(hostURL.Path, strconv.FormatInt(num, 10))
-			}
-		}
+		hostURL.Path = path.Join(hostURL.Path, strconv.FormatInt(num, 10))
 
 		err = browse(hostURL.String())
 		if err != nil {

--- a/cmd/mr_close.go
+++ b/cmd/mr_close.go
@@ -18,7 +18,7 @@ var mrCloseCmd = &cobra.Command{
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, id, err := parseArgs(args)
+		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -26,7 +26,7 @@ var mrCreateDiscussionCmd = &cobra.Command{
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, mrNum, err := parseArgs(args)
+		rn, mrNum, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -25,7 +26,6 @@ lab MR edit <id> -m "new title"                 # update title
 lab MR edit <id> -m "new title" -m "new desc"   # update title & description
 lab MR edit <id> -l newlabel --unlabel oldlabel # relabel MR
 lab MR edit <id>:<comment_id>                   # update a comment on MR`,
-	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, idString, err := parseArgsRemoteString(args)
 		if err != nil {
@@ -43,6 +43,14 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 			commentNum, _ = strconv.Atoi(ids[1])
 		} else {
 			mrNum, _ = strconv.Atoi(idString)
+		}
+
+		if mrNum == 0 {
+			mrNum = getCurrentBranchMR(rn)
+			if mrNum == 0 {
+				fmt.Println("Error: Cannot determine MR id.")
+				os.Exit(1)
+			}
 		}
 
 		mr, err := lab.MRGet(rn, mrNum)

--- a/cmd/mr_merge.go
+++ b/cmd/mr_merge.go
@@ -17,7 +17,7 @@ var mrMergeCmd = &cobra.Command{
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, id, err := parseArgs(args)
+		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_rebase.go
+++ b/cmd/mr_rebase.go
@@ -16,7 +16,7 @@ var mrRebaseCmd = &cobra.Command{
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, id, err := parseArgs(args)
+		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -29,7 +29,7 @@ var mrShowCmd = &cobra.Command{
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		rn, mrNum, err := parseArgs(args)
+		rn, mrNum, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_thumb.go
+++ b/cmd/mr_thumb.go
@@ -25,7 +25,7 @@ var mrThumbUpCmd = &cobra.Command{
 	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, id, err := parseArgs(args)
+		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -139,6 +139,21 @@ func parseArgs(args []string) (string, int64, error) {
 	return parseArgsRemoteInt(args)
 }
 
+// parseArgsWithGitBranchMR returns a remote name and a number if parsed.
+// If no number is specified, the MR id associated with the current
+// branch is returned.
+func parseArgsWithGitBranchMR(args []string) (string, int64, error) {
+	s, i, err := parseArgsRemoteInt(args)
+	if i == 0 {
+		i = int64(getCurrentBranchMR(s))
+		if i == 0 {
+			fmt.Println("Error: Cannot determine MR id.")
+			os.Exit(1)
+		}
+	}
+	return s, i, err
+}
+
 // parseArgsRemoteInt is similar to parseArgsStringInt except that it uses the
 // string argument as a remote and returns the project name for that remote
 func parseArgsRemoteInt(args []string) (string, int64, error) {

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,4 +13,40 @@ func Test_textToMarkdown(t *testing.T) {
 	teststring := basestring + "\n"
 	newteststring := textToMarkdown(teststring)
 	assert.Equal(t, basestring+"  \n", newteststring)
+}
+
+func Test_getCurrentBranchMR(t *testing.T) {
+	repo := copyTestRepo(t)
+
+	// make sure the branch does not exist
+	cmd := exec.Command("git", "branch", "-D", "mrtest")
+	cmd.Dir = repo
+	cmd.CombinedOutput()
+
+	cmd = exec.Command(labBinaryPath, "mr", "checkout", "1")
+	cmd.Dir = repo
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+
+	curDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Chdir(repo)
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+	mrNum := getCurrentBranchMR("zaquestion/test")
+	err = os.Chdir(curDir)
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1, mrNum)
 }


### PR DESCRIPTION
Add MR contextual support for issue 204.  This allows users to checkout a branch and execute commands on that branch without specifying the MR ID.  For example,

```
git checkout <branch_for_MR_100>
lab mr show
#shows MR for 100
```
