### PR TITLE
issue_note: Fix quoting of replied comment

### DIFF
--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -247,7 +247,7 @@ func replyNote(rn string, isMR bool, idNum int, reply int, quote bool, update bo
 			}
 
 			body := ""
-			if msgs != nil {
+			if len(msgs) != 0 {
 				body, err = noteMsg(msgs, isMR, note.Body)
 				if err != nil {
 					_, f, l, _ := runtime.Caller(0)


### PR DESCRIPTION
Comment paragraphs specified via -m on the command line take precedent
over quoting the replied comment. However if no -m flag is specified,
the corresponding variable is an empty array, not nil. As a result,
we never reach the code that marks the replied comment as quote.
