### PR TITLE
ci: Sort list of displayed jobs

### DIFF
--- a/cmd/ci_status_test.go
+++ b/cmd/ci_status_test.go
@@ -41,25 +41,25 @@ func Test_ciStatus(t *testing.T) {
 	}
 	out := string(b)
 	assert.Contains(t, out, `Stage:  Name                           - Status
-deploy: deploy10                       - success
-deploy: deploy9                        - success
-deploy: deploy8                        - success
-deploy: deploy7                        - success
-deploy: deploy6                        - success
-deploy: deploy5                        - success
-deploy: deploy5:really_a_long_name_for - success
-deploy: deploy4                        - success
-deploy: deploy3:no_sufix:deploy        - success
-deploy: deploy2                        - manual
-deploy: deploy1                        - success
-test:   test3                          - success
-test:   test2:no_suffix:test           - success
-test:   test2:really_a_long_name_for   - success
-test:   test2                          - success
-test:   test1                          - success
-build:  build2:fails                   - failed
+build:  build1                         - success
 build:  build2                         - success
-build:  build1                         - success`)
+build:  build2:fails                   - failed
+test:   test1                          - success
+test:   test2                          - success
+test:   test2:really_a_long_name_for   - success
+test:   test2:no_suffix:test           - success
+test:   test3                          - success
+deploy: deploy1                        - success
+deploy: deploy2                        - manual
+deploy: deploy3:no_sufix:deploy        - success
+deploy: deploy4                        - success
+deploy: deploy5:really_a_long_name_for - success
+deploy: deploy5                        - success
+deploy: deploy6                        - success
+deploy: deploy7                        - success
+deploy: deploy8                        - success
+deploy: deploy9                        - success
+deploy: deploy10                       - success`)
 
 	assert.Contains(t, out, "Pipeline Status: success")
 }

--- a/cmd/ci_trace_test.go
+++ b/cmd/ci_trace_test.go
@@ -40,7 +40,7 @@ func Test_ciTrace(t *testing.T) {
 			desc: "noargs",
 			args: []string{},
 			assertContains: func(t *testing.T, out string) {
-				assert.Contains(t, out, "Showing logs for build1")
+				assert.Contains(t, out, "Showing logs for deploy10")
 				assert.Contains(t, out, "Checking out 09b519cb as ci_test_pipeline...")
 				assert.Contains(t, out, "For example you might run an update here or install a build dependency")
 				assert.Contains(t, out, "$ echo \"Or perhaps you might print out some debugging details\"")

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -839,14 +839,7 @@ func CIJobs(pid interface{}, sha string) ([]*gitlab.Job, error) {
 			PerPage: 500,
 		},
 	}
-	list, resp, err := lab.Jobs.ListPipelineJobs(pid, target, opts)
-	if err != nil {
-		return nil, err
-	}
-	if resp.CurrentPage == resp.TotalPages {
-		return list, nil
-	}
-	opts.Page = resp.NextPage
+	list := make([]*gitlab.Job, 0)
 	for {
 		jobs, resp, err := lab.Jobs.ListPipelineJobs(pid, target, opts)
 		if err != nil {

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -824,6 +825,14 @@ func ProjectList(opts gitlab.ListProjectsOptions, n int) ([]*gitlab.Project, err
 	return list, nil
 }
 
+type JobSorter struct{ Jobs []*gitlab.Job }
+
+func (s JobSorter) Len() int      { return len(s.Jobs) }
+func (s JobSorter) Swap(i, j int) { s.Jobs[i], s.Jobs[j] = s.Jobs[j], s.Jobs[i] }
+func (s JobSorter) Less(i, j int) bool {
+	return time.Time(*s.Jobs[i].CreatedAt).Before(time.Time(*s.Jobs[j].CreatedAt))
+}
+
 // CIJobs returns a list of jobs in a pipeline for a given sha. The jobs are
 // returned sorted by their CreatedAt time
 func CIJobs(pid interface{}, sha string) ([]*gitlab.Job, error) {
@@ -851,6 +860,11 @@ func CIJobs(pid interface{}, sha string) ([]*gitlab.Job, error) {
 			break
 		}
 	}
+
+	// ListPipelineJobs returns jobs sorted by ID in descending order,
+	// while we want them to be ordered chronologically
+	sort.Sort(JobSorter{list})
+
 	return list, nil
 }
 


### PR DESCRIPTION
When we filter the list to only show the latest job of each stage+name
combo, we mess up the expected order of jobs in the pipeline.

Address this by sorting the filtered list before returning it.

Fixes https://github.com/zaquestion/lab/issues/471