### PR TITLE
mr_list: Fix test

### DIFF
--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -78,7 +78,7 @@ func Test_mrListStateMerged(t *testing.T) {
 func Test_mrListStateClosed(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
-	cmd := exec.Command(labBinaryPath, "mr", "list", "-s", "closed")
+	cmd := exec.Command(labBinaryPath, "mr", "list", "-a", "-s", "closed")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()


### PR DESCRIPTION
The test for milestone support creates and closes a MR on origin,
with the result that the test case for closed MRs ended up being
pushed off the list, given that only a limited number is shown
by default.

List all closed MRs to make it appear in the listing again.
