### PR TITLE
mr_list: Support search

### DIFF
--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -214,3 +214,19 @@ func Test_mrListCreatedDescending(t *testing.T) {
 	t.Log(mrs)
 	require.Equal(t, latestCreatedTestMR, mrs[0])
 }
+
+func Test_mrListSearch(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "mr", "list", "emoji")
+	cmd.Dir = repo
+
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mrs := strings.Split(string(b), "\n")
+	t.Log(mrs)
+	require.Contains(t, mrs, "!6 test award emoji")
+}


### PR DESCRIPTION
Search is as useful for merge requests as for issues, so support
the same option as `lab issue list`.
