### PR TITLE
RFC: Use bang to denote MR IDs

### DIFF
--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -54,7 +54,7 @@ var mrApproveCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("Merge Request #%d approved\n", id)
+		fmt.Printf("Merge Request !%d approved\n", id)
 	},
 }
 

--- a/cmd/mr_approve_test.go
+++ b/cmd/mr_approve_test.go
@@ -43,7 +43,7 @@ func Test_mrApprove(t *testing.T) {
 	origOutput := string(b)
 	origOutput = stripansi.Strip(origOutput)
 
-	require.Contains(t, origOutput, `Merge Request #18 approved`)
+	require.Contains(t, origOutput, `Merge Request !18 approved`)
 }
 
 func Test_mrUnapprove(t *testing.T) {
@@ -60,5 +60,5 @@ func Test_mrUnapprove(t *testing.T) {
 	origOutput := string(b)
 	origOutput = stripansi.Strip(origOutput)
 
-	require.Contains(t, origOutput, `Merge Request #18 unapproved`)
+	require.Contains(t, origOutput, `Merge Request !18 unapproved`)
 }

--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -49,7 +49,7 @@ var checkoutCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		if len(mrs) < 1 {
-			fmt.Printf("MR #%d not found\n", mrID)
+			fmt.Printf("MR !%d not found\n", mrID)
 			return
 		}
 

--- a/cmd/mr_close.go
+++ b/cmd/mr_close.go
@@ -31,7 +31,7 @@ var mrCloseCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("Merge Request #%d closed\n", id)
+		fmt.Printf("Merge Request !%d closed\n", id)
 	},
 }
 

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -40,7 +40,7 @@ var listCmd = &cobra.Command{
 			config.UserConfigError()
 		}
 		for _, mr := range mrs {
-			fmt.Printf("#%d %s\n", mr.IID, mr.Title)
+			fmt.Printf("!%d %s\n", mr.IID, mr.Title)
 		}
 	},
 }

--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -22,8 +22,8 @@ func Test_mrListAssignedTo(t *testing.T) {
 
 	mrs := strings.Split(string(b), "\n")
 	t.Log(mrs)
-	require.Contains(t, mrs, "#1 Test MR for lab list")
-	require.NotContains(t, mrs, "#3")
+	require.Contains(t, mrs, "!1 Test MR for lab list")
+	require.NotContains(t, mrs, "!3")
 	require.NotContains(t, mrs, "filtering with labels and lists")
 }
 
