### PR TITLE
RFC: Figure out issue automatically if possible

### DIFF
--- a/cmd/issue_browse.go
+++ b/cmd/issue_browse.go
@@ -20,7 +20,7 @@ var issueBrowseCmd = &cobra.Command{
 	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, num, err := parseArgsRemoteAndID(args)
+		rn, num, err := parseArgsRemoteAndIssueID(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_close.go
+++ b/cmd/issue_close.go
@@ -22,7 +22,7 @@ var issueCloseCmd = &cobra.Command{
 lab issue close --duplicate 123 1234
 lab issue close --duplicate other-project#123 1234`,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, id, err := parseArgsRemoteAndID(args)
+		rn, id, err := parseArgsRemoteAndIssueID(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -32,23 +32,16 @@ lab issue edit <id>:<comment_id>                   # update a comment on MR`,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		rn, idString, err := parseArgsRemoteAndProject(args)
+		commentNum, branchArgs, err := filterCommentArg(args)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		var (
-			issueNum   int = 0
-			commentNum int = 0
-		)
-
-		if strings.Contains(idString, ":") {
-			ids := strings.Split(idString, ":")
-			issueNum, _ = strconv.Atoi(ids[0])
-			commentNum, _ = strconv.Atoi(ids[1])
-		} else {
-			issueNum, _ = strconv.Atoi(idString)
+		rn, id, err := parseArgsRemoteAndIssueID(branchArgs)
+		if err != nil {
+			log.Fatal(err)
 		}
+		issueNum := int(id)
 
 		issue, err := lab.IssueGet(rn, issueNum)
 		if err != nil {

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -24,7 +24,6 @@ var issueNoteCmd = &cobra.Command{
 	Aliases:          []string{"comment", "reply"},
 	Short:            "Add a note or comment to an issue on GitLab",
 	Long:             ``,
-	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run:              NoteRunFn,
 }
@@ -55,7 +54,7 @@ func NoteRunFn(cmd *cobra.Command, args []string) {
 		idNum = int(mrNum)
 		rn = s
 	} else {
-		s, issueNum, _ := parseArgsRemoteAndID(branchArgs)
+		s, issueNum, _ := parseArgsRemoteAndIssueID(branchArgs)
 		if issueNum == 0 {
 			fmt.Println("Error: Cannot determine issue id.")
 			os.Exit(1)

--- a/cmd/issue_reopen.go
+++ b/cmd/issue_reopen.go
@@ -16,7 +16,7 @@ var issueReopenCmd = &cobra.Command{
 	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, id, err := parseArgsRemoteAndID(args)
+		rn, id, err := parseArgsRemoteAndIssueID(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -31,7 +31,7 @@ var issueShowCmd = &cobra.Command{
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		rn, issueNum, err := parseArgsRemoteAndID(args)
+		rn, issueNum, err := parseArgsRemoteAndIssueID(args)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_show_test.go
+++ b/cmd/issue_show_test.go
@@ -59,3 +59,36 @@ func Test_issueShow_updated_comments(t *testing.T) {
 
 	require.Contains(t, string(b), `updated comment at`)
 }
+
+func Test_issueShowByMR(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "mr", "edit",
+		"-m", "Test MR for lab list", "-m", "Closes #1", "1")
+	cmd.Dir = repo
+
+	err := cmd.Run()
+	if err != nil {
+		t.Error(err)
+	}
+
+	cmd = exec.Command(labBinaryPath, "issue", "show", "mrtest")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+
+	cmd = exec.Command(labBinaryPath, "mr", "edit",
+		"-m", "Test MR for lab list",
+		"-m", "This MR is to remain open for testing the `lab mr list` functionality", "1")
+	cmd.Dir = repo
+
+	_ = cmd.Run()
+
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	out := string(b)
+	require.Contains(t, out, "WebURL: https://gitlab.com/zaquestion/test/-/issues/1")
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -259,6 +259,29 @@ func parseArgsRemoteAndString(args []string) (string, string, error) {
 	return remote, str, nil
 }
 
+func parseArgsRemoteAndIssueID(args []string) (string, int64, error) {
+	var (
+		rn       string
+		issueNum int64
+		mrId     int64
+		err      error
+	)
+
+	rn, issueNum, err = parseArgsRemoteAndID(args)
+	if issueNum == 0 {
+		rn, mrId, err = parseArgsWithGitBranchMR(args)
+		if mrId != 0 {
+			issues, _ := lab.ListIssuesClosedOnMerge(rn, int(mrId))
+			if len(issues) > 0 {
+				issueNum = int64(issues[0])
+			} else {
+				err = errors.Errorf("Failed to find issue for MR %d", mrId)
+			}
+		}
+	}
+	return rn, issueNum, err
+}
+
 // parseArgsWithGitBranchMR returns a remote name and a number if parsed.
 // If no number is specified, the MR id associated with the given branch
 // is returned, using the current branch as fallback.


### PR DESCRIPTION
If no issue number is specified on the command line, we may still
get one if we find a MR request associated with the current branch,
and that MR is set to close an issue.

This is a follow-up from #541, but I kept it out of that pull request
because I'm much less convinced that it's a good idea. It *can* be convenient,
but also surprising and confusing ...
