### PR TITLE
cmd: Pipe output through pager in terminals

### DIFF
--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -43,6 +43,9 @@ lab ci status --wait`,
 
 		pid := rn
 
+		pager := NewPager(cmd.Flags())
+		defer pager.Close()
+
 		w := tabwriter.NewWriter(os.Stdout, 2, 4, 1, byte(' '), 0)
 
 		wait, err := cmd.Flags().GetBool("wait")

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -53,6 +53,9 @@ var ciTraceCmd = &cobra.Command{
 		}
 		projectID = project.ID
 
+		pager := NewPager(cmd.Flags())
+		defer pager.Close()
+
 		err = doTrace(context.Background(), os.Stdout, projectID, pipelineID, jobName)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -37,6 +37,10 @@ lab issue list remote "search terms"  # search "remote" for issues with "search 
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		pager := NewPager(cmd.Flags())
+		defer pager.Close()
+
 		for _, issue := range issues {
 			fmt.Printf("#%d %s\n", issue.IID, issue.Title)
 		}

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -42,6 +42,9 @@ var issueShowCmd = &cobra.Command{
 			renderMarkdown = !noMarkdown
 		}
 
+		pager := NewPager(cmd.Flags())
+		defer pager.Close()
+
 		printIssue(issue, rn, renderMarkdown)
 
 		showComments, _ := cmd.Flags().GetBool("comments")

--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -35,6 +35,9 @@ lab label list remote "search term"  # search "remote" for labels with "search t
 			log.Fatal(err)
 		}
 
+		pager := NewPager(cmd.Flags())
+		defer pager.Close()
+
 		for _, label := range labels {
 			// GitLab API has no search for labels, so we do it ourselves
 			if labelSearch != "" &&

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -50,6 +50,10 @@ lab mr list remote "search terms"  # search "remote" for merge requests with "se
 			log.Print(err)
 			config.UserConfigError()
 		}
+
+		pager := NewPager(cmd.Flags())
+		defer pager.Close()
+
 		for _, mr := range mrs {
 			fmt.Printf("!%d %s\n", mr.IID, mr.Title)
 		}

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -65,6 +65,9 @@ var mrShowCmd = &cobra.Command{
 			}
 			git.Show(remote+"/"+mr.TargetBranch, mr.SHA, mrShowPatchReverse)
 		} else {
+			pager := NewPager(cmd.Flags())
+			defer pager.Close()
+
 			printMR(mr, rn, renderMarkdown)
 		}
 

--- a/cmd/project_list.go
+++ b/cmd/project_list.go
@@ -48,6 +48,10 @@ var projectListCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		pager := NewPager(cmd.Flags())
+		defer pager.Close()
+
 		for _, p := range projects {
 			fmt.Println(p.PathWithNamespace)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -102,6 +102,7 @@ func init() {
 	RootCmd.SetHelpCommand(helpCmd)
 	RootCmd.SetHelpFunc(helpFunc)
 	RootCmd.Flags().Bool("version", false, "Show the lab version")
+	RootCmd.PersistentFlags().Bool("no-pager", false, "Do not pipe output into a pager")
 }
 
 var (

--- a/cmd/snippet_list.go
+++ b/cmd/snippet_list.go
@@ -28,6 +28,8 @@ var snippetListCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
+		pager := NewPager(cmd.Flags())
+		defer pager.Close()
 		for _, snip := range snips {
 			fmt.Printf("#%d %s\n", snip.ID, snip.Title)
 		}


### PR DESCRIPTION
Replicate git's behavior of piping output through a pager when it
doesn't fit a single screen. This is not only more convenient than
piping into less on the command line, but preserves terminal features
like colored output as well.

I do have a local follow-up to add a global --no-pager option like git
as well, if that's wanted (not sure that's the case, so leaving it out
right now)
