### PR TITLE
lab: Fix --help output

### DIFF
--- a/cmd/ci_run.go
+++ b/cmd/ci_run.go
@@ -135,15 +135,15 @@ func parseCIVariables(vars []string) (map[string]string, error) {
 }
 
 func init() {
-	ciCreateCmd.Flags().StringP("project", "p", "", "Project to create pipeline on")
+	ciCreateCmd.Flags().StringP("project", "p", "", "project to create pipeline on")
 	ciCmd.AddCommand(ciCreateCmd)
 	carapace.Gen(ciCreateCmd).PositionalCompletion(
 		action.Remotes(),
 	)
 
-	ciTriggerCmd.Flags().StringP("project", "p", "", "Project to run pipeline trigger on")
-	ciTriggerCmd.Flags().StringP("token", "t", os.Getenv("CI_JOB_TOKEN"), "Pipeline trigger token, optional if run within GitLabCI")
-	ciTriggerCmd.Flags().StringSliceP("variable", "v", []string{}, "Variables to pass to pipeline")
+	ciTriggerCmd.Flags().StringP("project", "p", "", "project to run pipeline trigger on")
+	ciTriggerCmd.Flags().StringP("token", "t", os.Getenv("CI_JOB_TOKEN"), "pipeline trigger token, optional if run within GitLabCI")
+	ciTriggerCmd.Flags().StringSliceP("variable", "v", []string{}, "variables to pass to pipeline")
 
 	ciCmd.AddCommand(ciTriggerCmd)
 	carapace.Gen(ciTriggerCmd).PositionalCompletion(

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -94,7 +94,7 @@ lab ci status --wait`,
 }
 
 func init() {
-	ciStatusCmd.Flags().Bool("wait", false, "Continuously print the status and wait to exit until the pipeline finishes. Exit code indicates pipeline status")
+	ciStatusCmd.Flags().Bool("wait", false, "continuously print the status and wait to exit until the pipeline finishes. Exit code indicates pipeline status")
 	ciCmd.AddCommand(ciStatusCmd)
 
 	carapace.Gen(ciStatusCmd).PositionalCompletion(

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -89,6 +89,6 @@ func determineForkRemote(project string) string {
 }
 
 func init() {
-	forkCmd.Flags().BoolP("skip-clone", "s", false, "Skip clone after remote fork")
+	forkCmd.Flags().BoolP("skip-clone", "s", false, "skip clone after remote fork")
 	RootCmd.AddCommand(forkCmd)
 }

--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -35,8 +35,8 @@ var issueCmd = &cobra.Command{
 }
 
 func init() {
-	issueCmd.Flags().BoolP("list", "l", false, "List issues on a remote")
-	issueCmd.Flags().BoolP("browse", "b", false, "View issue <id> in a browser")
-	issueCmd.Flags().StringP("close", "d", "", "Close issue <id> on remote")
+	issueCmd.Flags().BoolP("list", "l", false, "list issues on a remote")
+	issueCmd.Flags().BoolP("browse", "b", false, "view issue <id> in a browser")
+	issueCmd.Flags().StringP("close", "d", "", "close issue <id> on remote")
 	RootCmd.AddCommand(issueCmd)
 }

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -140,9 +140,9 @@ func issueText(templateName string) (string, error) {
 }
 
 func init() {
-	issueCreateCmd.Flags().StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
-	issueCreateCmd.Flags().StringSliceP("label", "l", []string{}, "Set the given label(s) on the created issue")
-	issueCreateCmd.Flags().StringSliceP("assignees", "a", []string{}, "Set assignees by username")
+	issueCreateCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	issueCreateCmd.Flags().StringSliceP("label", "l", []string{}, "set the given label(s) on the created issue")
+	issueCreateCmd.Flags().StringSliceP("assignees", "a", []string{}, "set assignees by username")
 	issueCreateCmd.Flags().StringP("template", "t", "default", "use the given issue template")
 	issueCreateCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -302,11 +302,11 @@ func same(a, b []string) bool {
 }
 
 func init() {
-	issueEditCmd.Flags().StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
-	issueEditCmd.Flags().StringSliceP("label", "l", []string{}, "Add the given label(s) to the issue")
-	issueEditCmd.Flags().StringSliceP("unlabel", "", []string{}, "Remove the given label(s) from the issue")
-	issueEditCmd.Flags().StringSliceP("assign", "a", []string{}, "Add an assignee by username")
-	issueEditCmd.Flags().StringSliceP("unassign", "", []string{}, "Remove an assignee by username")
+	issueEditCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	issueEditCmd.Flags().StringSliceP("label", "l", []string{}, "add the given label(s) to the issue")
+	issueEditCmd.Flags().StringSliceP("unlabel", "", []string{}, "remove the given label(s) from the issue")
+	issueEditCmd.Flags().StringSliceP("assign", "a", []string{}, "add an assignee by username")
+	issueEditCmd.Flags().StringSliceP("unassign", "", []string{}, "remove an assignee by username")
 	issueEditCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 
 	issueCmd.AddCommand(issueEditCmd)

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -69,16 +69,16 @@ func issueList(args []string) ([]*gitlab.Issue, error) {
 func init() {
 	issueListCmd.Flags().StringSliceVarP(
 		&issueLabels, "label", "l", []string{},
-		"Filter issues by label")
+		"filter issues by label")
 	issueListCmd.Flags().StringVarP(
 		&issueState, "state", "s", "opened",
-		"Filter issues by state (opened/closed)")
+		"filter issues by state (opened/closed)")
 	issueListCmd.Flags().IntVarP(
 		&issueNumRet, "number", "n", 10,
-		"Number of issues to return")
+		"number of issues to return")
 	issueListCmd.Flags().BoolVarP(
 		&issueAll, "all", "a", false,
-		"List all issues on the project")
+		"list all issues on the project")
 
 	issueCmd.AddCommand(issueListCmd)
 	carapace.Gen(issueListCmd).FlagCompletion(carapace.ActionMap{

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -252,10 +252,10 @@ func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, update bo
 }
 
 func init() {
-	issueNoteCmd.Flags().StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
-	issueNoteCmd.Flags().StringP("file", "F", "", "Use the given file as the message")
+	issueNoteCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	issueNoteCmd.Flags().StringP("file", "F", "", "use the given file as the message")
 	issueNoteCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
-	issueNoteCmd.Flags().Bool("quote", false, "Quote note in reply (used with --reply only)")
+	issueNoteCmd.Flags().Bool("quote", false, "quote note in reply (used with --reply only)")
 
 	issueCmd.AddCommand(issueNoteCmd)
 	carapace.Gen(issueNoteCmd).PositionalCompletion(

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -329,9 +329,9 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 }
 
 func init() {
-	issueShowCmd.Flags().BoolP("no-markdown", "M", false, "Don't use markdown renderer to print the issue description")
-	issueShowCmd.Flags().BoolP("comments", "c", false, "Show comments for the issue")
-	issueShowCmd.Flags().StringP("since", "s", "", "Show comments since specified date (format: 2020-08-21 14:57:46.808 +0000 UTC)")
+	issueShowCmd.Flags().BoolP("no-markdown", "M", false, "don't use markdown renderer to print the issue description")
+	issueShowCmd.Flags().BoolP("comments", "c", false, "show comments for the issue")
+	issueShowCmd.Flags().StringP("since", "s", "", "show comments since specified date (format: 2020-08-21 14:57:46.808 +0000 UTC)")
 	issueCmd.AddCommand(issueShowCmd)
 
 	carapace.Gen(issueShowCmd).PositionalCompletion(

--- a/cmd/mr.go
+++ b/cmd/mr.go
@@ -36,8 +36,8 @@ var mrCmd = &cobra.Command{
 }
 
 func init() {
-	mrCmd.Flags().BoolP("list", "l", false, "List merge requests on a remote")
-	mrCmd.Flags().BoolP("browse", "b", false, "View merge request <id> in a browser")
-	mrCmd.Flags().StringP("close", "d", "", "Close merge request <id> on remote")
+	mrCmd.Flags().BoolP("list", "l", false, "list merge requests on a remote")
+	mrCmd.Flags().BoolP("browse", "b", false, "view merge request <id> in a browser")
+	mrCmd.Flags().StringP("close", "d", "", "close merge request <id> on remote")
 	RootCmd.AddCommand(mrCmd)
 }

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -34,16 +34,16 @@ var mrCreateCmd = &cobra.Command{
 }
 
 func init() {
-	mrCreateCmd.Flags().StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
-	mrCreateCmd.Flags().StringSliceP("assignee", "a", []string{}, "Set assignee by username; can be specified multiple times for multiple assignees")
-	mrCreateCmd.Flags().StringSliceP("label", "l", []string{}, "Add label <label>; can be specified multiple times for multiple labels")
-	mrCreateCmd.Flags().BoolP("remove-source-branch", "d", false, "Remove source branch from remote after merge")
-	mrCreateCmd.Flags().BoolP("squash", "s", false, "Squash commits when merging")
-	mrCreateCmd.Flags().Bool("allow-collaboration", false, "Allow commits from other members")
-	mrCreateCmd.Flags().Int("milestone", -1, "Set milestone by milestone ID")
-	mrCreateCmd.Flags().StringP("file", "F", "", "Use the given file as the Description")
+	mrCreateCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	mrCreateCmd.Flags().StringSliceP("assignee", "a", []string{}, "set assignee by username; can be specified multiple times for multiple assignees")
+	mrCreateCmd.Flags().StringSliceP("label", "l", []string{}, "add label <label>; can be specified multiple times for multiple labels")
+	mrCreateCmd.Flags().BoolP("remove-source-branch", "d", false, "remove source branch from remote after merge")
+	mrCreateCmd.Flags().BoolP("squash", "s", false, "squash commits when merging")
+	mrCreateCmd.Flags().Bool("allow-collaboration", false, "allow commits from other members")
+	mrCreateCmd.Flags().Int("milestone", -1, "set milestone by milestone ID")
+	mrCreateCmd.Flags().StringP("file", "F", "", "use the given file as the Description")
 	mrCreateCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
-	mrCreateCmd.Flags().BoolP("cover-letter", "c", false, "Do not comment changelog and diffstat")
+	mrCreateCmd.Flags().BoolP("cover-letter", "c", false, "do not comment changelog and diffstat")
 	mergeRequestCmd.Flags().AddFlagSet(mrCreateCmd.Flags())
 
 	mrCmd.AddCommand(mrCreateCmd)

--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -112,8 +112,8 @@ func mrDiscussionText() (string, error) {
 }
 
 func init() {
-	mrCreateDiscussionCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
-	mrCreateDiscussionCmd.Flags().StringP("file", "F", "", "Use the given file as the message")
+	mrCreateDiscussionCmd.Flags().StringSliceP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	mrCreateDiscussionCmd.Flags().StringP("file", "F", "", "use the given file as the message")
 
 	mrCmd.AddCommand(mrCreateDiscussionCmd)
 	carapace.Gen(mrCreateDiscussionCmd).PositionalCompletion(

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -15,7 +15,7 @@ import (
 )
 
 var mrEditCmd = &cobra.Command{
-	Use:     "edit [remote] <id>[:<comment_id>",
+	Use:     "edit [remote] <id>[:<comment_id>]",
 	Aliases: []string{"update"},
 	Short:   "Edit or update an MR",
 	Long:    ``,
@@ -153,11 +153,11 @@ func mrGetCurrentAssignees(mr *gitlab.MergeRequest) []string {
 }
 
 func init() {
-	mrEditCmd.Flags().StringSliceP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
-	mrEditCmd.Flags().StringSliceP("label", "l", []string{}, "Add the given label(s) to the merge request")
-	mrEditCmd.Flags().StringSliceP("unlabel", "", []string{}, "Remove the given label(s) from the merge request")
-	mrEditCmd.Flags().StringSliceP("assign", "a", []string{}, "Add an assignee by username")
-	mrEditCmd.Flags().StringSliceP("unassign", "", []string{}, "Remove an assigne by username")
+	mrEditCmd.Flags().StringSliceP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	mrEditCmd.Flags().StringSliceP("label", "l", []string{}, "add the given label(s) to the merge request")
+	mrEditCmd.Flags().StringSliceP("unlabel", "", []string{}, "remove the given label(s) from the merge request")
+	mrEditCmd.Flags().StringSliceP("assign", "a", []string{}, "add an assignee by username")
+	mrEditCmd.Flags().StringSliceP("unassign", "", []string{}, "remove an assignee by username")
 	mrEditCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 
 	mrCmd.AddCommand(mrEditCmd)

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -92,10 +92,10 @@ func init() {
 	listCmd.Flags().StringVarP(
 		&mrTargetBranch, "target-branch", "t", "",
 		"filter merge requests by target branch")
-	listCmd.Flags().BoolVarP(&mrAll, "all", "a", false, "List all MRs on the project")
-	listCmd.Flags().BoolVarP(&mrMine, "mine", "m", false, "List only MRs assigned to me")
+	listCmd.Flags().BoolVarP(&mrAll, "all", "a", false, "list all MRs on the project")
+	listCmd.Flags().BoolVarP(&mrMine, "mine", "m", false, "list only MRs assigned to me")
 	listCmd.Flags().StringVar(
-		&mrAssignee, "assignee", "", "List only MRs assigned to $username")
+		&mrAssignee, "assignee", "", "list only MRs assigned to $username")
 
 	mrCmd.AddCommand(listCmd)
 	carapace.Gen(listCmd).FlagCompletion(carapace.ActionMap{

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -17,10 +17,10 @@ var mrNoteCmd = &cobra.Command{
 }
 
 func init() {
-	mrNoteCmd.Flags().StringArrayP("message", "m", []string{}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
-	mrNoteCmd.Flags().StringP("file", "F", "", "Use the given file as the message")
+	mrNoteCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	mrNoteCmd.Flags().StringP("file", "F", "", "use the given file as the message")
 	mrNoteCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
-	mrNoteCmd.Flags().Bool("quote", false, "Quote note in reply (used with --reply only)")
+	mrNoteCmd.Flags().Bool("quote", false, "quote note in reply (used with --reply only)")
 
 	mrCmd.AddCommand(mrNoteCmd)
 	carapace.Gen(mrNoteCmd).PositionalCompletion(

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -160,12 +160,12 @@ WebURL: %s
 }
 
 func init() {
-	mrShowCmd.Flags().BoolP("no-markdown", "M", false, "Don't use markdown renderer to print the issue description")
-	mrShowCmd.Flags().BoolP("comments", "c", false, "Show comments for the merge request")
-	mrShowCmd.Flags().StringP("since", "s", "", "Show comments since specified date (format: 2020-08-21 14:57:46.808 +0000 UTC)")
-	mrShowCmd.Flags().BoolVarP(&mrShowPatch, "patch", "p", false, "Show MR patches")
-	mrShowCmd.Flags().BoolVarP(&mrShowPatchReverse, "reverse", "", false, "Reverse order when showing MR patches (chronological instead of anti-chronological)")
-	mrShowCmd.Flags().BoolVarP(&mrShowNoColorDiff, "no-color-diff", "", false, "Show color diffs in comments")
+	mrShowCmd.Flags().BoolP("no-markdown", "M", false, "don't use markdown renderer to print the issue description")
+	mrShowCmd.Flags().BoolP("comments", "c", false, "show comments for the merge request")
+	mrShowCmd.Flags().StringP("since", "s", "", "show comments since specified date (format: 2020-08-21 14:57:46.808 +0000 UTC)")
+	mrShowCmd.Flags().BoolVarP(&mrShowPatch, "patch", "p", false, "show MR patches")
+	mrShowCmd.Flags().BoolVarP(&mrShowPatchReverse, "reverse", "", false, "reverse order when showing MR patches (chronological instead of anti-chronological)")
+	mrShowCmd.Flags().BoolVarP(&mrShowNoColorDiff, "no-color-diff", "", false, "show color diffs in comments")
 	mrCmd.AddCommand(mrShowCmd)
 	carapace.Gen(mrShowCmd).PositionalCompletion(
 		action.Remotes(),

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -96,8 +96,8 @@ func determinePath(args []string, name string) string {
 func init() {
 	projectCreateCmd.Flags().StringP("name", "n", "", "name of the new project")
 	projectCreateCmd.Flags().StringP("description", "d", "", "description of the new project")
-	projectCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "Make project private: visible only to project members")
-	projectCreateCmd.Flags().BoolVar(&public, "public", false, "Make project public: visible without any authentication")
-	projectCreateCmd.Flags().BoolVar(&internal, "internal", false, "Make project internal: visible to any authenticated user (default)")
+	projectCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "make project private: visible only to project members")
+	projectCreateCmd.Flags().BoolVar(&public, "public", false, "make project public: visible without any authentication")
+	projectCreateCmd.Flags().BoolVar(&internal, "internal", false, "make project internal: visible to any authenticated user (default)")
 	projectCmd.AddCommand(projectCreateCmd)
 }

--- a/cmd/project_list.go
+++ b/cmd/project_list.go
@@ -56,9 +56,9 @@ var projectListCmd = &cobra.Command{
 
 func init() {
 	projectCmd.AddCommand(projectListCmd)
-	projectListCmd.Flags().BoolVarP(&projectListConfig.All, "all", "a", false, "List all projects on the instance")
+	projectListCmd.Flags().BoolVarP(&projectListConfig.All, "all", "a", false, "list all projects on the instance")
 	projectListCmd.Flags().BoolVarP(&projectListConfig.Owned, "mine", "m", false, "limit by your projects")
 	projectListCmd.Flags().BoolVar(&projectListConfig.Membership, "member", false, "limit by projects which you are a member")
 	projectListCmd.Flags().BoolVar(&projectListConfig.Starred, "starred", false, "limit by your starred projects")
-	projectListCmd.Flags().IntVarP(&projectListConfig.Number, "number", "n", 100, "Number of projects to return")
+	projectListCmd.Flags().IntVarP(&projectListConfig.Number, "number", "n", 100, "number of projects to return")
 }

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -169,10 +169,10 @@ func snipText(tmpl string) (string, error) {
 }
 
 func init() {
-	snippetCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "Make snippet private; visible only to project members (default: internal)")
-	snippetCreateCmd.Flags().BoolVar(&public, "public", false, "Make snippet public; can be accessed without any authentication (default: internal)")
-	snippetCreateCmd.Flags().StringVarP(&name, "name", "n", "", "(optional) Name snippet to add code highlighting, e.g. potato.go for GoLang")
-	snippetCreateCmd.Flags().StringArrayP("message", "m", []string{"-"}, "Use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	snippetCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "make snippet private; visible only to project members (default: internal)")
+	snippetCreateCmd.Flags().BoolVar(&public, "public", false, "make snippet public; can be accessed without any authentication (default: internal)")
+	snippetCreateCmd.Flags().StringVarP(&name, "name", "n", "", "(optional) name snippet to add code highlighting, e.g. potato.go for GoLang")
+	snippetCreateCmd.Flags().StringArrayP("message", "m", []string{"-"}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	snippetCmd.Flags().AddFlagSet(snippetCreateCmd.Flags())
 
 	snippetCmd.AddCommand(snippetCreateCmd)

--- a/cmd/snippet_list.go
+++ b/cmd/snippet_list.go
@@ -63,8 +63,8 @@ func snippetList(args []string) ([]*gitlab.Snippet, error) {
 }
 
 func init() {
-	snippetListCmd.Flags().IntVarP(&snippetListConfig.Number, "number", "n", 10, "Number of snippets to return")
-	snippetListCmd.Flags().BoolVarP(&snippetListConfig.All, "all", "a", false, "List all snippets")
+	snippetListCmd.Flags().IntVarP(&snippetListConfig.Number, "number", "n", 10, "number of snippets to return")
+	snippetListCmd.Flags().BoolVarP(&snippetListConfig.All, "all", "a", false, "list all snippets")
 
 	snippetCmd.AddCommand(snippetListCmd)
 	carapace.Gen(snippetListCmd).PositionalCompletion(


### PR DESCRIPTION
Fix up some typos and capitalization issues in the help output.

There is no functional change in this commit.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>