### PR TITLE
mr list test: Update Test_mrListByTargetBranch

### DIFF
--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -135,5 +135,5 @@ func Test_mrListByTargetBranch(t *testing.T) {
 	}
 
 	mrs := strings.Split(string(b), "\n")
-	require.Equal(t, "#17 test for diff output in 'lab mr show --comments'", mrs[0])
+	require.Equal(t, "#18 MR for approvals and unapprovals", mrs[0])
 }


### PR DESCRIPTION
A new MR, #18 MR for approvals and unapprovals, was pushed to the lab
testing tree to test approval and unapproval functionality.

Test_mrListByTargetBranch must be updated to point at MR #18.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>