### PR TITLE
Approve and Unapprove with comment

### DIFF
--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -28,6 +28,29 @@ var mrApproveCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		comment, err := cmd.Flags().GetBool("with-comment")
+		if err != nil {
+			log.Fatal(err)
+		}
+		if comment {
+			msgs, err := cmd.Flags().GetStringArray("message")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			filename, err := cmd.Flags().GetString("file")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			linebreak, err := cmd.Flags().GetBool("force-linebreak")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			createNote(rn, true, int(id), msgs, filename, linebreak)
+		}
+
 		err = lab.MRApprove(p.ID, int(id))
 		if err != nil {
 			log.Fatal(err)
@@ -37,6 +60,10 @@ var mrApproveCmd = &cobra.Command{
 }
 
 func init() {
+	mrApproveCmd.Flags().Bool("with-comment", false, "Add a comment with the approval")
+	mrApproveCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs (used with --with-comment only)")
+	mrApproveCmd.Flags().StringP("file", "F", "", "use the given file as the message (used with --with-comment only)")
+	mrApproveCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks (used with --with-comment only)")
 	mrCmd.AddCommand(mrApproveCmd)
 	carapace.Gen(mrApproveCmd).PositionalCompletion(
 		action.Remotes(),

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -76,6 +76,37 @@ func Test_mrCmd(t *testing.T) {
 		require.Contains(t, outStripped, "mr description")
 		require.Contains(t, out, fmt.Sprintf("WebURL: https://gitlab.com/lab-testing/test/-/merge_requests/%s", mrID))
 	})
+	// Users cannot approve and unapprove their own MRs.  Comment out
+	// these tests for now until a better solution can be found.
+	//
+	//t.Run("approve", func(t *testing.T) {
+	//	if mrID == "" {
+	//		t.Skip("mrID is empty, create likely failed")
+	//	}
+	//	cmd := exec.Command(labBinaryPath, "mr", "lab-testing", "approve", mrID)
+	//	cmd.Dir = repo
+	//
+	//	//b, err := cmd.CombinedOutput()
+	//	if err != nil {
+	//		t.Log(string(b))
+	//		t.Fatal(err)
+	//	}
+	//	require.Contains(t, string(b), fmt.Sprintf("Merge Request #%s approved", mrID))
+	//})
+	//t.Run("unapprove", func(t *testing.T) {
+	//	if mrID == "" {
+	//		t.Skip("mrID is empty, create likely failed")
+	//	}
+	//	cmd := exec.Command(labBinaryPath, "mr", "lab-testing", "unapprove", mrID)
+	//	cmd.Dir = repo
+	//
+	//	b, err := cmd.CombinedOutput()
+	//	if err != nil {
+	//		t.Log(string(b))
+	//		t.Fatal(err)
+	//	}
+	//	require.Contains(t, string(b), fmt.Sprintf("Merge Request #%s unapproved", mrID))
+	//})
 	t.Run("delete", func(t *testing.T) {
 		if mrID == "" {
 			t.Skip("mrID is empty, create likely failed")

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -28,6 +28,29 @@ var mrUnapproveCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		comment, err := cmd.Flags().GetBool("with-comment")
+		if err != nil {
+			log.Fatal(err)
+		}
+		if comment {
+			msgs, err := cmd.Flags().GetStringArray("message")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			filename, err := cmd.Flags().GetString("file")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			linebreak, err := cmd.Flags().GetBool("force-linebreak")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			createNote(rn, true, int(id), msgs, filename, linebreak)
+		}
+
 		err = lab.MRUnapprove(p.ID, int(id))
 		if err != nil {
 			log.Fatal(err)
@@ -37,6 +60,10 @@ var mrUnapproveCmd = &cobra.Command{
 }
 
 func init() {
+	mrUnapproveCmd.Flags().Bool("with-comment", false, "Add a comment with the approval")
+	mrUnapproveCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs (used with --with-comment only)")
+	mrUnapproveCmd.Flags().StringP("file", "F", "", "use the given file as the message (used with --with-comment only)")
+	mrUnapproveCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks (used with --with-comment only)")
 	mrCmd.AddCommand(mrUnapproveCmd)
 	carapace.Gen(mrUnapproveCmd).PositionalCompletion(
 		action.Remotes(),


### PR DESCRIPTION
    lab: Add --with-comment option to mr approve and unapprove commands
    
    Some users would like to add a comment when they approve or unapprove a
    merge request.
    
    Add a --with-comment option to the 'mr approve' and 'mr unapprove'
    commands.
    
    Signed-off-by: Prarit Bhargava <prarit@redhat.com>
