### PR TITLE
mr note: Provide more information in comment message

### DIFF
--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -101,7 +101,22 @@ func createNote(rn string, isMR bool, idNum int, msgs []string, filename string,
 		}
 		body = string(content)
 	} else {
-		body, err = noteMsg(msgs, isMR, "\n")
+		if isMR {
+			mr, err := lab.MRGet(rn, idNum)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			state := map[string]string{
+				"opened": "OPEN",
+				"closed": "CLOSED",
+				"merged": "MERGED",
+			}[mr.State]
+
+			body = fmt.Sprintf("\n# This comment is being applied to %s Merge Request %d.", state, idNum)
+		}
+
+		body, err = noteMsg(msgs, isMR, body)
 		if err != nil {
 			_, f, l, _ := runtime.Caller(0)
 			log.Fatal(f+":"+strconv.Itoa(l)+" ", err)


### PR DESCRIPTION
lab commit bd1c969eed38 ("mr: Migrate commands to use MR mapping code")
introduced MR context commands to lab, removing the need to enter in an
Merge Request ID if the command was being executed on a tracked branch.
After this code was introduced it is easy for a user to inadvertently
write to the wrong MR using, for example, 'lab mr note'.

It is simple to provide additional context in the editor, for example,

	"This comment is being applied to OPEN Merge Request 52"

to avoid any confusion.

Update the default note editor message to output the status and MR number
being commented on.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>