### PR TITLE
mr list: add --sort and --order options

### DIFF
--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -22,6 +22,7 @@ var (
 	assigneeID     *int
 	mrAssignee     string
 	order          string
+	sortedBy       string
 )
 
 // listCmd represents the list command
@@ -71,6 +72,8 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 
 	orderBy := gitlab.String(order)
 
+	sort := gitlab.String(sortedBy)
+
 	return lab.MRList(rn, gitlab.ListProjectMergeRequestsOptions{
 		ListOptions: gitlab.ListOptions{
 			PerPage: mrNumRet,
@@ -79,6 +82,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 		State:        &mrState,
 		TargetBranch: &mrTargetBranch,
 		OrderBy:      orderBy,
+		Sort:         sort,
 		AssigneeID:   assigneeID,
 	}, num)
 }
@@ -100,6 +104,7 @@ func init() {
 	listCmd.Flags().StringVar(
 		&mrAssignee, "assignee", "", "list only MRs assigned to $username")
 	listCmd.Flags().StringVar(&order, "order", "updated_at", "display order, updated_at(default) or created_at")
+	listCmd.Flags().StringVar(&sortedBy, "sort", "desc", "sort order, desc(default) or asc")
 
 	mrCmd.AddCommand(listCmd)
 	carapace.Gen(listCmd).FlagCompletion(carapace.ActionMap{

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -21,6 +21,7 @@ var (
 	mrMine         bool
 	assigneeID     *int
 	mrAssignee     string
+	order          string
 )
 
 // listCmd represents the list command
@@ -68,6 +69,8 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 		assigneeID = &_assigneeID
 	}
 
+	orderBy := gitlab.String(order)
+
 	return lab.MRList(rn, gitlab.ListProjectMergeRequestsOptions{
 		ListOptions: gitlab.ListOptions{
 			PerPage: mrNumRet,
@@ -75,7 +78,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 		Labels:       mrLabels,
 		State:        &mrState,
 		TargetBranch: &mrTargetBranch,
-		OrderBy:      gitlab.String("updated_at"),
+		OrderBy:      orderBy,
 		AssigneeID:   assigneeID,
 	}, num)
 }
@@ -96,6 +99,7 @@ func init() {
 	listCmd.Flags().BoolVarP(&mrMine, "mine", "m", false, "list only MRs assigned to me")
 	listCmd.Flags().StringVar(
 		&mrAssignee, "assignee", "", "list only MRs assigned to $username")
+	listCmd.Flags().StringVar(&order, "order", "updated_at", "display order, updated_at(default) or created_at")
 
 	mrCmd.AddCommand(listCmd)
 	carapace.Gen(listCmd).FlagCompletion(carapace.ActionMap{

--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -123,6 +123,10 @@ func Test_mrFilterByTargetBranch(t *testing.T) {
 	assert.Empty(t, mrs, "Expected to find no MRs for non-existent branch")
 }
 
+var (
+	latestUpdatedTestMR = "#18 MR for approvals and unapprovals"
+)
+
 func Test_mrListByTargetBranch(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
@@ -135,5 +139,77 @@ func Test_mrListByTargetBranch(t *testing.T) {
 	}
 
 	mrs := strings.Split(string(b), "\n")
-	require.Equal(t, "#18 MR for approvals and unapprovals", mrs[0])
+	require.Equal(t, latestUpdatedTestMR, mrs[0])
+}
+
+// updated,asc
+// #1
+func Test_mrListUpdatedAscending(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "mr", "list", "--number=1", "--order=updated_at", "--sort=asc")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mrs := strings.Split(string(b), "\n")
+	t.Log(mrs)
+	require.Contains(t, mrs, "#3 for testings filtering with labels and lists")
+}
+
+// updatead,desc
+// #18
+func Test_mrListUpdatedDescending(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "mr", "list", "--number=1", "--order=updated_at", "--sort=desc")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mrs := strings.Split(string(b), "\n")
+	t.Log(mrs)
+	require.Equal(t, latestUpdatedTestMR, mrs[0])
+}
+
+// created,asc
+// #1
+func Test_mrListCreatedAscending(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "mr", "list", "--number=1", "--order=created_at", "--sort=asc")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mrs := strings.Split(string(b), "\n")
+	t.Log(mrs)
+	require.Contains(t, mrs, "#1 Test MR for lab list")
+}
+
+// created,desc
+// #18
+func Test_mrListCreatedDescending(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "mr", "list", "--number=1", "--order=created_at", "--sort=desc")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mrs := strings.Split(string(b), "\n")
+	t.Log(mrs)
+	require.Equal(t, latestUpdatedTestMR, mrs[0])
 }


### PR DESCRIPTION
Add a --sort option to display MRs in either ascending or descending order.  Add a --order option to display MRs in the order they were created, or in the order they were updated.