### PR TITLE
labels: Support partial label names

### DIFF
--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -34,7 +34,7 @@ var issueCreateCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		labels, err := cmd.Flags().GetStringSlice("label")
+		labelTerms, err := cmd.Flags().GetStringSlice("label")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -53,6 +53,11 @@ var issueCreateCmd = &cobra.Command{
 			}
 		}
 		rn, err := git.PathWithNameSpace(remote)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		labels, err := MapLabels(rn, labelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -67,13 +67,21 @@ lab issue edit <id>:<comment_id>                   # update a comment on MR`,
 		}
 
 		// get the labels to add
-		labels, err := cmd.Flags().GetStringSlice("label")
+		labelTerms, err := cmd.Flags().GetStringSlice("label")
+		if err != nil {
+			log.Fatal(err)
+		}
+		labels, err := MapLabels(rn, labelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		// get the labels to remove
-		unlabels, err := cmd.Flags().GetStringSlice("unlabel")
+		unlabelTerms, err := cmd.Flags().GetStringSlice("unlabel")
+		if err != nil {
+			log.Fatal(err)
+		}
+		unlabels, err := MapLabels(rn, unlabelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_edit_test.go
+++ b/cmd/issue_edit_test.go
@@ -70,7 +70,7 @@ func Test_issueEditLabels(t *testing.T) {
 
 	// update the issue
 	cmd := exec.Command(labBinaryPath, "issue", "edit", "lab-testing", issueNum,
-		"-l", "critical", "--unlabel", "bug")
+		"-l", "crit", "--unlabel", "bug")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -46,11 +46,16 @@ func issueList(args []string) ([]*gitlab.Issue, error) {
 		return nil, err
 	}
 
+	labels, err := MapLabels(rn, issueLabels)
+	if err != nil {
+		return nil, err
+	}
+
 	opts := gitlab.ListProjectIssuesOptions{
 		ListOptions: gitlab.ListOptions{
 			PerPage: issueNumRet,
 		},
-		Labels:  issueLabels,
+		Labels:  labels,
 		State:   &issueState,
 		OrderBy: gitlab.String("updated_at"),
 	}

--- a/cmd/label_create.go
+++ b/cmd/label_create.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	gitlab "github.com/xanzy/go-gitlab"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var labelCreateCmd = &cobra.Command{
+	Use:     "create [remote] <name>",
+	Aliases: []string{"add"},
+	Short:   "Create a new label",
+	Long:    ``,
+	Example: `lab label create my-label
+lab label create --color cornflowerblue --description "Blue as a cornflower" blue
+lab label create --color #6495ed --description "Also blue as a cornflower" blue2`,
+	PersistentPreRun: LabPersistentPreRun,
+	Args:             cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, name, err := parseArgsRemoteAndProject(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		color, err := cmd.Flags().GetString("color")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		desc, err := cmd.Flags().GetString("description")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = lab.LabelCreate(rn, &gitlab.CreateLabelOptions{
+			Name:        &name,
+			Description: &desc,
+			Color:       &color,
+		})
+
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	labelCreateCmd.Flags().String("color", "#428BCA", "color of the new label in HTML hex notation or CSS color name")
+	labelCreateCmd.Flags().String("description", "", "description of the new label")
+	labelCmd.AddCommand(labelCreateCmd)
+	carapace.Gen(labelCmd).PositionalCompletion(
+		action.Remotes(),
+	)
+}

--- a/cmd/label_delete.go
+++ b/cmd/label_delete.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var labelDeleteCmd = &cobra.Command{
+	Use:              "delete [remote] <name>",
+	Aliases:          []string{"remove"},
+	Short:            "Deletes an existing label",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
+	Args:             cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, name, err := parseArgsRemoteAndProject(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		labels, err := MapLabels(rn, []string{name})
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = lab.LabelDelete(rn, labels[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	labelCmd.AddCommand(labelDeleteCmd)
+	carapace.Gen(labelCmd).PositionalCompletion(
+		action.Remotes(),
+	)
+}

--- a/cmd/label_test.go
+++ b/cmd/label_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_labelCmd(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	t.Run("prepare", func(t *testing.T) {
+		cmd := exec.Command("sh", "-c", labBinaryPath+` label list lab-testing | grep -q 'test-label' && `+labBinaryPath+` label delete test-label`)
+		cmd.Dir = repo
+
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Log(string(b))
+			//t.Fatal(err)
+		}
+	})
+	t.Run("create", func(t *testing.T) {
+		cmd := exec.Command(labBinaryPath, "label", "create", "lab-testing", "test-label",
+			"--color", "crimson",
+			"--description", "Reddish test label",
+		)
+		cmd.Dir = repo
+
+		_ = cmd.Run()
+
+		cmd = exec.Command(labBinaryPath, "label", "list", "lab-testing")
+		cmd.Dir = repo
+
+		b, err := cmd.CombinedOutput()
+		out := string(b)
+		if err != nil {
+			t.Log(out)
+			//t.Fatal(err)
+		}
+		require.Contains(t, out, "test-label")
+	})
+	t.Run("delete", func(t *testing.T) {
+		cmd := exec.Command(labBinaryPath, "label", "delete", "lab-testing", "test-label")
+		cmd.Dir = repo
+
+		_ = cmd.Run()
+
+		cmd = exec.Command(labBinaryPath, "label", "list", "lab-testing")
+		cmd.Dir = repo
+
+		b, err := cmd.CombinedOutput()
+		out := string(b)
+		if err != nil {
+			t.Log(out)
+			//t.Fatal(err)
+		}
+		require.NotContains(t, out, "test-label")
+	})
+}

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -215,7 +215,11 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	squash, _ := cmd.Flags().GetBool("squash")
 	allowCollaboration, _ := cmd.Flags().GetBool("allow-collaboration")
 
-	labels, err := cmd.Flags().GetStringSlice("label")
+	labelTerms, err := cmd.Flags().GetStringSlice("label")
+	if err != nil {
+		log.Fatal(err)
+	}
+	labels, err := MapLabels(targetProjectName, labelTerms)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -62,13 +62,21 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 		}
 
 		// get the labels to add
-		labels, err := cmd.Flags().GetStringSlice("label")
+		labelTerms, err := cmd.Flags().GetStringSlice("label")
+		if err != nil {
+			log.Fatal(err)
+		}
+		labels, err := MapLabels(rn, labelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		// get the labels to remove
-		unlabels, err := cmd.Flags().GetStringSlice("unlabel")
+		unlabelTerms, err := cmd.Flags().GetStringSlice("unlabel")
+		if err != nil {
+			log.Fatal(err)
+		}
+		unlabels, err := MapLabels(rn, unlabelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -53,6 +53,11 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 		return nil, err
 	}
 
+	labels, err := MapLabels(rn, mrLabels)
+	if err != nil {
+		return nil, err
+	}
+
 	num := mrNumRet
 	if mrAll {
 		num = -1
@@ -80,7 +85,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 		ListOptions: gitlab.ListOptions{
 			PerPage: mrNumRet,
 		},
-		Labels:       mrLabels,
+		Labels:       labels,
 		State:        &mrState,
 		TargetBranch: &mrTargetBranch,
 		OrderBy:      orderBy,

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -777,6 +777,19 @@ func LabelCreate(project string, opts *gitlab.CreateLabelOptions) error {
 	return err
 }
 
+// LabelDelete removes a project label
+func LabelDelete(project, name string) error {
+	p, err := FindProject(project)
+	if err != nil {
+		return err
+	}
+
+	_, err = lab.Labels.DeleteLabel(p.ID, &gitlab.DeleteLabelOptions{
+		Name: &name,
+	})
+	return err
+}
+
 // ProjectSnippetCreate creates a snippet in a project
 func ProjectSnippetCreate(pid interface{}, opts *gitlab.CreateProjectSnippetOptions) (*gitlab.Snippet, error) {
 	snip, _, err := lab.ProjectSnippets.CreateSnippet(pid, opts)

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -766,6 +766,17 @@ func LabelList(project string) ([]*gitlab.Label, error) {
 	return labels, nil
 }
 
+// LabelCreate creates a new project label
+func LabelCreate(project string, opts *gitlab.CreateLabelOptions) error {
+	p, err := FindProject(project)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = lab.Labels.CreateLabel(p.ID, opts)
+	return err
+}
+
 // ProjectSnippetCreate creates a snippet in a project
 func ProjectSnippetCreate(pid interface{}, opts *gitlab.CreateProjectSnippetOptions) (*gitlab.Snippet, error) {
 	snip, _, err := lab.ProjectSnippets.CreateSnippet(pid, opts)


### PR DESCRIPTION
Currently label names have to be specified by their full name, and
any partial or non-existing names end up creating new labels. Instead,
map the list of names we get on the command line to the real labels.

This allows user-friendly (read: long and descriptive) label names
without losing command line convenience.
