### PR TITLE
mr_list_test: Fix Test_mrListByTargetBranch

### DIFF
--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -135,5 +135,5 @@ func Test_mrListByTargetBranch(t *testing.T) {
 	}
 
 	mrs := strings.Split(string(b), "\n")
-	require.Equal(t, "#1 Test MR for lab list", mrs[1])
+	require.Equal(t, "#1 Test MR for lab list", mrs[0])
 }


### PR DESCRIPTION
The Test_mrListByTargetBranch is failing with

--- FAIL: Test_mrListByTargetBranch (0.97s)
    mr_list_test.go:138:
        	Error Trace:	mr_list_test.go:138
        	Error:      	Not equal:
        	            	expected: "#1 Test MR for lab list"
        	            	actual  : "#6 test award emoji"

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-#1 Test MR for lab list
        	            	+#6 test award emoji
        	Test:       	Test_mrListByTargetBranch

because test MR #6 was modified and now has an 'updated_at' date newer
than #1.

Change the Test_mrListByTargetBranch test so that it correctly detects #1
again.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>