### PR TITLE
issue note: Provide more information in comment message

### DIFF
--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -114,6 +114,18 @@ func createNote(rn string, isMR bool, idNum int, msgs []string, filename string,
 			}[mr.State]
 
 			body = fmt.Sprintf("\n# This comment is being applied to %s Merge Request %d.", state, idNum)
+		} else {
+			issue, err := lab.IssueGet(rn, idNum)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			state := map[string]string{
+				"opened": "OPEN",
+				"closed": "CLOSED",
+			}[issue.State]
+
+			body = fmt.Sprintf("\n# This comment is being applied to %s Issue %d.", state, idNum)
 		}
 
 		body, err = noteMsg(msgs, isMR, body)


### PR DESCRIPTION
lab commit f64a2421023a ("mr note: Provide more information in comment message")
added additional context about Merge Requests in the editor.  The same can
be done for Issues, for example,

	"This comment is being applied to CLOSED Issue 3."

Update the default note editor message to output the status and Issue number
being commented on.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>