### PR TITLE
Use the remote tracking branch where appropriate

### DIFF
--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/action"
-	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
@@ -33,15 +32,9 @@ lab ci status --wait`,
 			err     error
 		)
 
-		rn, refName, err = parseArgsRemoteAndProject(args)
+		rn, refName, err = parseArgsRemoteAndBranch(args)
 		if err != nil {
 			log.Fatal(err)
-		}
-		if refName == "" {
-			refName, err = git.CurrentBranch()
-			if err != nil {
-				log.Fatal(err)
-			}
 		}
 
 		pid := rn

--- a/cmd/ci_status_test.go
+++ b/cmd/ci_status_test.go
@@ -17,14 +17,14 @@ func Test_ciStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd = exec.Command(labBinaryPath, "checkout", "origin/ci_test_pipeline")
+	cmd = exec.Command(labBinaryPath, "checkout", "-b", "ci_test_pipeline")
 	cmd.Dir = repo
 	if b, err := cmd.CombinedOutput(); err != nil {
 		t.Log(string(b))
 		t.Fatal(err)
 	}
 
-	cmd = exec.Command(labBinaryPath, "checkout", "-b", "ci_test_pipeline")
+	cmd = exec.Command(labBinaryPath, "branch", "-m", "local/ci_test_pipeline")
 	cmd.Dir = repo
 	if b, err := cmd.CombinedOutput(); err != nil {
 		t.Log(string(b))

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -21,7 +21,6 @@ import (
 	gitlab "github.com/xanzy/go-gitlab"
 
 	"github.com/zaquestion/lab/internal/action"
-	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
@@ -54,15 +53,9 @@ Feedback Encouraged!: https://github.com/zaquestion/lab/issues`,
 			err     error
 		)
 
-		rn, refName, err = parseArgsRemoteAndProject(args)
+		rn, refName, err = parseArgsRemoteAndBranch(args)
 		if err != nil {
 			log.Fatal(err)
-		}
-		if refName == "" {
-			refName, err = git.CurrentBranch()
-			if err != nil {
-				log.Fatal(err)
-			}
 		}
 
 		project, err := lab.FindProject(rn)

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -105,15 +105,25 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
+	remoteBranch, err := git.CurrentUpstreamBranch()
+	if remoteBranch == "" {
+		// Fall back to local branch
+		remoteBranch, err = git.CurrentBranch()
+	}
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	p, err := lab.FindProject(sourceProjectName)
 	if err != nil {
 		log.Fatal(err)
 	}
