### PR TITLE
lab: Check that LAB_CORE_TOKEN is set before querying user for a token

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ brews:
       system "git", "add", "haunted", "house"
       system "git", "commit", "-a", "-m", "Initial Commit"
       lab_env_config = "LAB_CORE_HOST=foo LAB_CORE_USER=bar LAB_CORE_TOKEN=baz"
-      assert_equal "haunted\nhouse", shell_output("#{lab_env_config} #{bin}/lab ls-files").strip
+      assert_match "haunted\nhouse", shell_output("#{lab_env_config} #{bin}/lab ls-files").strip
 
 scoop:
   bucket:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,10 @@ func New(confpath string, r io.Reader) error {
 var readPassword = func(reader bufio.Reader) (string, string, error) {
 	var loadToken string
 
+	if strings.TrimSpace(os.Getenv("LAB_CORE_TOKEN")) != "" {
+		return strings.TrimSpace(os.Getenv("LAB_CORE_TOKEN")), "", nil
+	}
+
 	tokenURL, err := url.Parse(MainConfig.GetString("core.host"))
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
chenrui333 noted in #558 that the goreleaser test for lab was failing.
The test is a simple execution of the git wrapper capabilities of lab.

The test does:

	git init
	touch haunted
	touch house
	git add haunted house
	git commit -a -m "Initial Commit"
	lab ls-files

and expects the output of the last command to be

	haunted
	house

The test currently fails on the command line with

```
[prarit@prarit dummy (master)]$ LAB_CORE_HOST=foo LAB_CORE_USER=bar LAB_CORE_TOKEN=baz lab  ls-files
Create a token with scope 'api' here: profile/personal_access_tokens
Enter default GitLab token, or leave blank to provide a command to load the token:
```

instead of displaying the list of files.  This occurs because the code
does not check to see if LAB_CORE_TOKEN is set before querying the user
for a token.

Check that LAB_CORE_TOKEN is set before querying the user for the token.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>
Reported-by: @chenrui333 (in #558)
Cc: Bruno Meneguele <bmeneg@redhat.com>