### PR TITLE
util: Always override config file flags from the command line

### DIFF
--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -43,6 +43,7 @@ var ciViewCmd = &cobra.Command{
 Supports vi style (hjkl,Gg) bindings and arrow keys for navigating jobs and logs.
 
 Feedback Encouraged!: https://github.com/zaquestion/lab/issues`,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		a := tview.NewApplication()
 		defer recoverPanic(a)

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -26,6 +26,7 @@ lab MR edit <id> -m "new title"                 # update title
 lab MR edit <id> -m "new title" -m "new desc"   # update title & description
 lab MR edit <id> -l newlabel --unlabel oldlabel # relabel MR
 lab MR edit <id>:<comment_id>                   # update a comment on MR`,
+	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, idString, err := parseArgsRemoteAndProject(args)
 		if err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -380,3 +380,30 @@ func Test_flag_config_TF(t *testing.T) {
 	// both configs set to true, comments should be output
 	require.Contains(t, string(b), `commented at`)
 }
+
+// flag (explicitly) unset, config true == no comments
+func Test_flag_config_FT(t *testing.T) {
+	repo := copyTestRepo(t)
+
+	err := setConfigValues(repo, "true", "true")
+	if err != nil {
+		t.Skip(err)
+	}
+	os.Remove(repo + "/lab.toml")
+
+	cmd := exec.Command(labBinaryPath, "mr", "show", "1", "--comments=false")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	out := string(b)
+	out = stripansi.Strip(out)
+
+	os.Remove("/home/travis/.config/lab/lab.toml")
+	// configs overridden on the command line, comments should not be output
+	require.NotContains(t, string(b), `commented at`)
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -56,7 +56,7 @@ func flagConfig(fs *flag.FlagSet) {
 		}
 
 		// if set, always use the command line option (flag) value
-		if f.Value.String() != f.DefValue {
+		if f.Changed {
 			return
 		}
 		// o/w use the value in the configfile


### PR DESCRIPTION
Currently we check whether a flag's current value differs from its
default in order to skip the value from the config file. That works
in most cases, but as a result it is not possible to override a value
from the config by explicitly passing the default value:

  [mr_show]
  comments = true

  $ lab mr show --comments=false

Fix this by checking the flag's Changed property instead.
