### PR TITLE
mr_show: Fix --patch option with no arguments

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -51,7 +51,7 @@ var mrShowCmd = &cobra.Command{
 		if mrShowPatch {
 			var remote string
 
-			if len(args) == 1 {
+			if len(args) < 2 {
 				remote = findLocalRemote(mr.TargetProjectID)
 			} else if len(args) == 2 {
 				remote = args[0]


### PR DESCRIPTION
The current code still assumes a minimum of one argument (the MR ID),
but we can determine that automatically nowadays.
