### PR TITLE
mr_list_test: mrListStateClosed fix

### DIFF
--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -78,7 +78,7 @@ func Test_mrListStateMerged(t *testing.T) {
 func Test_mrListStateClosed(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
-	cmd := exec.Command(labBinaryPath, "mr", "list", "-s", "closed")
+	cmd := exec.Command(labBinaryPath, "mr", "list", "-a", "-s", "closed")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()


### PR DESCRIPTION
mrListStateClosed test is failing with not finding the output "!5 closed
mr".  This occurs because the output contains only the first 20 closed
MRs.  If all the closed MRs were listed the test will pass.

Modify the mrListStateClosed test to list all closed MRs.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>