### PR TITLE
discussion: Drop 'comment' alias

### DIFF
--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -20,7 +20,6 @@ import (
 
 var mrCreateDiscussionCmd = &cobra.Command{
 	Use:              "discussion [remote] <id>",
-	Aliases:          []string{"comment"},
 	Short:            "Start a discussion on an MR on GitLab",
 	Long:             ``,
 	Args:             cobra.MinimumNArgs(1),


### PR DESCRIPTION
lab commit fd4bc293d29c ("Add mr discussion creation") added a 'comment'
alias for the discussion command.  This alias was already in use by
the note command and should not be used.

Drop the 'comment' alias from the 'mr discussion; command.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>