### PR TITLE
mr_list: fix order and sort flags description

### DIFF
--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -113,8 +113,8 @@ func init() {
 	listCmd.Flags().BoolVarP(&mrMine, "mine", "m", false, "list only MRs assigned to me")
 	listCmd.Flags().StringVar(
 		&mrAssignee, "assignee", "", "list only MRs assigned to $username")
-	listCmd.Flags().StringVar(&order, "order", "updated_at", "display order, updated_at(default) or created_at")
-	listCmd.Flags().StringVar(&sortedBy, "sort", "desc", "sort order, desc(default) or asc")
+	listCmd.Flags().StringVar(&order, "order", "updated_at", "display order (updated_at/created_at)")
+	listCmd.Flags().StringVar(&sortedBy, "sort", "desc", "sort order (desc/asc)")
 	listCmd.Flags().BoolVarP(&mrDraft, "draft", "", false, "list MRs marked as draft")
 	listCmd.Flags().BoolVarP(&mrReady, "ready", "", false, "list MRs not marked as draft")
 	listCmd.Flags().SortFlags = false


### PR DESCRIPTION
Simple fix/change in the mr_list flag description for both `order` and `sort` flags.