### PR TITLE
show: Add system note output

### DIFF
--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -227,6 +227,9 @@ func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, update bo
 		for _, note := range discussion.Notes {
 
 			if note.System {
+				if note.ID == reply {
+					fmt.Println("ERROR: Cannot reply to note", note.ID)
+				}
 				continue
 			}
 

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -290,11 +290,6 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 	for _, discussion := range discussions {
 		for i, note := range discussion.Notes {
 
-			// skip system notes
-			if note.System {
-				continue
-			}
-
 			indentHeader, indentNote := "", ""
 			commented := "commented"
 			if !time.Time(*note.CreatedAt).Equal(time.Time(*note.UpdatedAt)) {
@@ -316,6 +311,18 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 
 			noteBody := strings.Replace(note.Body, "\n", "\n"+indentHeader, -1)
 			printit := color.New().PrintfFunc()
+
+			if note.System {
+				// system notes are informational messages only
+				// and cannot have replies.  Do not output the
+				// note.ID
+				printit(`
+* %s %s at %s
+`,
+					note.Author.Username, noteBody, time.Time(*note.UpdatedAt).String())
+				continue
+			}
+
 			printit(`
 %s-----------------------------------`, indentHeader)
 


### PR DESCRIPTION
The information in the system notes is important.  For example, changing
a merge request description will generate a system note.  Engineers find
this useful in the WebUI and it is easy to show in 'lab mr show' or
'lab issue show'.

System notes cannot have replies so there is no reason to output the
note ID.  Instead, preface system notes with an asterisk '*'.

This change adds lines like, for example,

     * prarit changed the description at 2020-11-12 20:36:39.425 +0000 UTC

to the lab show commands.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>