### PR TITLE
edit: ignore empty argument

### DIFF
--- a/internal/git/edit.go
+++ b/internal/git/edit.go
@@ -83,8 +83,12 @@ func editorCMD(editorPath, filePath string) *exec.Cmd {
 		args = append(args, "--cmd", "set ft=gitcommit tw=0 wrap lbr")
 	}
 	argparts := strings.Join(parts[1:], " ")
-	argparts = strings.Replace(argparts, "'", "\"", -1)
-	args = append(args, argparts, filePath)
+	if len(argparts) == 0 {
+		args = append(args, filePath)
+	} else {
+		argparts = strings.Replace(argparts, "'", "\"", -1)
+		args = append(args, argparts, filePath)
+	}
 	cmd := exec.Command(parts[0], args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Golang exec.Command() considers empty args as valid/normal arguments to be
passed to the program to operate against.  In the case of a text editor an
empty filepath may causes different actions depending on the one the user
uses, for example: (1) a "new buffer" (nano) or (2) the current path (vim)
are opened for edit.

With that, when the user call "lab mr create" without specifying a file (-F)
the text editor open two files for edit: the "empty file" (triggering an
undefined behavior) and the actual ISSUE_NOTE/MR_NOTE/MERGEREQ.  This patch
adds a conditional to ignore the args passed to the text editor in case it's
empty, avoiding such behavior.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>