### PR TITLE
ci: Handle job names with colons in filterJobArg()

### DIFF
--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -123,7 +123,7 @@ func filterJobArg(args []string) (string, []string, error) {
 	}
 
 	if strings.Contains(jobName, ":") {
-		ps := strings.Split(jobName, ":")
+		ps := strings.SplitN(jobName, ":", 2)
 		branchArgs = append(branchArgs, ps[0])
 		jobName = ps[1]
 	}


### PR DESCRIPTION
When splitting an argument into branch and job name, we assume that
the string only contains a single ':'. It's a legal character in
job names though, so handle that edge case by limiting the number
of substrings.
