### PR TITLE
Add support for milestones

### DIFF
--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -38,6 +38,10 @@ var issueCreateCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
+		milestoneName, err := cmd.Flags().GetString("milestone")
+		if err != nil {
+			log.Fatal(err)
+		}
 		templateName, err := cmd.Flags().GetString("template")
 		if err != nil {
 			log.Fatal(err)
@@ -60,6 +64,15 @@ var issueCreateCmd = &cobra.Command{
 		labels, err := MapLabels(rn, labelTerms)
 		if err != nil {
 			log.Fatal(err)
+		}
+
+		var milestoneID *int
+		if milestoneName != "" {
+			milestone, err := lab.MilestoneGet(rn, milestoneName)
+			if err != nil {
+				log.Fatal(err)
+			}
+			milestoneID = &milestone.ID
 		}
 
 		title, body, err := issueMsg(templateName, msgs)
@@ -86,6 +99,7 @@ var issueCreateCmd = &cobra.Command{
 			Description: &body,
 			Labels:      labels,
 			AssigneeIDs: assigneeIDs,
+			MilestoneID: milestoneID,
 		})
 		if err != nil {
 			log.Fatal(err)
@@ -148,6 +162,7 @@ func init() {
 	issueCreateCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	issueCreateCmd.Flags().StringSliceP("label", "l", []string{}, "set the given label(s) on the created issue")
 	issueCreateCmd.Flags().StringSliceP("assignees", "a", []string{}, "set assignees by username")
+	issueCreateCmd.Flags().String("milestone", "", "set milestone by title")
 	issueCreateCmd.Flags().StringP("template", "t", "default", "use the given issue template")
 	issueCreateCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 

--- a/cmd/issue_list_test.go
+++ b/cmd/issue_list_test.go
@@ -56,6 +56,22 @@ func Test_issueListStateClosed(t *testing.T) {
 	require.Contains(t, issues, "#4 test closed issue")
 }
 
+func Test_issueListFlagMilestone(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "issue", "list", "--milestone", "1.0")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	issues := strings.Split(string(b), "\n")
+	t.Log(issues)
+	require.Contains(t, issues, "#1 test issue for lab list")
+}
+
 func Test_issueListSearch(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)

--- a/cmd/milestone.go
+++ b/cmd/milestone.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var milestoneCmd = &cobra.Command{
+	Use:              "milestone",
+	Short:            `List and search milestones`,
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+		return
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(milestoneCmd)
+}

--- a/cmd/milestone_create.go
+++ b/cmd/milestone_create.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	gitlab "github.com/xanzy/go-gitlab"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var milestoneCreateCmd = &cobra.Command{
+	Use:              "create [remote] <name>",
+	Aliases:          []string{"add"},
+	Short:            "Create a new milestone",
+	Long:             ``,
+	Example:          "lab milestone create my-milestone",
+	PersistentPreRun: LabPersistentPreRun,
+	Args:             cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, title, err := parseArgsRemoteAndProject(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		desc, err := cmd.Flags().GetString("description")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = lab.MilestoneCreate(rn, &gitlab.CreateMilestoneOptions{
+			Title:       &title,
+			Description: &desc,
+		})
+
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	milestoneCreateCmd.Flags().String("description", "", "description of the new milestone")
+	milestoneCmd.AddCommand(milestoneCreateCmd)
+	carapace.Gen(milestoneCmd).PositionalCompletion(
+		action.Remotes(),
+	)
+}

--- a/cmd/milestone_delete.go
+++ b/cmd/milestone_delete.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var milestoneDeleteCmd = &cobra.Command{
+	Use:              "delete [remote] <name>",
+	Aliases:          []string{"remove"},
+	Short:            "Deletes an existing milestone",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
+	Args:             cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, name, err := parseArgsRemoteAndProject(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = lab.MilestoneDelete(rn, name)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	milestoneCmd.AddCommand(milestoneDeleteCmd)
+	carapace.Gen(milestoneCmd).PositionalCompletion(
+		action.Remotes(),
+	)
+}

--- a/cmd/milestone_list.go
+++ b/cmd/milestone_list.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	gitlab "github.com/xanzy/go-gitlab"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var milestoneListCmd = &cobra.Command{
+	Use:     "list [remote] [search]",
+	Aliases: []string{"ls", "search"},
+	Short:   "List milestones",
+	Long:    ``,
+	Example: `lab milestone list                       # list all milestones
+lab milestone list "search term"         # search milestones for "search term"
+lab milestone search "search term"       # same as above
+lab milestone list remote "search term"  # search "remote" for milestones with "search term"`,
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, milestoneSearch, err := parseArgsRemoteAndProject(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		milestoneState, _ := cmd.Flags().GetString("state")
+		opts := &gitlab.ListMilestonesOptions{
+			State: &milestoneState,
+		}
+
+		milestoneSearch = strings.ToLower(milestoneSearch)
+		if milestoneSearch != "" {
+			opts.Search = &milestoneSearch
+		}
+
+		milestones, err := lab.MilestoneList(rn, opts)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, milestone := range milestones {
+			description := ""
+			if milestone.Description != "" {
+				description = " - " + milestone.Description
+			}
+
+			fmt.Printf("%s%s\n", milestone.Title, description)
+		}
+	},
+}
+
+func init() {
+	milestoneListCmd.Flags().StringP("state", "s", "active", "filter milestones by state (active/closed)")
+	milestoneCmd.AddCommand(milestoneListCmd)
+	carapace.Gen(milestoneCmd).PositionalCompletion(
+		action.Remotes(),
+	)
+}

--- a/cmd/milestone_list_test.go
+++ b/cmd/milestone_list_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_milestoneList(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "milestone", "list")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	milestones := strings.Split(string(b), "\n")
+	t.Log(milestones)
+	require.Contains(t, milestones, "1.0")
+}
+
+func Test_milestoneListSearch(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "milestone", "list", "99")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	milestones := strings.Split(string(b), "\n")
+	t.Log(milestones)
+	require.NotContains(t, milestones, "1.0")
+}
+
+func Test_milestoneListState(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "milestone", "list", "--state", "closed")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	milestones := strings.Split(string(b), "\n")
+	t.Log(milestones)
+	require.NotContains(t, milestones, "1.0")
+}

--- a/cmd/milestone_test.go
+++ b/cmd/milestone_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_milestoneCmd(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	t.Run("prepare", func(t *testing.T) {
+		cmd := exec.Command("sh", "-c", labBinaryPath+` milestone list lab-testing | grep -q 'test-milestone' && `+labBinaryPath+` milestone delete test-milestone`)
+		cmd.Dir = repo
+
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Log(string(b))
+			//t.Fatal(err)
+		}
+	})
+	t.Run("create", func(t *testing.T) {
+		cmd := exec.Command(labBinaryPath, "milestone", "create", "lab-testing", "test-milestone")
+		cmd.Dir = repo
+
+		b, _ := cmd.CombinedOutput()
+		if strings.Contains(string(b), "403 Forbidden") {
+			t.Skip("No permission to change milestones, skipping")
+		}
+
+		cmd = exec.Command(labBinaryPath, "milestone", "list", "lab-testing")
+		cmd.Dir = repo
+
+		b, err := cmd.CombinedOutput()
+		out := string(b)
+		if err != nil {
+			t.Log(out)
+			//t.Fatal(err)
+		}
+		require.Contains(t, out, "test-milestone")
+	})
+	t.Run("delete", func(t *testing.T) {
+		cmd := exec.Command(labBinaryPath, "milestone", "delete", "lab-testing", "test-milestone")
+		cmd.Dir = repo
+
+		_ = cmd.Run()
+
+		cmd = exec.Command(labBinaryPath, "milestone", "list", "lab-testing")
+		cmd.Dir = repo
+
+		b, err := cmd.CombinedOutput()
+		out := string(b)
+		if err != nil {
+			t.Log(out)
+			//t.Fatal(err)
+		}
+		require.NotContains(t, out, "test-milestone")
+	})
+}

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -16,6 +16,7 @@ var (
 	mrLabels       []string
 	mrState        string
 	mrTargetBranch string
+	mrMilestone    string
 	mrNumRet       int
 	mrAll          bool
 	mrMine         bool
@@ -77,6 +78,14 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 		assigneeID = &_assigneeID
 	}
 