@@ -40,7 +40,7 @@ func Test_mrList(t *testing.T) {
 
 	mrs := strings.Split(string(b), "\n")
 	t.Log(mrs)
-	require.Contains(t, mrs, "#1 Test MR for lab list")
+	require.Contains(t, mrs, "!1 Test MR for lab list")
 }
 
 func Test_mrListFlagLabel(t *testing.T) {
@@ -56,7 +56,7 @@ func Test_mrListFlagLabel(t *testing.T) {
 
 	mrs := strings.Split(string(b), "\n")
 	t.Log(mrs)
-	require.Contains(t, mrs, "#3 for testings filtering with labels and lists")
+	require.Contains(t, mrs, "!3 for testings filtering with labels and lists")
 }
 
 func Test_mrListStateMerged(t *testing.T) {
@@ -72,7 +72,7 @@ func Test_mrListStateMerged(t *testing.T) {
 
 	mrs := strings.Split(string(b), "\n")
 	t.Log(mrs)
-	require.Contains(t, mrs, "#4 merged merge request")
+	require.Contains(t, mrs, "!4 merged merge request")
 }
 
 func Test_mrListStateClosed(t *testing.T) {
@@ -88,7 +88,7 @@ func Test_mrListStateClosed(t *testing.T) {
 
 	mrs := strings.Split(string(b), "\n")
 	t.Log(mrs)
-	require.Contains(t, mrs, "#5 closed mr")
+	require.Contains(t, mrs, "!5 closed mr")
 
 }
 
@@ -105,7 +105,7 @@ func Test_mrListFivePerPage(t *testing.T) {
 
 	mrs := strings.Split(string(b), "\n")
 	t.Log(mrs)
-	require.Contains(t, mrs, "#1 Test MR for lab list")
+	require.Contains(t, mrs, "!1 Test MR for lab list")
 }
 
 func Test_mrFilterByTargetBranch(t *testing.T) {
@@ -123,7 +123,7 @@ func Test_mrFilterByTargetBranch(t *testing.T) {
 	assert.Empty(t, mrs, "Expected to find no MRs for non-existent branch")
 }
 
-var latestUpdatedTestMR = "#19 MR for closing and reopening"
+var latestUpdatedTestMR = "!19 MR for closing and reopening"
 
 func Test_mrListByTargetBranch(t *testing.T) {
 	t.Parallel()
@@ -141,7 +141,7 @@ func Test_mrListByTargetBranch(t *testing.T) {
 }
 
 // updated,asc
-// #1
+// !1
 func Test_mrListUpdatedAscending(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
@@ -155,11 +155,11 @@ func Test_mrListUpdatedAscending(t *testing.T) {
 
 	mrs := strings.Split(string(b), "\n")
 	t.Log(mrs)
-	require.Contains(t, mrs, "#3 for testings filtering with labels and lists")
+	require.Contains(t, mrs, "!3 for testings filtering with labels and lists")
 }
 
 // updatead,desc
-// #18
+// !18
 func Test_mrListUpdatedDescending(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
@@ -177,7 +177,7 @@ func Test_mrListUpdatedDescending(t *testing.T) {
 }
 
 // created,asc
-// #1
+// !1
 func Test_mrListCreatedAscending(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
@@ -191,11 +191,11 @@ func Test_mrListCreatedAscending(t *testing.T) {
 
 	mrs := strings.Split(string(b), "\n")
 	t.Log(mrs)
-	require.Contains(t, mrs, "#1 Test MR for lab list")
+	require.Contains(t, mrs, "!1 Test MR for lab list")
 }
 
 // created,desc
-// #18
+// !18
 func Test_mrListCreatedDescending(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)

--- a/cmd/mr_reopen.go
+++ b/cmd/mr_reopen.go
@@ -30,7 +30,7 @@ var mrReopenCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("Merge Request #%d reopened\n", id)
+		fmt.Printf("Merge Request !%d reopened\n", id)
 	},
 }
 

--- a/cmd/mr_reopen_test.go
+++ b/cmd/mr_reopen_test.go
@@ -21,7 +21,7 @@ func Test_mrCloseReopen(t *testing.T) {
 		{
 			desc:     "close-open",
 			opt:      "close",
-			expected: "Merge Request #19 closed",
+			expected: "Merge Request !19 closed",
 		},
 		{
 			desc:     "close-closed",
@@ -31,7 +31,7 @@ func Test_mrCloseReopen(t *testing.T) {
 		{
 			desc:     "reopen-closed",
 			opt:      "reopen",
-			expected: "Merge Request #19 reopened",
+			expected: "Merge Request !19 reopened",
 		},
 	}
 

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -159,7 +159,7 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 	}
 
 	fmt.Printf(`
-#%d %s
+!%d %s
 ===================================
 %s
 -----------------------------------

--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -25,7 +25,7 @@ func Test_mrShow(t *testing.T) {
 
 	out := string(b)
 	require.Contains(t, out, `
-#1 Test MR for lab list
+!1 Test MR for lab list
 ===================================
 This MR is to remain open for testing the `+"`lab mr list`"+` functionality
 -----------------------------------

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -71,7 +71,7 @@ func Test_mrCmd(t *testing.T) {
 		require.Contains(t, out, "Branches: mrtest->master\n")
 		require.Contains(t, out, "Status: Open\n")
 		require.Contains(t, out, "Assignee: lab-testing\n")
-		require.Contains(t, out, fmt.Sprintf("#%s mr title", mrID))
+		require.Contains(t, out, fmt.Sprintf("!%s mr title", mrID))
 		require.Contains(t, out, "===================================")
 		require.Contains(t, outStripped, "mr description")
 		require.Contains(t, out, fmt.Sprintf("WebURL: https://gitlab.com/lab-testing/test/-/merge_requests/%s", mrID))
@@ -88,7 +88,7 @@ func Test_mrCmd(t *testing.T) {
 			t.Log(string(b))
 			t.Fatal(err)
 		}
-		require.Contains(t, string(b), fmt.Sprintf("Merge Request #%s closed", mrID))
+		require.Contains(t, string(b), fmt.Sprintf("Merge Request !%s closed", mrID))
 	})
 }
 
@@ -204,7 +204,7 @@ func Test_mrCmd_MR_description_and_options(t *testing.T) {
 			t.Log(string(b))
 			t.Fatal(err)
 		}
-		require.Contains(t, string(b), fmt.Sprintf("Merge Request #%s closed", mrID))
+		require.Contains(t, string(b), fmt.Sprintf("Merge Request !%s closed", mrID))
 	})
 }
 
@@ -258,7 +258,7 @@ func Test_mrCmd_DifferingUpstreamBranchName(t *testing.T) {
 			t.Log(string(b))
 			t.Fatal(err)
 		}
-		require.Contains(t, string(b), fmt.Sprintf("Merge Request #%s closed", mrID))
+		require.Contains(t, string(b), fmt.Sprintf("Merge Request !%s closed", mrID))
 	})
 }
 

--- a/cmd/mr_thumb.go
+++ b/cmd/mr_thumb.go
@@ -39,7 +39,7 @@ var mrThumbUpCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("Merge Request #%d thumb'd up\n", id)
+		fmt.Printf("Merge Request !%d thumb'd up\n", id)
 	},
 }
 
@@ -63,7 +63,7 @@ var mrThumbDownCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("Merge Request #%d thumb'd down\n", id)
+		fmt.Printf("Merge Request !%d thumb'd down\n", id)
 	},
 }
 

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -54,7 +54,7 @@ var mrUnapproveCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("Merge Request #%d unapproved\n", id)
+		fmt.Printf("Merge Request !%d unapproved\n", id)
 	},
 }
 


### PR DESCRIPTION
In Gitlab's UI, issues appear as #123 and merge requests as !123.
Follow that convention when outputting MR IDs.
