### PR TITLE
Fix the -h lab option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -205,7 +205,7 @@ func Execute() {
 	if cmd.Use == RootCmd.Use && len(os.Args) > 1 {
 		var knownFlag bool
 		for _, v := range os.Args {
-			if v == "--help" || v == "--version" {
+			if v == "-h" || v == "--help" || v == "--version" {
 				knownFlag = true
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func skipInit() bool {
 	switch os.Args[1] {
 	case "--version", "version":
 		return true
-	case "--help", "help":
+	case "-h", "--help", "help":
 		return true
 	case "completion":
 		return true


### PR DESCRIPTION
The help describes -h as a valid option:

  Flags:
    -h, --help      help for lab

But using it fails with:

  $ lab -h
  unknown option: -h

Fix this.