### PR TITLE
Improve comments appearance

### DIFF
--- a/cmd/issue_note_test.go
+++ b/cmd/issue_note_test.go
@@ -80,7 +80,8 @@ func Test_issueReplyNote(t *testing.T) {
 	noteID := noteIDs[1]
 
 	// add reply to the noteID
-	reply := exec.Command(labBinaryPath, "issue", "reply", "lab-testing", issueID+":"+noteID, "-m", "reply to note")
+	reply := exec.Command(labBinaryPath, "issue", "reply", "lab-testing", issueID+":"+noteID,
+		"-m", "reply to note", "-m", "second reply paragraph")
 	reply.Dir = repo
 	c, err := reply.CombinedOutput()
 	if err != nil {
@@ -101,6 +102,8 @@ func Test_issueReplyNote(t *testing.T) {
 
 	require.Contains(t, string(d), "#"+noteID+": "+"lab-testing started a discussion")
 	require.Contains(t, string(d), "#"+replyID+": "+"lab-testing commented at")
+	require.Contains(t, string(d), "    reply to note")
+	require.Contains(t, string(d), "    second reply paragraph")
 }
 
 func Test_issueNoteText(t *testing.T) {

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -319,16 +319,22 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 				OmitLinks:    true,
 			}
 			noteBody, _ = html2text.FromString(noteBody, html2textOptions)
-			noteBody = strings.Replace(noteBody, "\n", "\n"+indentNote, -1)
 			printit := color.New().PrintfFunc()
 			if note.System {
+				splitNote := strings.SplitN(noteBody, "\n", 2)
+
 				// system notes are informational messages only
 				// and cannot have replies.  Do not output the
 				// note.ID
 				printit(`
 * %s %s at %s
 `,
-					note.Author.Username, noteBody, time.Time(*note.UpdatedAt).String())
+					note.Author.Username, splitNote[0], time.Time(*note.UpdatedAt).String())
+				if len(splitNote) == 2 {
+					printit(`%s
+`,
+						splitNote[1])
+				}
 				continue
 			}
 
@@ -340,6 +346,9 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 			if time.Time(*note.UpdatedAt).After(CompareTime) {
 				printit = color.New(color.Bold).PrintfFunc()
 			}
+
+			noteBody = strings.Replace(noteBody, "\n", "\n"+indentNote, -1)
+
 			printit(`%s#%d: %s %s at %s
 
 `,

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -313,7 +313,7 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 				}
 			}
 
-			noteBody := strings.Replace(note.Body, "\n", "<br>\n"+indentHeader, -1)
+			noteBody := strings.Replace(note.Body, "\n", "<br>\n"+indentNote, -1)
 			html2textOptions := html2text.Options{
 				PrettyTables: true,
 				OmitLinks:    true,

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -333,13 +333,14 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 			}
 
 			printit(`
-%s-----------------------------------`, indentHeader)
+%s-----------------------------------
+`,
+				indentHeader)
 
 			if time.Time(*note.UpdatedAt).After(CompareTime) {
 				printit = color.New(color.Bold).PrintfFunc()
 			}
-			printit(`
-%s#%d: %s %s at %s
+			printit(`%s#%d: %s %s at %s
 
 `,
 				indentHeader, note.ID, note.Author.Username, commented, time.Time(*note.UpdatedAt).String())

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -313,12 +313,13 @@ func PrintDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 				}
 			}
 
-			noteBody := strings.Replace(note.Body, "\n", "<br>\n"+indentNote, -1)
+			noteBody := strings.Replace(note.Body, "\n", "<br>\n", -1)
 			html2textOptions := html2text.Options{
 				PrettyTables: true,
 				OmitLinks:    true,
 			}
 			noteBody, _ = html2text.FromString(noteBody, html2textOptions)
+			noteBody = strings.Replace(noteBody, "\n", "\n"+indentNote, -1)
 			printit := color.New().PrintfFunc()
 			if note.System {
 				// system notes are informational messages only

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -80,7 +80,7 @@ var mrShowCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 
-			PrintDiscussions(discussions, since, "mr", int(mrNum))
+			PrintDiscussions(discussions, since, "mr", int(mrNum), renderMarkdown)
 		}
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.4 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/muesli/reflow v0.2.0 // indirect
-	github.com/muesli/termenv v0.7.4 // indirect
+	github.com/muesli/termenv v0.7.4
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
A couple of minor fixes and tweaks, and a bigger one: Render markdown in comments as we do for the desciption.

The last change means that only the header line of new comments is printed in bold, but IMHO this is enough for them to stand out.

And the readability improvement is quite significant:

![Screenshot from 2020-12-23 12-51-08](https://user-images.githubusercontent.com/80701/102993801-2199e000-451e-11eb-87ca-dcc7347bae30.png)

