### PR TITLE
mr_note: Fix error with contextual command

### DIFF
--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -11,7 +11,6 @@ var mrNoteCmd = &cobra.Command{
 	Aliases:          []string{"comment", "reply"},
 	Short:            "Add a note or comment to an MR on GitLab",
 	Long:             ``,
-	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run:              NoteRunFn,
 }


### PR DESCRIPTION
Executing

	lab mr checkout <mr_id>
	lab mr comment

results in the incorrect error

	"Error: requires at least 1 arg(s), only received 0"

Remove the requirement for a single argument to be provided by the
'mr note' command.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>