### PR TITLE
config: check mandatory config opts before moving on

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -309,8 +309,16 @@ func LoadMainConfig() (string, string, string, string, bool) {
 		}
 	}
 
-	host = MainConfig.GetString("core.host")
-	token = GetToken()
+	if !MainConfig.IsSet("core.host") {
+		host = defaultGitLabHost
+	} else {
+		host = MainConfig.GetString("core.host")
+	}
+
+	if token = GetToken(); token == "" {
+		UserConfigError()
+	}
+
 	caFile := MainConfig.GetString("tls.ca_file")
 	tlsSkipVerify := MainConfig.GetBool("tls.skip_verify")
 	user = getUser(host, token, tlsSkipVerify)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,9 +25,8 @@ import (
 
 const defaultGitLabHost = "https://gitlab.com"
 
-var (
-	MainConfig *viper.Viper
-)
+// MainConfig represents the loaded config
+var MainConfig *viper.Viper
 
 // New prompts the user for the default config values to use with lab, and save
 // them to the provided confpath (default: ~/.config/lab.hcl)
@@ -126,7 +125,7 @@ func CI() (string, string, string) {
 	return ciHost, ciUser, ciToken
 }
 
-// ConvertHCLtoTOML() converts an .hcl file to a .toml file
+// ConvertHCLtoTOML converts an .hcl file to a .toml file
 func ConvertHCLtoTOML(oldpath string, newpath string, file string) {
 	oldconfig := oldpath + "/" + file + ".hcl"
 	newconfig := newpath + "/" + file + ".toml"
@@ -363,6 +362,7 @@ func WriteConfigEntry(desc string, value interface{}, configpath string, confign
 	targetConfig.WriteConfig()
 }
 
+// UserConfigError returns a default error message about authentication
 func UserConfigError() {
 	fmt.Println("Error: User authentication failed.  This is likely due to a misconfigured Personal Access Token.  Verify the token or token_load config settings before attemping to authenticate.")
 	os.Exit(1)


### PR DESCRIPTION
It seems to be a good idea to first check the mandatory config opts before leaving/returning from `LoadMainConfig`, avoiding strange error messages as `lab` tries to perform actions with empty opts.