### PR TITLE
MR approvals: Add show functionality and tests for commands

### DIFF
--- a/cmd/mr_approve_test.go
+++ b/cmd/mr_approve_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/acarl005/stripansi"
+	"github.com/stretchr/testify/require"
+)
+
+// https://gitlab.com/zaquestion/test/-/merge_requests/18 was opened for these
+// tests
+
+func Test_mrApproveSetup(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	orig := exec.Command(labBinaryPath, "mr", "show", "18")
+	orig.Dir = repo
+
+	b, err := orig.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	origOutput := string(b)
+	origOutput = stripansi.Strip(origOutput)
+
+	require.Contains(t, origOutput, `Approved By: None`)
+}
+
+func Test_mrApprove(t *testing.T) {
+	repo := copyTestRepo(t)
+	orig := exec.Command(labBinaryPath, "mr", "approve", "18")
+	orig.Dir = repo
+
+	b, err := orig.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	origOutput := string(b)
+	origOutput = stripansi.Strip(origOutput)
+
+	require.Contains(t, origOutput, `Merge Request #18 approved`)
+}
+
+func Test_mrUnapprove(t *testing.T) {
+	repo := copyTestRepo(t)
+	orig := exec.Command(labBinaryPath, "mr", "unapprove", "18")
+	orig.Dir = repo
+
+	b, err := orig.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	origOutput := string(b)
+	origOutput = stripansi.Strip(origOutput)
+
+	require.Contains(t, origOutput, `Merge Request #18 unapproved`)
+}

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -116,6 +116,7 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 	assignee := "None"
 	milestone := "None"
 	labels := "None"
+	approvedByUsers := "None"
 	state := map[string]string{
 		"opened": "Open",
 		"closed": "Closed",
@@ -145,6 +146,14 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 		log.Fatal(err)
 	}
 
+	approvedBys, err := lab.GetMRApprovedBys(project, mr.IID)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(approvedBys) > 0 {
+		approvedByUsers = strings.Join(approvedBys, ", ")
+	}
+
 	fmt.Printf(`
 #%d %s
 ===================================
@@ -155,6 +164,7 @@ Branches: %s->%s
 Status: %s
 Assignee: %s
 Author: %s
+Approved By: %s
 Milestone: %s
 Labels: %s
 Issues Closed by this MR: %s
@@ -162,7 +172,7 @@ WebURL: %s
 `,
 		mr.IID, mr.Title, mr.Description, project, mr.SourceBranch,
 		mr.TargetBranch, state, assignee,
-		mr.Author.Username, milestone, labels,
+		mr.Author.Username, approvedByUsers, milestone, labels,
 		strings.Trim(strings.Replace(fmt.Sprint(closingIssues), " ", ",", -1), "[]"),
 		mr.WebURL,
 	)

--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -37,6 +37,7 @@ Branches: mrtest->master
 Status: Open
 Assignee: zaquestion
 Author: zaquestion
+Approved By: None
 Milestone: 1.0
 Labels: documentation
 Issues Closed by this MR: 

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -76,37 +76,6 @@ func Test_mrCmd(t *testing.T) {
 		require.Contains(t, outStripped, "mr description")
 		require.Contains(t, out, fmt.Sprintf("WebURL: https://gitlab.com/lab-testing/test/-/merge_requests/%s", mrID))
 	})
-	// Users cannot approve and unapprove their own MRs.  Comment out
-	// these tests for now until a better solution can be found.
-	//
-	//t.Run("approve", func(t *testing.T) {
-	//	if mrID == "" {
-	//		t.Skip("mrID is empty, create likely failed")
-	//	}
-	//	cmd := exec.Command(labBinaryPath, "mr", "lab-testing", "approve", mrID)
-	//	cmd.Dir = repo
-	//
-	//	//b, err := cmd.CombinedOutput()
-	//	if err != nil {
-	//		t.Log(string(b))
-	//		t.Fatal(err)
-	//	}
-	//	require.Contains(t, string(b), fmt.Sprintf("Merge Request #%s approved", mrID))
-	//})
-	//t.Run("unapprove", func(t *testing.T) {
-	//	if mrID == "" {
-	//		t.Skip("mrID is empty, create likely failed")
-	//	}
-	//	cmd := exec.Command(labBinaryPath, "mr", "lab-testing", "unapprove", mrID)
-	//	cmd.Dir = repo
-	//
-	//	b, err := cmd.CombinedOutput()
-	//	if err != nil {
-	//		t.Log(string(b))
-	//		t.Fatal(err)
-	//	}
-	//	require.Contains(t, string(b), fmt.Sprintf("Merge Request #%s unapproved", mrID))
-	//})
 	t.Run("delete", func(t *testing.T) {
 		if mrID == "" {
 			t.Skip("mrID is empty, create likely failed")

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -55,7 +55,7 @@ var mrUnapproveCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("Merge Request #%d Unapproved\n", id)
+		fmt.Printf("Merge Request #%d unapproved\n", id)
 	},
 }
 

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1081,3 +1081,23 @@ func MoveIssue(project string, issueNum int, dest string) (string, error) {
 	}
 	return fmt.Sprintf("%s/issues/%d", destProject.WebURL, issue.IID), nil
 }
+
+func GetMRApprovedBys(project string, mrNum int) ([]string, error) {
+	var retArray []string
+
+	p, err := FindProject(project)
+	if err != nil {
+		return retArray, err
+	}
+
+	configuration, _, err := lab.MergeRequestApprovals.GetConfiguration(p.ID, mrNum)
+	if err != nil {
+		return retArray, err
+	}
+
+	for _, approvedby := range configuration.ApprovedBy {
+		retArray = append(retArray, approvedby.User.Username)
+	}
+
+	return retArray, err
+}


### PR DESCRIPTION
Display the list of reviewers in the 'lab mr show' command, and add tests for 'lab approve' and 'lab unapprove'.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>