### PR TITLE
show: check output type before rendering Markdown

### DIFF
--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -41,11 +41,14 @@ var issueShowCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		noMarkdown, _ := cmd.Flags().GetBool("no-markdown")
-		if err != nil {
-			log.Fatal(err)
+		renderMarkdown := false
+		if isOutputTerminal() {
+			noMarkdown, _ := cmd.Flags().GetBool("no-markdown")
+			if err != nil {
+				log.Fatal(err)
+			}
+			renderMarkdown = !noMarkdown
 		}
-		renderMarkdown := !noMarkdown
 
 		printIssue(issue, rn, renderMarkdown)
 
@@ -317,7 +320,6 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 			}
 			noteBody, _ = html2text.FromString(noteBody, html2textOptions)
 			printit := color.New().PrintfFunc()
-
 			if note.System {
 				// system notes are informational messages only
 				// and cannot have replies.  Do not output the

--- a/cmd/issue_show_test.go
+++ b/cmd/issue_show_test.go
@@ -21,13 +21,9 @@ func Test_issueShow(t *testing.T) {
 	}
 
 	out := string(b)
-	out = stripansi.Strip(out) // This is required because glamour adds a lot of ansi chars
-
 	require.Contains(t, out, `
 #1 test issue for lab list
 ===================================
-
-
 
 -----------------------------------
 Project: zaquestion/test

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -39,11 +39,14 @@ var mrShowCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		noMarkdown, _ := cmd.Flags().GetBool("no-markdown")
-		if err != nil {
-			log.Fatal(err)
+		renderMarkdown := false
+		if isOutputTerminal() {
+			noMarkdown, _ := cmd.Flags().GetBool("no-markdown")
+			if err != nil {
+				log.Fatal(err)
+			}
+			renderMarkdown = !noMarkdown
 		}
-		renderMarkdown := !noMarkdown
 
 		if mrShowPatch {
 			var remote string

--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -11,6 +11,7 @@ import (
 func Test_mrShow(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
+
 	// a comment has been added to
 	// https://gitlab.com/zaquestion/test/-/merge_requests/1 for this test
 	cmd := exec.Command(labBinaryPath, "mr", "show", "1", "--comments")
@@ -23,14 +24,10 @@ func Test_mrShow(t *testing.T) {
 	}
 
 	out := string(b)
-	out = stripansi.Strip(out)
 	require.Contains(t, out, `
 #1 Test MR for lab list
 ===================================
-
-  This MR is to remain open for testing the  lab mr list  functionality       
-
-
+This MR is to remain open for testing the `+"`lab mr list`"+` functionality
 -----------------------------------
 Project: zaquestion/test
 Branches: mrtest->master
@@ -41,9 +38,7 @@ Approved By: None
 Milestone: 1.0
 Labels: documentation
 Issues Closed by this MR: 
-WebURL: https://gitlab.com/zaquestion/test/-/merge_requests/1
-`)
-
+WebURL: https://gitlab.com/zaquestion/test/-/merge_requests/1`)
 	require.Contains(t, string(b), `commented at`)
 	require.Contains(t, string(b), `updated comment at`)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -16,6 +17,7 @@ import (
 	"github.com/zaquestion/lab/internal/config"
 	git "github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (
@@ -295,6 +297,16 @@ func setCommandPrefix(scmd *cobra.Command) {
 func textToMarkdown(text string) string {
 	text = strings.Replace(text, "\n", "  \n", -1)
 	return text
+}
+
+// isOutputTerminal checks if both stdout and stderr are indeed terminals
+// to avoid some markdown rendering garbage going to other outputs that
+// don't support some control chars.
+func isOutputTerminal() bool {
+	if !terminal.IsTerminal(syscall.Stdout) || !terminal.IsTerminal(syscall.Stderr) {
+		return false
+	}
+	return true
 }
 
 func LabPersistentPreRun(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Prevent ANSI control chars from being prompted to stdout and stderr in case lab is piping it and not printing in a usual terminal.
Fixes #519 .