+	if mrMilestone != "" {
+		milestone, err := lab.MilestoneGet(rn, mrMilestone)
+		if err != nil {
+			log.Fatal(err)
+		}
+		mrMilestone = milestone.Title
+	}
+
 	orderBy := gitlab.String(order)
 
 	sort := gitlab.String(sortedBy)
@@ -88,6 +97,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 		Labels:       labels,
 		State:        &mrState,
 		TargetBranch: &mrTargetBranch,
+		Milestone:    &mrMilestone,
 		OrderBy:      orderBy,
 		Sort:         sort,
 		AssigneeID:   assigneeID,
@@ -114,6 +124,8 @@ func init() {
 	listCmd.Flags().StringVarP(
 		&mrTargetBranch, "target-branch", "t", "",
 		"filter merge requests by target branch")
+	listCmd.Flags().StringVar(
+		&mrMilestone, "milestone", "", "list only MRs for the given milestone")
 	listCmd.Flags().BoolVarP(&mrAll, "all", "a", false, "list all MRs on the project")
 	listCmd.Flags().BoolVarP(&mrMine, "mine", "m", false, "list only MRs assigned to me")
 	listCmd.Flags().StringVar(

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -344,6 +344,88 @@ func Test_mrCmd_Draft(t *testing.T) {
 	})
 }
 
