### PR TITLE
Use official `lab` Homebrew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Dependencies
 
 ### Homebrew
 ```
-brew install zaquestion/tap/lab
+brew install lab
 ```
 
 ### NixOS


### PR DESCRIPTION
This PR updates readme in response to the recent introduction of the `lab` formula to default Homebrew formulae. 🎉 

Checks one of the items listed in https://github.com/zaquestion/lab/issues/406#issue-686955945
> This issue aims to capture the immediate todos to get `lab` fully re-homed functionally speaking. (no particular order)
> 
> * [ ]  Replace Travis CI with GitLab CI
>   * [ ]  Update `.goreleaser` to upload artifacts as GitLab release artifacts
>   * [x]  **Update homebrew tap home? Submit formula to homebrew core?**
