### PR TITLE
Makefile: move PHONY target from 'deps' to 'build'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ internal-test:
 	go get -u github.com/wadey/gocovmerge
 	gocovmerge coverage-*.out > coverage.txt && rm coverage-*.out
 
-.PHONY: deps install test internal-test
+.PHONY: build install test internal-test


### PR DESCRIPTION
There is no 'deps' target whatsoever. OTOH, 'build' was not being considered
as PHONY. This patch change one for another.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>