+func Test_mrCmd_Milestone(t *testing.T) {
+	repo := copyTestRepo(t)
+	var mrID string
+	t.Run("prepare", func(t *testing.T) {
+		cmd := exec.Command("sh", "-c", labBinaryPath+` mr list origin | grep -m1 'Test draft' | cut -c2- | awk '{print $1}' | xargs `+labBinaryPath+` mr origin -d`)
+		cmd.Dir = repo
+
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Log(string(b))
+			//t.Fatal(err)
+		}
+	})
+	t.Run("create", func(t *testing.T) {
+		git := exec.Command("git", "checkout", "mrtest")
+		git.Dir = repo
+		b, err := git.CombinedOutput()
+		if err != nil {
+			t.Log(string(b))
+			t.Fatal(err)
+		}
+
+		cmd := exec.Command(labBinaryPath, "mr", "create", "--milestone", "1.0", "origin", "master",
+			"-m", "MR for 1.0",
+		)
+		cmd.Dir = repo
+
+		b, _ = cmd.CombinedOutput()
+		out := string(b)
+		t.Log(out)
+		require.Contains(t, out, "https://gitlab.com/zaquestion/test/-/merge_requests")
+
+		i := strings.Index(out, "/diffs\n")
+		mrID = strings.TrimPrefix(out[:i], "https://gitlab.com/zaquestion/test/-/merge_requests/")
+		t.Log(mrID)
+	})
+	t.Run("list", func(t *testing.T) {
+		if mrID == "" {
+			t.Skip("mrID is empty, create likely failed")
+		}
+		cmd := exec.Command(labBinaryPath, "mr", "list", "--milestone", "1.0", "origin")
+		cmd.Dir = repo
+
+		b, _ := cmd.CombinedOutput()
+		out := string(b)
+		t.Log(out)
+		require.Contains(t, out, "MR for 1.0")
+	})
+	t.Run("modify", func(t *testing.T) {
+		if mrID == "" {
+			t.Skip("mrID is empty, create likely failed")
+		}
+		cmd := exec.Command(labBinaryPath, "mr", "edit", "--milestone", "", "origin")
+		cmd.Dir = repo
+
+		b, _ := cmd.CombinedOutput()
+		t.Log(string(b))
+
+		cmd = exec.Command(labBinaryPath, "mr", "list", "--milestone", "1.0", "origin")
+		cmd.Dir = repo
+
+		b, _ = cmd.CombinedOutput()
+		out := string(b)
+		t.Log(out)
+		require.NotContains(t, out, "MR for 1.0")
+	})
+	t.Run("delete", func(t *testing.T) {
+		if mrID == "" {
+			t.Skip("mrID is empty, create likely failed")
+		}
+		cmd := exec.Command(labBinaryPath, "mr", "close", "origin", mrID)
+		cmd.Dir = repo
+
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Log(string(b))
+			t.Fatal(err)
+		}
+		require.Contains(t, string(b), fmt.Sprintf("Merge Request !%s closed", mrID))
+	})
+}
+
 func Test_mrCmd_ByBranch(t *testing.T) {
 	repo := copyTestRepo(t)
 	var mrID string


### PR DESCRIPTION
Milestones are useful to associate issues/MRs with some target (usually a release).

This adds some basic support, following the existing handling of labels.
