### PR TITLE
mr_show: Add MR status "open (needs rebase)"

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -127,6 +127,10 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 		"merged": "Merged",
 	}[mr.State]
 
+	if state == "Open" && mr.MergeStatus == "cannot_be_merged" {
+		state = "Open (Needs Rebase)"
+	}
+
 	if mr.Assignee != nil && mr.Assignee.Username != "" {
 		assignee = mr.Assignee.Username
 	}


### PR DESCRIPTION
I noticed that 'lab mr show' shows Merge Requests that need a rebase as
status "open" with no further information.

The MergeRequest struct has a MergeStatus field that returns
"can_be_merged" or "cannot_be_merged".  The "cannot_be_merged" state can
be used to return better status information to the user.

Add an "open (needs rebase)" status.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>