### PR TITLE
mr_list: fix test latest MR

### DIFF
--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -123,9 +123,7 @@ func Test_mrFilterByTargetBranch(t *testing.T) {
 	assert.Empty(t, mrs, "Expected to find no MRs for non-existent branch")
 }
 
-var (
-	latestUpdatedTestMR = "#18 MR for approvals and unapprovals"
-)
+var latestUpdatedTestMR = "#19 MR for closing and reopening"
 
 func Test_mrListByTargetBranch(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
There are some tests that relies on the last MR opened. One was created for
testing MR closing and reopening, which became the last. With that the
reference in mr_list_test should be changed.

[prarit: Applying this change so other open MRs can move forward.]

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>
Signed-off-by: Prarit Bhargava <prarit@redhat.com>