### PR TITLE
Disable flag sorting for some commands

### DIFF
--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -308,6 +308,7 @@ func init() {
 	issueEditCmd.Flags().StringSliceP("assign", "a", []string{}, "add an assignee by username")
 	issueEditCmd.Flags().StringSliceP("unassign", "", []string{}, "remove an assignee by username")
 	issueEditCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
+	issueEditCmd.Flags().SortFlags = false
 
 	issueCmd.AddCommand(issueEditCmd)
 	carapace.Gen(issueEditCmd).PositionalCompletion(

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -207,6 +207,7 @@ func init() {
 	mrEditCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	mrEditCmd.Flags().Bool("draft", false, "mark the merge request as draft")
 	mrEditCmd.Flags().Bool("ready", false, "mark the merge request as ready")
+	mrEditCmd.Flags().SortFlags = false
 
 	mrCmd.AddCommand(mrEditCmd)
 	carapace.Gen(mrEditCmd).PositionalCompletion(

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -117,6 +117,7 @@ func init() {
 	listCmd.Flags().StringVar(&sortedBy, "sort", "desc", "sort order, desc(default) or asc")
 	listCmd.Flags().BoolVarP(&mrDraft, "draft", "", false, "list MRs marked as draft")
 	listCmd.Flags().BoolVarP(&mrReady, "ready", "", false, "list MRs not marked as draft")
+	listCmd.Flags().SortFlags = false
 
 	mrCmd.AddCommand(listCmd)
 	carapace.Gen(listCmd).FlagCompletion(carapace.ActionMap{

--- a/cmd/project_list.go
+++ b/cmd/project_list.go
@@ -61,4 +61,5 @@ func init() {
 	projectListCmd.Flags().BoolVar(&projectListConfig.Membership, "member", false, "limit by projects which you are a member")
 	projectListCmd.Flags().BoolVar(&projectListConfig.Starred, "starred", false, "limit by your starred projects")
 	projectListCmd.Flags().IntVarP(&projectListConfig.Number, "number", "n", 100, "number of projects to return")
+	projectListCmd.Flags().SortFlags = false
 }


### PR DESCRIPTION
By default, flags are sorted alphabetically. However there are some
cases where it makes more sense to group related flags together,
like --label/--unlabel, --assign/--unassign or --draft/--ready.

Disable flag sorting in those cases.