-	if _, err := lab.GetCommit(p.ID, branch); err != nil {
+	if _, err := lab.GetCommit(p.ID, remoteBranch); err != nil {
 		err = errors.Wrapf(
 			err,
 			"aborting MR, source branch %s not present on remote %s. did you forget to push?",
-			branch, sourceRemote)
+			remoteBranch, sourceRemote)
 		log.Fatal(err)
 	}
 

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -109,7 +109,7 @@ func Test_mrCmd_MR_description_and_options(t *testing.T) {
 		}
 	})
 	t.Run("create MR from file", func(t *testing.T) {
-		git := exec.Command("git", "checkout", "mrtest")
+		git := exec.Command("git", "checkout", "-b", "local/mrtest", "origin/mrtest")
 		git.Dir = repo
 		b, err := git.CombinedOutput()
 		if err != nil {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -145,27 +145,54 @@ func parseArgsRemoteAndProject(args []string) (string, string, error) {
 		return "", "", nil
 	}
 
-	remote, str := forkedFromRemote, ""
-
-	if len(args) == 1 {
-		ok, err := git.IsRemote(args[0])
-		if err != nil {
-			return "", "", err
-		}
-		if ok {
-			remote = args[0]
-		} else {
-			str = args[0]
-		}
-	} else if len(args) > 1 {
-		remote, str = args[0], args[1]
+	remote, str, err := parseArgsRemoteAndString(args)
+	if err != nil {
+		return "", "", nil
 	}
 
-	remote, err := getRemoteName(remote)
+	if remote == "" {
+		remote = forkedFromRemote
+	}
+
+	remote, err = getRemoteName(remote)
 	if err != nil {
 		return "", "", err
 	}
 	return remote, str, nil
+}
+
+// parseArgsRemoteAndBranch is used by commands to parse command line
+// arguments.  This function returns a remote name and a branch name.
+// If no branch name is given, the function returns the upstream of
+// the current branch and the corresponding remote.
+func parseArgsRemoteAndBranch(args []string) (string, string, error) {
+	if !git.InsideGitRepo() {
+		return "", "", nil
+	}
+
+	remote, branch, err := parseArgsRemoteAndString(args)
+	if branch == "" && err == nil {
+		branch, err = git.CurrentBranch()
+	}
+
+	if err != nil {
+		return "", "", err
+	}
+
+	if remote == "" {
+		remote = determineSourceRemote(branch)
+	}
+
+	remoteBranch, _ := git.UpstreamBranch(branch)
+	if remoteBranch != "" {
+		branch = remoteBranch
+	}
+
+	remote, err = getRemoteName(remote)
+	if err != nil {
+		return "", "", err
+	}
+	return remote, branch, nil
 }
 
 func getRemoteName(remote string) (string, error) {
@@ -203,6 +230,26 @@ func parseArgsStringAndID(args []string) (string, int64, error) {
 		return "", n, nil
 	}
 	return "", 0, nil
+}
+
+func parseArgsRemoteAndString(args []string) (string, string, error) {
+	remote, str := "", ""
+
+	if len(args) == 1 {
+		ok, err := git.IsRemote(args[0])
+		if err != nil {
+			return "", "", err
+		}
+		if ok {
+			remote = args[0]
+		} else {
+			str = args[0]
+		}
+	} else if len(args) > 1 {
+		remote, str = args[0], args[1]
+	}
+
+	return remote, str, nil
 }
 
 // parseArgsWithGitBranchMR returns a remote name and a number if parsed.

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -69,9 +69,14 @@ func flagConfig(fs *flag.FlagSet) {
 func getCurrentBranchMR(rn string) int {
 	var num int = 0
 
-	currentBranch, err := git.CurrentBranch()
+	currentBranch, err := git.CurrentUpstreamBranch()
+	if currentBranch == "" {
+		// Fall back to local branch
+		currentBranch, err = git.CurrentBranch()
+	}
+
 	if err != nil {
-		log.Fatal(err)
+		return 0
 	}
 
 	mrs, err := lab.MRList(rn, gitlab.ListProjectMergeRequestsOptions{

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -131,6 +131,33 @@ func CurrentBranch() (string, error) {
 	return strings.TrimSpace(string(branch)), nil
 }
 
+// CurrentUpstreamBranch returns the upstream of the currently checked out branch
+func CurrentUpstreamBranch() (string, error) {
+	localBranch, err := CurrentBranch()
+	if err != nil {
+		return "", err
+	}
+
+	branch, err := UpstreamBranch(localBranch)
+	if err != nil {
+		return "", err
+	}
+	return branch, nil
+}
+
+// UpstreamBranch returns the upstream of the specified branch
+func UpstreamBranch(branch string) (string, error) {
+	cmd := New("rev-parse", "--abbrev-ref", branch+"@{upstream}")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	ref, err := cmd.Output()
+	if err != nil {
+		return "", errors.Errorf("No upstream for branch '%s'", branch)
+	}
+	upstreamBranch := strings.SplitN(string(ref), "/", 2)[1]
+	return strings.TrimSpace(upstreamBranch), nil
+}
+
 // PathWithNameSpace returns the owner/repository for the current repo
 // Such as zaquestion/lab
 // Respects GitLab subgroups (https://docs.gitlab.com/ce/user/group/subgroups/)

--- a/testdata/test.git/config
+++ b/testdata/test.git/config
@@ -9,7 +9,7 @@
 	fetch = +refs/heads/*:refs/remotes/origin/*
 [remote "lab-testing"]
         url = git@gitlab.com:lab-testing/test.git
-        fetch = +refs/heads/*:refs/remotes/origin/*
+        fetch = +refs/heads/*:refs/remotes/lab-testing/*
 
 [branch "origin"]
 	remote = zaquestion
@@ -26,26 +26,26 @@
 # https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a
 [remote "origin-http"]
 	url = http://gitlab.com/zaquestion/test.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/heads/*:refs/remotes/origin-http/*
 [remote "origin-https"]
 	url = https://gitlab.com/zaquestion/test.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/heads/*:refs/remotes/origin-https/*
 [remote "origin-pushurl"]
 	url = garbageurl
 	pushurl = https://gitlab.com/zaquestion/test.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/heads/*:refs/remotes/origin-pushurl/*
 [remote "origin-https-token"]
 	url = https://token@gitlab.com/zaquestion/test.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/heads/*:refs/remotes/origin-https-token/*
 [remote "origin-git"]
 	url = git://gitlab.com/zaquestion/test.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/heads/*:refs/remotes/origin-git/*
 [remote "origin-ssh-alt"]
 	url = ssh://gitlab.com/zaquestion/test.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/heads/*:refs/remotes/origin-ssh-alt/*
 [remote "origin-no_dot_git"]
 	url = git@gitlab.com:zaquestion/test
-	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/heads/*:refs/remotes/origin-no_dot_git/*
 [remote "garbage"]
 	url = garbageurl
 	fetch = +refs/heads/*:refs/remotes/garbage/*


### PR DESCRIPTION
While the local branch name usually matches the remote one, this is
not necessarily the case, and the automatic detection of a MR or pipeline
fails.

Handle those cases as well by figuring out the remote tracking branch
and use that instead of the local name if possible.

Fixes #360