### PR TITLE
lab: Add 'mr unapprove' command

### DIFF
--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var mrUnapproveCmd = &cobra.Command{
+	Use:              "unapprove [remote] <id>",
+	Aliases:          []string{},
+	Short:            "Unapprove merge request",
+	Long:             ``,
+	Args:             cobra.MinimumNArgs(1),
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, id, err := parseArgsWithGitBranchMR(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		p, err := lab.FindProject(rn)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = lab.MRUnapprove(p.ID, int(id))
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Merge Request #%d Unapproved\n", id)
+	},
+}
+
+func init() {
+	mrCmd.AddCommand(mrUnapproveCmd)
+	carapace.Gen(mrUnapproveCmd).PositionalCompletion(
+		action.Remotes(),
+		action.MergeRequests(mrList),
+	)
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -412,6 +412,15 @@ func MRApprove(pid interface{}, id int) error {
 	return nil
 }
 
+// MRUnapprove Unapproves a previously approved mr on a GitLab project
+func MRUnapprove(pid interface{}, id int) error {
+	_, err := lab.MergeRequestApprovals.UnapproveMergeRequest(pid, id, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // MRThumbUp places a thumb up/down on a merge request
 func MRThumbUp(pid interface{}, id int) error {
 	_, _, err := lab.AwardEmoji.CreateMergeRequestAwardEmoji(pid, id, &gitlab.CreateAwardEmojiOptions{


### PR DESCRIPTION
lab has functionality to approve an MR, but not remove the approval if the
reviewer has changed their mind.

Add 'mr unapprove'.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>