### PR TITLE
Add support for draft merge requests

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -44,6 +44,7 @@ func init() {
 	mrCreateCmd.Flags().StringP("file", "F", "", "use the given file as the Description")
 	mrCreateCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	mrCreateCmd.Flags().BoolP("cover-letter", "c", false, "do not comment changelog and diffstat")
+	mrCreateCmd.Flags().Bool("draft", false, "mark the merge request as draft")
 	mergeRequestCmd.Flags().AddFlagSet(mrCreateCmd.Flags())
 
 	mrCmd.AddCommand(mrCreateCmd)
@@ -196,6 +197,18 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	linebreak, _ := cmd.Flags().GetBool("force-linebreak")
 	if linebreak {
 		body = textToMarkdown(body)
+	}
+
+	draft, _ := cmd.Flags().GetBool("draft")
+	if draft {
+		isWIP := strings.EqualFold(title[0:4], "wip:")
+		isDraft := strings.EqualFold(title[0:6], "draft:") ||
+			strings.EqualFold(title[0:7], "[draft]") ||
+			strings.EqualFold(title[0:7], "(draft)")
+
+		if !isWIP && !isDraft {
+			title = "Draft: " + title
+		}
 	}
 
 	removeSourceBranch, _ := cmd.Flags().GetBool("remove-source-branch")


### PR DESCRIPTION
Gitlab supports marking a merge request as draft to indicate that it is not ready to be merged. This is supported in the web UI (actions to mark as draft/ready, disabled merge button in draft MRs), but not explicitly exposed in the API: Drafts are simply indicated by prefixing the MR title with "Draft:", "[Draft]" or "(Draft)" (or previously "WIP)[0].

lab therefore kind of supports the feature already, but it still seems reasonable to export the feature explicitly rather than via manipulating the title (although that's of course what the implementation does under the hood).

[0] https://docs.gitlab.com/ee/user/project/merge_requests/work_in_progress_merge_requests.html