### PR TITLE
Support duplicating and reopening issues

### DIFF
--- a/cmd/issue_close.go
+++ b/cmd/issue_close.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -17,6 +18,9 @@ var issueCloseCmd = &cobra.Command{
 	Long:             ``,
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
+	Example: `lab issue close 1234
+lab issue close --duplicate 123 1234
+lab issue close --duplicate other-project#123 1234`,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)
 		if err != nil {
@@ -28,15 +32,28 @@ var issueCloseCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		err = lab.IssueClose(p.ID, int(id))
-		if err != nil {
-			log.Fatal(err)
+		dupId, _ := cmd.Flags().GetString("duplicate")
+		if dupId != "" {
+			if !strings.Contains(dupId, "#") {
+				dupId = "#" + dupId
+			}
+			err = lab.IssueDuplicate(p.ID, int(id), dupId)
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("Issue #%d closed as duplicate of %s\n", id, dupId)
+		} else {
+			err = lab.IssueClose(p.ID, int(id))
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("Issue #%d closed\n", id)
 		}
-		fmt.Printf("Issue #%d closed\n", id)
 	},
 }
 
 func init() {
+	issueCloseCmd.Flags().StringP("duplicate", "", "", "mark as duplicate of another issue")
 	issueCmd.AddCommand(issueCloseCmd)
 	carapace.Gen(issueCloseCmd).PositionalCompletion(
 		action.Remotes(),

--- a/cmd/issue_reopen.go
+++ b/cmd/issue_reopen.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var issueReopenCmd = &cobra.Command{
+	Use:              "reopen [remote] <id>",
+	Short:            "Reopen a closed issue",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, id, err := parseArgsRemoteAndID(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		p, err := lab.FindProject(rn)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = lab.IssueReopen(p.ID, int(id))
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Issue #%d reopened\n", id)
+	},
+}
+
+func init() {
+	issueCmd.AddCommand(issueReopenCmd)
+	carapace.Gen(mrReopenCmd).PositionalCompletion(
+		action.Remotes(),
+		action.Issues(issueList),
+	)
+}

--- a/cmd/issue_reopen_test.go
+++ b/cmd/issue_reopen_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_issueCloseReopen(t *testing.T) {
+	tests := []struct {
+		desc     string
+		opt      string
+		expected string
+	}{
+		{
+			desc:     "reopen-open",
+			opt:      "reopen",
+			expected: "issue not closed",
+		},
+		{
+			desc:     "close-open",
+			opt:      "close",
+			expected: "Issue #1 closed",
+		},
+		{
+			desc:     "close-closed",
+			opt:      "close",
+			expected: "issue already closed",
+		},
+		{
+			desc:     "reopen-closed",
+			opt:      "reopen",
+			expected: "Issue #1 reopened",
+		},
+	}
+
+	repo := copyTestRepo(t)
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			cmd := exec.Command(labBinaryPath, "issue", test.opt, "1")
+			cmd.Dir = repo
+
+			b, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Log(string(b))
+			}
+
+			out := string(b)
+			require.Contains(t, out, test.expected)
+		})
+	}
+}

--- a/cmd/issue_test.go
+++ b/cmd/issue_test.go
@@ -76,6 +76,48 @@ func Test_issueCmd(t *testing.T) {
 	})
 }
 
+func Test_issueCmdDuplicate(t *testing.T) {
+	var issueID string
+	t.Run("create", func(t *testing.T) {
+		repo := copyTestRepo(t)
+		cmd := exec.Command(labBinaryPath, "issue", "create", "lab-testing",
+			"-m", "issue title",
+			"-m", "issue description",
+			"-l", "bug",
+			"-l", "critical",
+			"-a", "lab-testing")
+		cmd.Dir = repo
+
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Log(string(b))
+			t.Fatal(err)
+		}
+
+		out := string(b)
+		require.Contains(t, out, "https://gitlab.com/lab-testing/test/-/issues/")
+
+		i := strings.Index(out, "\n")
+		issueID = strings.TrimPrefix(out[:i], "https://gitlab.com/lab-testing/test/-/issues/")
+		t.Log(issueID)
+	})
+	t.Run("close", func(t *testing.T) {
+		if issueID == "" {
+			t.Skip("issueID is empty, create likely failed")
+		}
+		repo := copyTestRepo(t)
+		cmd := exec.Command(labBinaryPath, "issue", "close", "lab-testing", "--duplicate", "1", issueID)
+		cmd.Dir = repo
+
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Log(string(b))
+			t.Fatal(err)
+		}
+		require.Contains(t, string(b), fmt.Sprintf("Issue #%s closed as duplicate", issueID))
+	})
+}
+
 func Test_issueCmd_noArgs(t *testing.T) {
 	repo := copyTestRepo(t)
 	cmd := exec.Command(labBinaryPath, "issue")

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -604,6 +604,25 @@ func IssueClose(pid interface{}, id int) error {
 	return nil
 }
 
+// IssueDuplicate closes an issue as duplicate of another
+func IssueDuplicate(pid interface{}, id int, dupId string) error {
+	// Not exposed in API, go through quick action
+	body := "/duplicate " + dupId
+
+	_, _, err := lab.Notes.CreateIssueNote(pid, id, &gitlab.CreateIssueNoteOptions{
+		Body: &body,
+	})
+	if err != nil {
+		return errors.Errorf("Failed to close issue #%d as duplicate of %s", id, dupId)
+	}
+
+	issue, _, err := lab.Issues.GetIssue(pid, id)
+	if issue == nil || issue.State != "closed" {
+		return errors.Errorf("Failed to close issue #%d as duplicate of %s", id, dupId)
+	}
+	return nil
+}
+
 // IssueReopen reopens a closed issue
 func IssueReopen(pid interface{}, id int) error {
 	issue, _, err := lab.Issues.GetIssue(pid, id)

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -604,6 +604,24 @@ func IssueClose(pid interface{}, id int) error {
 	return nil
 }
 
+// IssueReopen reopens a closed issue
+func IssueReopen(pid interface{}, id int) error {
+	issue, _, err := lab.Issues.GetIssue(pid, id)
+	if err != nil {
+		return err
+	}
+	if issue.State == "opened" {
+		return fmt.Errorf("issue not closed")
+	}
+	_, _, err = lab.Issues.UpdateIssue(pid, id, &gitlab.UpdateIssueOptions{
+		StateEvent: gitlab.String("reopen"),
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // IssueListDiscussions retrieves the discussions (aka notes & comments) for an issue
 func IssueListDiscussions(project string, issueNum int) ([]*gitlab.Discussion, error) {
 	p, err := FindProject(project)

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -588,7 +588,14 @@ func IssueList(project string, opts gitlab.ListProjectIssuesOptions, n int) ([]*
 
 // IssueClose closes an issue on a GitLab project
 func IssueClose(pid interface{}, id int) error {
-	_, _, err := lab.Issues.UpdateIssue(pid, id, &gitlab.UpdateIssueOptions{
+	issue, _, err := lab.Issues.GetIssue(pid, id)
+	if err != nil {
+		return err
+	}
+	if issue.State == "closed" {
+		return fmt.Errorf("issue already closed")
+	}
+	_, _, err = lab.Issues.UpdateIssue(pid, id, &gitlab.UpdateIssueOptions{
 		StateEvent: gitlab.String("close"),
 	})
 	if err != nil {


### PR DESCRIPTION
Right now there's support for reopening merge requests, but not issues.

Plus when closing an issue, it can be useful to mark it as a duplicate of another issue.
