### PR TITLE
mr: Don't set minimum number of args

### DIFF
--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -15,7 +15,6 @@ var mrApproveCmd = &cobra.Command{
 	Aliases:          []string{},
 	Short:            "Approve merge request",
 	Long:             ``,
-	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_close.go
+++ b/cmd/mr_close.go
@@ -15,7 +15,6 @@ var mrCloseCmd = &cobra.Command{
 	Aliases:          []string{"delete"},
 	Short:            "Close merge request",
 	Long:             ``,
-	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -23,7 +23,6 @@ var mrCreateDiscussionCmd = &cobra.Command{
 	Short:            "Start a discussion on an MR on GitLab",
 	Long:             ``,
 	Aliases:          []string{"block", "thread"},
-	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrNum, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_merge.go
+++ b/cmd/mr_merge.go
@@ -14,7 +14,6 @@ var mrMergeCmd = &cobra.Command{
 	Aliases:          []string{"delete"},
 	Short:            "Merge an open merge request",
 	Long:             `If the pipeline for the mr is still running, lab sets merge on success`,
-	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_rebase.go
+++ b/cmd/mr_rebase.go
@@ -13,7 +13,6 @@ var mrRebaseCmd = &cobra.Command{
 	Use:              "rebase [remote] <id>",
 	Aliases:          []string{"delete"},
 	Short:            "Rebase an open merge request",
-	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -15,7 +15,6 @@ var mrUnapproveCmd = &cobra.Command{
 	Aliases:          []string{},
 	Short:            "Unapprove merge request",
 	Long:             ``,
-	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)


### PR DESCRIPTION
The commands use parseArgsWithGitBranchMR() to parse non-flag arguments,
which will return the MR id associated with the current branch if no
id is specified.

That behavior makes a lot of sense, but can only work if the option parser
doesn't enforce the id to be specified.