### PR TITLE
mr/show: Fix glitch in error message

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -108,7 +108,7 @@ func findLocalRemote(ProjectID int) string {
 	}
 
 	if remote == "" {
-		log.Fatal("remote for ", project.NameWithNamespace, "not found in local remotes")
+		log.Fatal("remote for ", project.NameWithNamespace, " not found in local remotes")
 	}
 	return remote
 }


### PR DESCRIPTION
The remote name in the output isn't separated from the next word.