### PR TITLE
lab: Move issues from one project to another

### DIFF
--- a/cmd/issue_move.go
+++ b/cmd/issue_move.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var issueMoveCmd = &cobra.Command{
+	Use:              "move <id> <destination>",
+	Short:            "Move issue to another project",
+	Long:             ``,
+	Example:          "lab issue move 5 zaquestion/test/           # FQDN must match",
+	Args:             cobra.MinimumNArgs(2),
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		// get this rn
+		srcRN, err := getRemoteName(forkedFromRemote)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// get the issue ID
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// get the dest rn (everything after gitlab.com/, for example,
+		destRN := args[1]
+
+		issueURL, err := lab.MoveIssue(srcRN, id, destRN)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Issue moved to:", issueURL)
+	},
+}
+
+func init() {
+	issueCmd.AddCommand(issueMoveCmd)
+	carapace.Gen(issueMoveCmd).PositionalCompletion(
+		action.Remotes(),
+		action.Issues(issueList),
+	)
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -156,19 +156,28 @@ func parseArgsRemoteAndProject(args []string) (string, string, error) {
 		remote, str = args[0], args[1]
 	}
 
-	ok, err := git.IsRemote(remote)
-	if err != nil {
-		return "", "", err
-	}
-	if !ok {
-		return "", "", errors.Errorf("%s is not a valid remote", remote)
-	}
-
-	remote, err = git.PathWithNameSpace(remote)
+	remote, err := getRemoteName(remote)
 	if err != nil {
 		return "", "", err
 	}
 	return remote, str, nil
+}
+
+func getRemoteName(remote string) (string, error) {
+	ok, err := git.IsRemote(remote)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", errors.Errorf("%s is not a valid remote", remote)
+	}
+
+	remote, err = git.PathWithNameSpace(remote)
+	if err != nil {
+		return "", err
+	}
+
+	return remote, nil
 }
 
 // parseArgsStringAndID is used by commands to parse command line arguments.

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1059,3 +1059,25 @@ func ListIssuesClosedOnMerge(project string, mrNum int) ([]int, error) {
 	return retArray, nil
 
 }
+
+func MoveIssue(project string, issueNum int, dest string) (string, error) {
+	srcProject, err := FindProject(project)
+	if err != nil {
+		return "", err
+	}
+
+	destProject, err := FindProject(dest)
+	if err != nil {
+		return "", err
+	}
+
+	opts := &gitlab.MoveIssueOptions{
+		ToProjectID: &destProject.ID,
+	}
+
+	issue, _, err := lab.Issues.MoveIssue(srcProject.ID, issueNum, opts)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/issues/%d", destProject.WebURL, issue.IID), nil
+}


### PR DESCRIPTION
In large projects with groups, and extended namespaces, issues
occasionally get filed in the wrong project.  GitLab's API provides
functionality to move an issue from one project to another.

Add 'lab issue move <new_project>'.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>