### PR TITLE
fork: enable different name, namespace and path on destination

### DIFF
--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -41,8 +41,14 @@ var forkCmd = &cobra.Command{
 }
 
 func forkFromOrigin(cmd *cobra.Command, args []string) {
-	if _, err := gitconfig.Local("remote." + lab.User() + ".url"); err == nil {
-		log.Fatalf("remote: %s already exists", lab.User())
+	// Check for custom target namespace
+	remote := lab.User()
+	if forkData.TargetNamespace != "" {
+		remote = forkData.TargetNamespace
+	}
+
+	if _, err := gitconfig.Local("remote." + remote + ".url"); err == nil {
+		log.Fatalf("remote: %s already exists", remote)
 	}
 	if _, err := gitconfig.Local("remote.upstream.url"); err == nil {
 		log.Fatal("remote: upstream already exists")
@@ -81,6 +87,7 @@ func forkFromOrigin(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 }
+
 func forkToUpstream(cmd *cobra.Command, args []string) {
 	forkData.SrcProject = args[0]
 	// lab.Fork doesn't have access to the useHTTP var, so we need to pass
@@ -115,9 +122,13 @@ func forkToUpstream(cmd *cobra.Command, args []string) {
 		cloneCmd.Run(nil, []string{namespace + name})
 	}
 }
+
 func determineForkRemote(project string) string {
 	name := lab.User()
-	if strings.Split(project, "/")[0] == lab.User() {
+	if forkData.TargetNamespace != "" {
+		name = forkData.TargetNamespace
+	}
+	if strings.Split(project, "/")[0] == name {
 		// #78 allow upstream remote to be added when "origin" is
 		// referring to the user fork (and the fork already exists)
 		name = "upstream"

--- a/cmd/fork_test.go
+++ b/cmd/fork_test.go
@@ -12,56 +12,139 @@ import (
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
-func Test_fork(t *testing.T) {
-	t.Parallel()
-
-	repo := copyTestRepo(t)
-
-	// remove the .git/config so no remotes exist
-	os.Remove(path.Join(repo, ".git/config"))
-
-	cmd := exec.Command("git", "remote", "add", "origin",
-		"git@gitlab.com:zaquestion/fork_test")
-	cmd.Dir = repo
-	err := cmd.Run()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Run("do_fork", func(t *testing.T) {
-		cmd = exec.Command(labBinaryPath, "fork")
-		cmd.Dir = repo
-		b, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		out := string(b)
-
-		require.Contains(t, out, "From gitlab.com:lab-testing/fork_test")
-		require.Contains(t, out, "new remote: lab-testing")
-
-		cmd = exec.Command("git", "remote", "-v")
-		cmd.Dir = repo
-
-		b, err = cmd.CombinedOutput()
-		if err != nil {
-			t.Fatal(err)
-		}
-		require.Contains(t, string(b), "lab-testing")
-	})
-	time.Sleep(2 * time.Second)
-
+func cleanupFork(t *testing.T, project string) {
 	// Failing to find the project will fail the test and is a legit
 	// failure case since its the only thing asserting the project exists
 	// (was forked)
-	p, err := lab.FindProject("fork_test")
+	p, err := lab.FindProject(project)
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "failed to find project for cleanup"))
+		t.Fatal(errors.Wrap(err, "failed to find project "+project+" for cleanup"))
 	}
 	err = lab.ProjectDelete(p.ID)
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "failed to delete project during cleanup"))
+		t.Fatal(errors.Wrap(err, "failed to delete project "+project+" during cleanup"))
+	}
+}
+
+func Test_fork(t *testing.T) {
+	tests := []struct {
+		desc      string
+		args      []string
+		name      string
+		path      string
+		namespace string
+	}{
+		{
+			desc:      "do_fork",
+			args:      []string{},
+			name:      "fork_test",
+			path:      "",
+			namespace: "",
+		},
+		{
+			desc:      "do_fork_name",
+			args:      []string{"-n", "fork_test_name"},
+			name:      "fork_test_name",
+			path:      "",
+			namespace: "",
+		},
+		{
+			desc:      "do_fork_path",
+			args:      []string{"-p", "fork_test_path"},
+			name:      "fork_test",
+			path:      "fork_test_path",
+			namespace: "",
+		},
+		{
+			desc:      "do_fork_name_path",
+			args:      []string{"-n", "fork_test_name_1", "-p", "fork_test_path_1"},
+			name:      "fork_test_name_1",
+			path:      "fork_test_path_1",
+			namespace: "",
+		},
+		{
+			desc:      "do_fork_namespace",
+			args:      []string{"-m", "lab-testing-test-group"},
+			name:      "fork_test",
+			path:      "",
+			namespace: "lab-testing-test-group",
+		},
+		{
+			desc:      "do_fork_namespace_name",
+			args:      []string{"-m", "lab-testing-test-group", "-n", "fork_test_name"},
+			name:      "fork_test_name",
+			path:      "",
+			namespace: "lab-testing-test-group",
+		},
+		{
+			desc:      "do_fork_namespace_path",
+			args:      []string{"-m", "lab-testing-test-group", "-p", "fork_test_path"},
+			name:      "fork_test",
+			path:      "fork_test_path",
+			namespace: "lab-testing-test-group",
+		},
+		{
+			desc:      "do_fork_namespace_name_path",
+			args:      []string{"-m", "lab-testing-test-group", "-n", "fork_test_name_1", "-p", "fork_test_path_1"},
+			name:      "fork_test_name_1",
+			path:      "fork_test_path_1",
+			namespace: "lab-testing-test-group",
+		},
+	}
+
+	t.Parallel()
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			// remove the .git/config so no remotes exist
+			repo := copyTestRepo(t)
+			os.Remove(path.Join(repo, ".git/config"))
+
+			cmd := exec.Command("git", "remote", "add", "origin", "git@gitlab.com:zaquestion/fork_test")
+			cmd.Dir = repo
+			err := cmd.Run()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			args := []string{"fork"}
+			if len(test.args) > 0 {
+				args = append(args, test.args...)
+			}
+			cmd = exec.Command(labBinaryPath, args...)
+			cmd.Dir = repo
+			b, err := cmd.CombinedOutput()
+			out := string(b)
+			if err != nil {
+				t.Log(out)
+				t.Fatal(err)
+			}
+
+			namespace := "lab-testing"
+			if test.namespace != "" {
+				namespace = test.namespace
+			}
+			name := test.name
+			if test.path != "" {
+				name = test.path
+			}
+			project := namespace + "/" + name
+
+			require.Contains(t, out, "From gitlab.com:"+project)
+			require.Contains(t, out, "new remote: "+namespace)
+
+			cmd = exec.Command("git", "remote", "-v")
+			cmd.Dir = repo
+
+			b, err = cmd.CombinedOutput()
+			if err != nil {
+				t.Fatal(err)
+			}
+			require.Contains(t, string(b), namespace)
+			time.Sleep(2 * time.Second)
+			cleanupFork(t, project)
+		})
 	}
 }
 

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -267,6 +267,10 @@ func Fork(data ForkStruct, useHTTP bool, wait bool) (string, error) {
 
 	var forkOpts *gitlab.ForkProjectOptions = nil
 	if data.isCustomTargetSet() {
+		// Name and/or path must be set
+		if data.TargetName == "" && data.TargetPath == "" {
+			data.TargetName = target.Name
+		}
 		forkOpts = &gitlab.ForkProjectOptions{
 			Name:      gitlab.String(data.TargetName),
 			Namespace: gitlab.String(data.TargetNamespace),

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -230,8 +230,22 @@ func Fork(data ForkStruct, useHTTP bool, wait bool) (string, error) {
 	}
 	parts := strings.Split(data.SrcProject, "/")
 
-	// See if a fork already exists
-	target, err := FindProject(parts[1])
+	// See if a fork already exists in the destination
+	name := parts[1]
+	namespace := ""
+	if data.isCustomTargetSet() {
+		if data.TargetNamespace != "" {
+			namespace = data.TargetNamespace + "/"
+		}
+		// Project name takes precedence over path for finding a project
+		// on Gitlab through API
+		if data.TargetName != "" {
+			name = data.TargetName
+		} else if data.TargetPath != "" {
+			name = data.TargetPath
+		}
+	}
+	target, err := FindProject(namespace + name)
 	if err == nil {
 		urlToRepo := target.SSHURLToRepo
 		if useHTTP {


### PR DESCRIPTION
Allow the user to specify three fork properties: `name`, `namespace` and `path`.
With it the user can fork the same project to different namespaces with different names, working around possible conflicts.

Fixes #488  