### PR TITLE
config: home dir is only useful if XDG_CONFIG_HOME isn't set

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -251,12 +251,12 @@ func LoadMainConfig() (string, string, string, string, bool) {
 
 	// Try to find XDG_CONFIG_HOME which is declared in XDG base directory
 	// specification and use it's location as the config directory
-	home, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatal(err)
-	}
 	confpath := os.Getenv("XDG_CONFIG_HOME")
 	if confpath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatal(err)
+		}
 		confpath = path.Join(home, ".config")
 	}
 	labconfpath := confpath + "/lab"


### PR DESCRIPTION
Instead of setting the 'home' var early, only set it in case XDG_CONFIG_HOME
isn't set. 'home' var is only useful for composing the config path, nothing
else.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>