### PR TITLE
mr note: Add --resolve option

### DIFF
--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -62,7 +62,7 @@ lab issue edit <id>:<comment_id>                   # update a comment on MR`,
 
 		// Edit a comment on the Issue
 		if commentNum != 0 {
-			replyNote(rn, false, issueNum, commentNum, true, false, "", linebreak, false)
+			replyNote(rn, false, issueNum, commentNum, true, false, "", linebreak, false, nil)
 			return
 		}
 

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -62,7 +62,7 @@ lab issue edit <id>:<comment_id>                   # update a comment on MR`,
 
 		// Edit a comment on the Issue
 		if commentNum != 0 {
-			replyNote(rn, false, issueNum, commentNum, true, false, "", linebreak)
+			replyNote(rn, false, issueNum, commentNum, true, false, "", linebreak, false)
 			return
 		}
 

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -82,6 +82,10 @@ func NoteRunFn(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
+		// 'lab mr resolve' always overrides options
+		if os.Args[2] == "resolve" {
+			resolve = true
+		}
 
 		quote, err := cmd.Flags().GetBool("quote")
 		if err != nil {

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -91,7 +91,7 @@ func NoteRunFn(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		replyNote(rn, isMR, int(idNum), reply, quote, false, filename, linebreak, resolve)
+		replyNote(rn, isMR, int(idNum), reply, quote, false, filename, linebreak, resolve, msgs)
 		return
 	}
 
@@ -216,7 +216,7 @@ func noteText(body string) (string, error) {
 	return b.String(), nil
 }
 
-func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, update bool, filename string, linebreak bool, resolve bool) {
+func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, update bool, filename string, linebreak bool, resolve bool, msgs []string) {
 
 	var (
 		discussions []*gitlab.Discussion
@@ -244,7 +244,13 @@ func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, update bo
 			}
 
 			body := ""
-			if filename != "" {
+			if msgs != nil {
+				body, err = noteMsg(msgs, isMR, note.Body)
+				if err != nil {
+					_, f, l, _ := runtime.Caller(0)
+					log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
+				}
+			} else if filename != "" {
 				content, err := ioutil.ReadFile(filename)
 				if err != nil {
 					log.Fatal(err)

--- a/cmd/issue_note_test.go
+++ b/cmd/issue_note_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,6 +52,55 @@ func Test_issueNoteMsg(t *testing.T) {
 			assert.Equal(t, test.ExpectedBody, body)
 		})
 	}
+}
+
+func Test_issueReplyNote(t *testing.T) {
+	repo := copyTestRepo(t)
+	create := exec.Command(labBinaryPath, "issue", "create", "lab-testing", "-m", "note text")
+	create.Dir = repo
+
+	a, err := create.CombinedOutput()
+	if err != nil {
+		t.Log(string(a))
+		t.Fatal(err)
+	}
+	issueIDs := strings.Split(string(a), "\n")
+	issueID := strings.Trim(issueIDs[0], "https://gitlab.com/lab-testing/test/-/issues/")
+
+	note := exec.Command(labBinaryPath, "issue", "note", "lab-testing", issueID, "-m", "note text")
+	note.Dir = repo
+
+	b, err := note.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+	_noteIDs := strings.Split(string(b), "\n")
+	noteIDs := strings.Split(_noteIDs[0], "#note_")
+	noteID := noteIDs[1]
+
+	// add reply to the noteID
+	reply := exec.Command(labBinaryPath, "issue", "reply", "lab-testing", issueID+":"+noteID, "-m", "reply to note")
+	reply.Dir = repo
+	c, err := reply.CombinedOutput()
+	if err != nil {
+		t.Log(string(c))
+		t.Fatal(err)
+	}
+	_replyIDs := strings.Split(string(c), "\n")
+	replyIDs := strings.Split(_replyIDs[0], "#note_")
+	replyID := replyIDs[1]
+
+	show := exec.Command(labBinaryPath, "issue", "show", "lab-testing", issueID, "--comments")
+	show.Dir = repo
+	d, err := show.CombinedOutput()
+	if err != nil {
+		t.Log(string(d))
+		t.Fatal(err)
+	}
+
+	require.Contains(t, string(d), "#"+noteID+": "+"lab-testing started a discussion")
+	require.Contains(t, string(d), "#"+replyID+": "+"lab-testing commented at")
 }
 
 func Test_issueNoteText(t *testing.T) {

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -65,7 +65,7 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 
 		// Edit a comment on the MR
 		if commentNum != 0 {
-			replyNote(rn, true, mrNum, commentNum, true, true, "", linebreak, false)
+			replyNote(rn, true, mrNum, commentNum, true, true, "", linebreak, false, nil)
 			return
 		}
 

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -65,7 +65,7 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 
 		// Edit a comment on the MR
 		if commentNum != 0 {
-			replyNote(rn, true, mrNum, commentNum, true, true, "", linebreak)
+			replyNote(rn, true, mrNum, commentNum, true, true, "", linebreak, false)
 			return
 		}
 

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -8,7 +8,7 @@ import (
 
 var mrNoteCmd = &cobra.Command{
 	Use:              "note [remote] <id>[:<comment_id>]",
-	Aliases:          []string{"comment", "reply"},
+	Aliases:          []string{"comment", "reply", "resolve"},
 	Short:            "Add a note or comment to an MR on GitLab",
 	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -20,6 +20,7 @@ func init() {
 	mrNoteCmd.Flags().StringP("file", "F", "", "use the given file as the message")
 	mrNoteCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	mrNoteCmd.Flags().Bool("quote", false, "quote note in reply (used with --reply only)")
+	mrNoteCmd.Flags().Bool("resolve", false, "mark thread resolved (used with --reply only)")
 
 	mrCmd.AddCommand(mrNoteCmd)
 	carapace.Gen(mrNoteCmd).PositionalCompletion(

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1122,3 +1122,20 @@ func GetMRApprovedBys(project string, mrNum int) ([]string, error) {
 
 	return retArray, err
 }
+
+func ResolveMRDiscussion(project string, mrNum int, discussionID string, noteID int) (string, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return "", err
+	}
+
+	opts := &gitlab.ResolveMergeRequestDiscussionOptions{
+		Resolved: gitlab.Bool(true),
+	}
+
+	discussion, _, err := lab.Discussions.ResolveMergeRequestDiscussion(p.ID, mrNum, discussionID, opts)
+	if err != nil {
+		return discussion.ID, err
+	}
+	return fmt.Sprintf("Resolved %s/merge_requests/%d#note_%d", p.WebURL, mrNum, noteID), nil
+}


### PR DESCRIPTION
Currently lab does not have functionality to resolve threads.  Add a
--resolve option to the 'mr note' command that will result in the thread
being resolved.  Empty comments are allowed for the --resolve option.

Add a --resolve option to the 'mr note' command.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>