### PR TITLE
ci_artifacts: Allow downloading artifact(s)

### DIFF
--- a/cmd/ci_artifacts.go
+++ b/cmd/ci_artifacts.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var ciArtifactsCmd = &cobra.Command{
+	Use:              "artifacts [remote [[branch:]job]]",
+	Short:            "Download artifacts of a ci job",
+	Long:             `If a job is not specified the latest job with artifacts is used`,
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		var (
+			rn      string
+			jobName string
+			err     error
+		)
+		jobName, branchArgs, err := filterJobArg(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		forMR, err := cmd.Flags().GetBool("merge-request")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		path, err := cmd.Flags().GetString("artifact-path")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		rn, pipelineID, err := getPipelineFromArgs(branchArgs, forMR)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		project, err := lab.FindProject(rn)
+		if err != nil {
+			log.Fatal(err)
+		}
+		projectID := project.ID
+
+		r, outpath, err := lab.CIArtifacts(projectID, pipelineID, jobName, path)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		dst, err := os.Create(outpath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		_, err = io.Copy(dst, r)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf("Downloaded %s\n", outpath)
+	},
+}
+
+func init() {
+	ciArtifactsCmd.Flags().Bool("merge-request", false, "use merge request pipeline if enabled")
+	ciArtifactsCmd.Flags().StringP("artifact-path", "p", "", "only download specified file from archive")
+	ciCmd.AddCommand(ciArtifactsCmd)
+	carapace.Gen(ciArtifactsCmd).PositionalCompletion(
+		action.Remotes(),
+		action.RemoteBranches(0),
+	)
+}

--- a/cmd/ci_artifacts_test.go
+++ b/cmd/ci_artifacts_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ciArtifacts(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command("git", "fetch", "origin")
+	cmd.Dir = repo
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command(labBinaryPath, "ci", "artifacts", "origin", "master:build3:artifacts")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+	out := string(b)
+	assert.Contains(t, out, "Downloaded artifacts.zip")
+}
+
+func Test_ciArtifactsPath(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command("git", "fetch", "origin")
+	cmd.Dir = repo
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command(labBinaryPath, "ci", "artifacts", "-p", "artifact", "origin", "master:build3:artifacts")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+	out := string(b)
+	assert.Contains(t, out, "Downloaded artifact")
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1049,12 +1049,67 @@ func CITrace(pid interface{}, id int, name string) (io.Reader, *gitlab.Job, erro
 	if job == nil {
 		job = jobs[len(jobs)-1]
 	}
+
 	r, _, err := lab.Jobs.GetTraceFile(pid, job.ID)
 	if err != nil {
 		return nil, job, err
 	}
 
 	return r, job, err
+}
+
+// CIArtifacts searches by name for a job and returns its artifacts archive
+// together with the upstream filename. If path is specified and refers to
+// a single file within the artifacts archive, that file is returned instead.
+// If no name is provided, the last job with an artifacts file is picked.
+func CIArtifacts(pid interface{}, id int, name, path string) (io.Reader, string, error) {
+	jobs, err := CIJobs(pid, id)
+	if len(jobs) == 0 || err != nil {
+		return nil, "", err
+	}
+	var (
+		job               *gitlab.Job
+		lastWithArtifacts *gitlab.Job
+	)
+
+	for _, j := range jobs {
+		if j.ArtifactsFile.Filename != "" {
+			lastWithArtifacts = j
+		}
+		if j.Name == name {
+			job = j
+			// don't break because there may be a newer version of the job
+		}
+	}
+	if job == nil {
+		job = lastWithArtifacts
+	}
+	if job == nil {
+		return nil, "", fmt.Errorf("Could not find any jobs with artifacts")
+	}
+
+	var (
+		r       io.Reader
+		outpath string
+	)
+
+	if job.ArtifactsFile.Filename == "" {
+		return nil, "", fmt.Errorf("Job %d has no artifacts", job.ID)
+	}
+
+	if path != "" {
+		r, _, err = lab.Jobs.DownloadSingleArtifactsFile(pid, job.ID, path, nil)
+		outpath = filepath.Base(path)
+	} else {
+		r, _, err = lab.Jobs.GetJobArtifacts(pid, job.ID, nil)
+		outpath = job.ArtifactsFile.Filename
+	}
+
+	if err != nil {
+		return nil, "", err
+	}
+
+	return r, outpath, nil
 }
 
 // CIPlayOrRetry runs a job either by playing it for the first time or by


### PR DESCRIPTION
Quoting the commit message:

    Pipeline jobs can produce files that are uploaded to gitlab and made
    available for download.

    Support this with a new `ci artifacts` subcommand, which either
    downloads the entire artifacts archive, or a singe file from
    that archive when the --artifact-path option is used.

I originally implemented the single-artifact case as positional argument
as discussed in #232, i.e. "remote branch:job path", but then decided
against it:

 - I like how `lab` generally does the right thing when a positional
   argument is omitted, but that's tricky when there are four of them;
   in particular job name and path are problematic, as those are just
   arbitrary strings as far as we know

 - command line flags can be set up in the config file (for example
   if the pipeline only produces a single "interesting" artifact)

The new test case uses the new job added in
https://gitlab.com/zaquestion/test/-/merge_requests/22,
so for now it's expected to fail.

Fixes #232