### PR TITLE
Enable HTTP protocol for different commands

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -32,7 +32,7 @@ var cloneCmd = &cobra.Command{
 		} else if err != nil {
 			log.Fatal(err)
 		}
-		path := project.SSHURLToRepo
+		path := labURLToRepo(project)
 		// #116 retry on the cases where we found a project but clone
 		// failed over ssh
 		err = retry.Do(func() error {
@@ -57,7 +57,8 @@ var cloneCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
-			err = git.RemoteAdd("upstream", ffProject.SSHURLToRepo, "./"+dir)
+			urlToRepo := labURLToRepo(ffProject)
+			err = git.RemoteAdd("upstream", urlToRepo, "./"+dir)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -66,5 +67,7 @@ var cloneCmd = &cobra.Command{
 }
 
 func init() {
+	// useHTTP is defined in "project_create.go"
+	cloneCmd.Flags().BoolVar(&useHTTP, "http", false, "clone using HTTP protocol instead of SSH")
 	RootCmd.AddCommand(cloneCmd)
 }

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -54,7 +54,7 @@ func forkFromOrigin(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	forkRemoteURL, err := lab.Fork(project)
+	forkRemoteURL, err := lab.Fork(project, useHTTP)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -66,7 +66,9 @@ func forkFromOrigin(cmd *cobra.Command, args []string) {
 	}
 }
 func forkToUpstream(cmd *cobra.Command, args []string) {
-	_, err := lab.Fork(args[0])
+	// lab.Fork doesn't have access to the useHTTP var, so we need to pass
+	// this info to that, so the process works correctly.
+	_, err := lab.Fork(args[0], useHTTP)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -90,5 +92,7 @@ func determineForkRemote(project string) string {
 
 func init() {
 	forkCmd.Flags().BoolP("skip-clone", "s", false, "skip clone after remote fork")
+	// useHTTP is defined in "project_create.go"
+	forkCmd.Flags().BoolVar(&useHTTP, "http", false, "fork using HTTP protocol instead of SSH")
 	RootCmd.AddCommand(forkCmd)
 }

--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -71,7 +71,8 @@ var checkoutCmd = &cobra.Command{
 				if err != nil {
 					log.Fatal(err)
 				}
-				if err := git.RemoteAdd(mr.Author.Username, mrProject.SSHURLToRepo, "."); err != nil {
+				urlToRepo := labURLToRepo(mrProject)
+				if err := git.RemoteAdd(mr.Author.Username, urlToRepo, "."); err != nil {
 					log.Fatal(err)
 				}
 			}
@@ -108,6 +109,8 @@ var checkoutCmd = &cobra.Command{
 func init() {
 	checkoutCmd.Flags().StringVarP(&mrCheckoutCfg.branch, "branch", "b", "", "checkout merge request with <branch> name")
 	checkoutCmd.Flags().BoolVarP(&mrCheckoutCfg.track, "track", "t", false, "set checked out branch to track mr author remote branch, adds remote if needed")
+	// useHTTP is defined in "project_create.go"
+	checkoutCmd.Flags().BoolVar(&useHTTP, "http", false, "checkout using HTTP protocol instead of SSH")
 	mrCmd.AddCommand(checkoutCmd)
 	carapace.Gen(checkoutCmd).PositionalCompletion(
 		carapace.ActionCallback(func(args []string) carapace.Action {

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -99,7 +99,8 @@ func findLocalRemote(ProjectID int) string {
 	for r := range remotes {
 		// The fetch and push entries can be different for a remote.
 		// Only the fetch entry is useful.
-		if strings.Contains(remotes[r], project.SSHURLToRepo+" (fetch)") {
+		if strings.Contains(remotes[r], project.SSHURLToRepo+" (fetch)") ||
+			strings.Contains(remotes[r], project.HTTPURLToRepo+" (fetch)") {
 			found := strings.Split(remotes[r], "\t")
 			remote = found[0]
 			break
@@ -107,7 +108,7 @@ func findLocalRemote(ProjectID int) string {
 	}
 
 	if remote == "" {
-		log.Fatal("remote for ", project.SSHURLToRepo, "not found in local remotes")
+		log.Fatal("remote for ", project.NameWithNamespace, "not found in local remotes")
 	}
 	return remote
 }

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -11,8 +11,11 @@ import (
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
-// private and public are defined in snippet_create.go
-var internal bool
+var (
+	// private and public are defined in snippet_create.go
+	internal bool
+	useHTTP  bool
+)
 
 // projectCreateCmd represents the create command
 var projectCreateCmd = &cobra.Command{
@@ -68,7 +71,8 @@ lab project create -n "new proj"           # user/new-proj named "new proj"`,
 			log.Fatal(err)
 		}
 		if git.InsideGitRepo() {
-			err = git.RemoteAdd("origin", p.SSHURLToRepo, ".")
+			urlToRepo := labURLToRepo(p)
+			err = git.RemoteAdd("origin", urlToRepo, ".")
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -99,5 +103,6 @@ func init() {
 	projectCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "make project private: visible only to project members")
 	projectCreateCmd.Flags().BoolVar(&public, "public", false, "make project public: visible without any authentication")
 	projectCreateCmd.Flags().BoolVar(&internal, "internal", false, "make project internal: visible to any authenticated user (default)")
+	projectCreateCmd.Flags().BoolVar(&useHTTP, "http", false, "use HTTP protocol instead of SSH")
 	projectCmd.AddCommand(projectCreateCmd)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -239,3 +239,13 @@ func textToMarkdown(text string) string {
 func LabPersistentPreRun(cmd *cobra.Command, args []string) {
 	flagConfig(cmd.Flags())
 }
+
+// labURLToRepo returns the string representing the URL to a certain repo based
+// on the protocol used
+func labURLToRepo(project *gitlab.Project) string {
+	urlToRepo := project.SSHURLToRepo
+	if useHTTP {
+		urlToRepo = project.HTTPURLToRepo
+	}
+	return urlToRepo
+}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	gitlab "github.com/xanzy/go-gitlab"
 )
 
 func Test_textToMarkdown(t *testing.T) {
@@ -272,4 +273,20 @@ func Test_parseArgsRemoteAndProject(t *testing.T) {
 			assert.Equal(t, test.ExpectedString, s)
 		})
 	}
+}
+
+func Test_labURLToRepo(t *testing.T) {
+	HTTPURL := "https://test"
+	SSHURL := "ssh://test"
+	project := gitlab.Project{
+		HTTPURLToRepo: HTTPURL,
+		SSHURLToRepo:  SSHURL,
+	}
+
+	urlToRepo := labURLToRepo(&project)
+	assert.Equal(t, urlToRepo, SSHURL)
+
+	useHTTP = true
+	urlToRepo = labURLToRepo(&project)
+	assert.Equal(t, urlToRepo, HTTPURL)
 }

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -210,8 +210,8 @@ func FindProject(project string) (*gitlab.Project, error) {
 	return target, nil
 }
 
-// Fork creates a user fork of a GitLab project
-func Fork(project string) (string, error) {
+// Fork creates a user fork of a GitLab project using the specified protocol
+func Fork(project string, useHTTP bool) (string, error) {
 	if !strings.Contains(project, "/") {
 		return "", errors.New("remote must include namespace")
 	}
@@ -220,7 +220,11 @@ func Fork(project string) (string, error) {
 	// See if a fork already exists
 	target, err := FindProject(parts[1])
 	if err == nil {
-		return target.HTTPURLToRepo, nil
+		urlToRepo := target.SSHURLToRepo
+		if useHTTP {
+			urlToRepo = target.HTTPURLToRepo
+		}
+		return urlToRepo, nil
 	} else if err != nil && err != ErrProjectNotFound {
 		return "", err
 	}
@@ -234,8 +238,11 @@ func Fork(project string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	return fork.HTTPURLToRepo, nil
+	urlToRepo := fork.SSHURLToRepo
+	if useHTTP {
+		urlToRepo = fork.HTTPURLToRepo
+	}
+	return urlToRepo, nil
 }
 
 // MRCreate opens a merge request on GitLab

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -220,7 +220,7 @@ func Fork(project string) (string, error) {
 	// See if a fork already exists
 	target, err := FindProject(parts[1])
 	if err == nil {
-		return target.SSHURLToRepo, nil
+		return target.HTTPURLToRepo, nil
 	} else if err != nil && err != ErrProjectNotFound {
 		return "", err
 	}
@@ -235,7 +235,7 @@ func Fork(project string) (string, error) {
 		return "", err
 	}
 
-	return fork.SSHURLToRepo, nil
+	return fork.HTTPURLToRepo, nil
 }
 
 // MRCreate opens a merge request on GitLab


### PR DESCRIPTION
This MR bring the patch created by @eedgar in MR #477, which turns HTTP protocol as the default for forking a repo.
However, it turns SSH off and let other places that relies on the protocol format without changes.
The additional patch(es) make HTTP possible through a command flag (`--http`), letting SSH still as the default.
But now, the user can `lab fork --http`, `lab clone --http`, and others, to use the HTTP URL scheme instead of the SSH.
Quick note for reviewers: the GitLab API token for HTTP need to have both `{read,write}_repository` capabilities set since they're the ones allowing GIT-over-HTTP trafic.
