### PR TITLE
Add support for merge request pipelines

### DIFF
--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -42,7 +42,7 @@ lab ci status --wait`,
 		if err != nil {
 			log.Fatal(err)
 		}
-		commitSHA = commit.ID
+		pipelineID = commit.LastPipeline.ID
 
 		w := tabwriter.NewWriter(os.Stdout, 2, 4, 1, byte(' '), 0)
 
@@ -56,7 +56,7 @@ lab ci status --wait`,
 		fmt.Fprintln(w, "Stage:\tName\t-\tStatus")
 		for {
 			// fetch all of the CI Jobs from the API
-			jobs, err = lab.CIJobs(pid, commitSHA)
+			jobs, err = lab.CIJobs(pid, pipelineID)
 			if err != nil {
 				log.Fatal(errors.Wrap(err, "failed to find ci jobs"))
 			}

--- a/cmd/ci_status_test.go
+++ b/cmd/ci_status_test.go
@@ -63,3 +63,39 @@ deploy: deploy10                       - success`)
 
 	assert.Contains(t, out, "Pipeline Status: success")
 }
+
+func Test_ciStatusMR(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "ci", "status", "--merge-request", "17")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+	out := string(b)
+	assert.Contains(t, out, `Stage:  Name                           - Status
+build:  build1                         - success
+build:  build2                         - success
+build:  build2:fails                   - failed
+test:   test1                          - success
+test:   test2                          - success
+test:   test2:really_a_long_name_for   - success
+test:   test2:no_suffix:test           - success
+test:   test3                          - success
+deploy: deploy1                        - success
+deploy: deploy2                        - manual
+deploy: deploy3:no_sufix:deploy        - success
+deploy: deploy4                        - success
+deploy: deploy5:really_a_long_name_for - success
+deploy: deploy5                        - success
+deploy: deploy6                        - success
+deploy: deploy7                        - success
+deploy: deploy8                        - success
+deploy: deploy9                        - success
+deploy: deploy10                       - success`)
+
+	assert.Contains(t, out, "Pipeline Status: success")
+}

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -48,16 +48,16 @@ var ciTraceCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		commitSHA = commit.ID
+		pipelineID = commit.LastPipeline.ID
 
-		err = doTrace(context.Background(), os.Stdout, projectID, commitSHA, jobName)
+		err = doTrace(context.Background(), os.Stdout, projectID, pipelineID, jobName)
 		if err != nil {
 			log.Fatal(err)
 		}
 	},
 }
 
-func doTrace(ctx context.Context, w io.Writer, pid interface{}, sha, name string) error {
+func doTrace(ctx context.Context, w io.Writer, pid interface{}, pipelineID int, name string) error {
 	var (
 		once   sync.Once
 		offset int64
@@ -66,7 +66,7 @@ func doTrace(ctx context.Context, w io.Writer, pid interface{}, sha, name string
 		if ctx.Err() == context.Canceled {
 			break
 		}
-		trace, job, err := lab.CITrace(pid, sha, name)
+		trace, job, err := lab.CITrace(pid, pipelineID, name)
 		if err != nil || job == nil || trace == nil {
 			return errors.Wrap(err, "failed to find job")
 		}

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	projectID int
-	refName   string
-	commitSHA string
+	projectID  int
+	refName    string
+	pipelineID int
 )
 
 // ciViewCmd represents the ci command
@@ -67,7 +67,7 @@ Feedback Encouraged!: https://github.com/zaquestion/lab/issues`,
 		if err != nil {
 			log.Fatal(err)
 		}
-		commitSHA = commit.ID
+		pipelineID = commit.LastPipeline.ID
 		root := tview.NewPages()
 		root.SetBorderPadding(1, 1, 2, 2)
 
@@ -177,7 +177,7 @@ func inputCapture(a *tview.Application, root *tview.Pages, navi navigator, input
 			a.Suspend(func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				go func() {
-					err := doTrace(ctx, os.Stdout, projectID, commitSHA, curJob.Name)
+					err := doTrace(ctx, os.Stdout, projectID, pipelineID, curJob.Name)
 					if err != nil {
 						a.Stop()
 						log.Fatal(err)
@@ -336,7 +336,7 @@ func jobsView(app *tview.Application, jobsCh chan []*gitlab.Job, inputCh chan st
 			tv.SetBorderPadding(0, 0, 1, 1).SetBorder(true)
 
 			go func() {
-				err := doTrace(context.Background(), vtclean.NewWriter(tview.ANSIWriter(tv), true), projectID, commitSHA, curJob.Name)
+				err := doTrace(context.Background(), vtclean.NewWriter(tview.ANSIWriter(tv), true), projectID, pipelineID, curJob.Name)
 				if err != nil {
 					app.Stop()
 					log.Fatal(err)
@@ -479,7 +479,7 @@ func updateJobs(app *tview.Application, jobsCh chan []*gitlab.Job) {
 			time.Sleep(time.Second * 1)
 			continue
 		}
-		jobs, err := lab.CIJobs(projectID, commitSHA)
+		jobs, err := lab.CIJobs(projectID, pipelineID)
 		if len(jobs) == 0 || err != nil {
 			app.Stop()
 			log.Fatal(errors.Wrap(err, "failed to find ci jobs"))

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -833,16 +833,9 @@ func (s JobSorter) Less(i, j int) bool {
 	return time.Time(*s.Jobs[i].CreatedAt).Before(time.Time(*s.Jobs[j].CreatedAt))
 }
 
-// CIJobs returns a list of jobs in a pipeline for a given sha. The jobs are
+// CIJobs returns a list of jobs in the pipeline with given id. The jobs are
 // returned sorted by their CreatedAt time
-func CIJobs(pid interface{}, sha string) ([]*gitlab.Job, error) {
-	pipelines, _, err := lab.Pipelines.ListProjectPipelines(pid, &gitlab.ListProjectPipelinesOptions{
-		SHA: gitlab.String(sha),
-	})
-	if len(pipelines) == 0 || err != nil {
-		return nil, err
-	}
-	target := pipelines[0].ID
+func CIJobs(pid interface{}, id int) ([]*gitlab.Job, error) {
 	opts := &gitlab.ListJobsOptions{
 		ListOptions: gitlab.ListOptions{
 			PerPage: 500,
@@ -850,7 +843,7 @@ func CIJobs(pid interface{}, sha string) ([]*gitlab.Job, error) {
 	}
 	list := make([]*gitlab.Job, 0)
 	for {
-		jobs, resp, err := lab.Jobs.ListPipelineJobs(pid, target, opts)
+		jobs, resp, err := lab.Jobs.ListPipelineJobs(pid, id, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -874,8 +867,8 @@ func CIJobs(pid interface{}, sha string) ([]*gitlab.Job, error) {
 // 1. Last Running Job
 // 2. First Pending Job
 // 3. Last Job in Pipeline
-func CITrace(pid interface{}, sha, name string) (io.Reader, *gitlab.Job, error) {
-	jobs, err := CIJobs(pid, sha)
+func CITrace(pid interface{}, id int, name string) (io.Reader, *gitlab.Job, error) {
+	jobs, err := CIJobs(pid, id)
 	if len(jobs) == 0 || err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Gitlab allows setting up pipelines that are associated with a
merge request rather than a branch/tag ("detached")[0].

Merge request pipelines may be created instead of or in addition
to the regular branch/tag pipeline, and can use a different set
of jobs.

When merge request pipelines are used, they control whether a MR
can be merged, so their status is clearly interesting.

Unfortunately if both branch and MR pipelines are enabled, which
one ends up being the last one associated with a commit is random.

Address this by adding an explicit --merge-request flag to the
various ci subcommands to explicitly refer to the detached pipeline.

[0] https://docs.gitlab.com/ee/ci/merge_request_pipelines/#pipelines-for-merge-requests