### PR TITLE
couple changes to help cmd to improve user experience

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,8 +64,7 @@ func helpFunc(cmd *cobra.Command, args []string) {
 	}
 	rootCmd := cmd.Root()
 	// Show help for sub/commands -- any commands that isn't "lab" or "help"
-	if cmd, _, err := rootCmd.Find(args); err == nil &&
-		cmd != rootCmd && strings.Split(cmd.Use, " ")[0] != "help" {
+	if cmd, _, err := rootCmd.Find(args); err == nil {
 		// Cobra will check parent commands for a helpFunc and we only
 		// want the root command to actually use this custom help func.
 		// Here we trick cobra into thinking that there is no help func

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -109,54 +109,30 @@ Date:   Sun Apr 1 19:40:47 2018 -0700
 
 func TestRootNoArg(t *testing.T) {
 	cmd := exec.Command(labBinaryPath)
-	b, _ := cmd.CombinedOutput()
-	assert.Contains(t, string(b), "usage: git [--version] [--help] [-C <path>]")
-	assert.Contains(t, string(b), `These GitLab commands are provided by lab:
-
-  ci            Work with GitLab CI pipelines and jobs`)
-}
-
-func TestGitHelp(t *testing.T) {
-	cmd := exec.Command(labBinaryPath)
 	b, err := cmd.CombinedOutput()
 	if err != nil {
+		t.Log(string(b))
 		t.Fatal(err)
 	}
-	expected := string(b)
-	expected = expected[:strings.LastIndex(strings.TrimSpace(expected), "\n")]
+	assert.Contains(t, string(b), `A Git Wrapper for GitLab
 
-	tests := []struct {
-		desc string
-		Cmds []string
-	}{
-		{
-			desc: "help arg",
-			Cmds: []string{"help"},
-		},
-		{
-			desc: "no arg",
-			Cmds: []string{},
-		},
+Usage:
+  lab [flags]
+  lab [command]`)
+}
+
+func TestRootHelp(t *testing.T) {
+	cmd := exec.Command(labBinaryPath, "help")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
 	}
+	res := string(b)
+	assert.Contains(t, res, `Show the help for lab
 
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
-			cmd := exec.Command(labBinaryPath)
-			if len(test.Cmds) >= 1 {
-				cmd = exec.Command(labBinaryPath, test.Cmds...)
-			}
-			b, _ := cmd.CombinedOutput()
-			res := string(b)
-			res = res[:strings.LastIndex(strings.TrimSpace(res), "\n")]
-			t.Log(expected)
-			t.Log(res)
-			assert.Equal(t, expected, res)
-			assert.Contains(t, res, "usage: git [--version] [--help] [-C <path>]")
-			assert.Contains(t, res, `These GitLab commands are provided by lab:
-
-  ci            Work with GitLab CI pipelines and jobs`)
-		})
-	}
+Usage:
+  lab help [command [subcommand...]] [flags]`)
 }
 
 type fatalLogger interface {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"bytes"
-	"fmt"
-	"io"
 	"log"
 	"math/rand"
 	"os"
@@ -117,31 +114,6 @@ func TestRootNoArg(t *testing.T) {
 	assert.Contains(t, string(b), `These GitLab commands are provided by lab:
 
   ci            Work with GitLab CI pipelines and jobs`)
-}
-
-func TestRootVersion(t *testing.T) {
-	old := os.Stdout // keep backup of the real stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	RootCmd.Flag("version").Value.Set("true")
-	RootCmd.Run(RootCmd, nil)
-
-	outC := make(chan string)
-	// copy the output in a separate goroutine so printing can't block indefinitely
-	go func() {
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		outC <- buf.String()
-	}()
-
-	// back to normal state
-	w.Close()
-	os.Stdout = old // restoring the real stdout
-	out := <-outC
-
-	assert.Contains(t, out, "git version")
-	assert.Contains(t, out, fmt.Sprintf("lab version %s", Version))
 }
 
 func TestGitHelp(t *testing.T) {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,10 +12,9 @@ var Version string
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
-	Use:              "version",
-	Short:            "",
-	Long:             ``,
-	PersistentPreRun: LabPersistentPreRun,
+	Use:   "version",
+	Short: "",
+	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		git := git.New("version")
 		git.Stdout = nil

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zaquestion/lab/internal/git"
+)
+
+// Make sure the version command don't break things in the future
+func Test_versionCmd(t *testing.T) {
+	git_cmd := git.New("version")
+	git_cmd.Stdout = nil
+	out, err := git_cmd.Output()
+	if err != nil {
+		t.Log(string(out))
+		t.Fatal(err)
+	}
+	git_ver := strings.TrimSpace(string(out))
+
+	t.Run("version", func(t *testing.T) {
+		lab_cmd := exec.Command(labBinaryPath, "version")
+		out, err := lab_cmd.CombinedOutput()
+		if err != nil {
+			t.Log(string(out))
+			t.Fatal(err)
+		}
+		combined_ver := string(out)
+		progs_ver := strings.Split(combined_ver, "\n")
+
+		assert.Contains(t, progs_ver[0], git_ver)
+		assert.Contains(t, progs_ver[1], "lab version "+Version)
+	})
+	t.Run("--version", func(t *testing.T) {
+		old := os.Stdout // keep backup of the real stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		RootCmd.Flag("version").Value.Set("true")
+		RootCmd.Run(RootCmd, nil)
+
+		outC := make(chan string)
+		// copy the output in a separate goroutine so printing can't block indefinitely
+		go func() {
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			outC <- buf.String()
+		}()
+
+		// back to normal state
+		w.Close()
+		os.Stdout = old // restoring the real stdout
+		out := <-outC
+
+		assert.Contains(t, out, git_ver)
+		assert.Contains(t, out, "lab version "+Version)
+	})
+}


### PR DESCRIPTION
Change some pieces of "help" documenation:
* `lab --help` and `lab help` don't prompts `git-help` output anymore.
* `lab version` doesn't sigfaults anymore: solved by removing the "PreRun" callback.

Solves issue #480 .