### PR TITLE
Allow configuring a default remote

### DIFF
--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -46,7 +46,7 @@ var issueCreateCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		remote := forkedFromRemote
+		remote := defaultRemote
 		if len(args) > 0 {
 			ok, err := git.IsRemote(args[0])
 			if err != nil {

--- a/cmd/issue_move.go
+++ b/cmd/issue_move.go
@@ -20,7 +20,7 @@ var issueMoveCmd = &cobra.Command{
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		// get this rn
-		srcRN, err := getRemoteName(forkedFromRemote)
+		srcRN, err := getRemoteName(defaultRemote)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -36,7 +36,7 @@ var checkoutCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		var targetRemote = forkedFromRemote
+		var targetRemote = defaultRemote
 		if len(args) == 2 {
 			// parseArgs above already validated this is a remote
 			targetRemote = args[0]

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -128,7 +128,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	targetRemote := forkedFromRemote
+	targetRemote := defaultRemote
 	if len(args) > 0 {
 		targetRemote = args[0]
 		ok, err := git.IsRemote(targetRemote)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,6 +111,41 @@ var (
 	forkRemote = ""
 )
 
+// Try to guess what should be the default remote.
+func guessDefaultRemote() string {
+	guess := ""
+
+	_, err := gitconfig.Local("remote.upstream.url")
+	if err == nil {
+		guess = "upstream"
+	}
+	_, err = gitconfig.Local("remote.origin.url")
+	if err == nil {
+		guess = "origin"
+	}
+
+	if guess == "" {
+		// use the remote tracked by the default branch if set
+		if remote, err := gitconfig.Local("branch.main.remote"); err == nil {
+			guess = remote
+		} else if remote, err = gitconfig.Local("branch.master.remote"); err == nil {
+			guess = remote
+		} else {
+			// use the first remote added to .git/config file, which, usually, is
+			// the one from which the repo was clonned
+			remotesStr, err := git.GetLocalRemotesFromFile()
+			if err == nil {
+				remotes := strings.Split(remotesStr, "\n")
+				// remotes format: remote.<name>.<url|fetch>
+				remoteName := strings.Split(remotes[0], ".")[1]
+				guess = remoteName
+			}
+		}
+	}
+
+	return guess
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -118,38 +153,13 @@ func Execute() {
 	// Otherwise, skip it, since the info won't be used at all, also avoiding
 	// misleading error/warning messages about missing remote.
 	if git.InsideGitRepo() {
-		_, err := gitconfig.Local("remote.upstream.url")
-		if err == nil {
-			defaultRemote = "upstream"
-		}
-		_, err = gitconfig.Local("remote.origin.url")
-		if err == nil {
-			defaultRemote = "origin"
-		}
-
+		defaultRemote = guessDefaultRemote()
 		if defaultRemote == "" {
-			// use the remote tracked by the default branch if set
-			if remote, err := gitconfig.Local("branch.main.remote"); err == nil {
-				defaultRemote = remote
-			} else if remote, err = gitconfig.Local("branch.master.remote"); err == nil {
-				defaultRemote = remote
-			} else {
-				// use the first remote added to .git/config file, which, usually, is
-				// the one from which the repo was clonned
-				remotesStr, err := git.GetLocalRemotesFromFile()
-				if err == nil {
-					remotes := strings.Split(remotesStr, "\n")
-					// remotes format: remote.<name>.<url|fetch>
-					remoteName := strings.Split(remotes[0], ".")[1]
-					defaultRemote = remoteName
-				} else {
-					log.Println("No default remote found")
-				}
-			}
+			log.Println("No default remote found")
 		}
 
 		// Check if the user fork exists
-		_, err = gitconfig.Local("remote." + lab.User() + ".url")
+		_, err := gitconfig.Local("remote." + lab.User() + ".url")
 		if err == nil {
 			forkRemote = lab.User()
 		} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,7 +106,7 @@ func init() {
 
 var (
 	// Will be updated to upstream in Execute() if "upstream" remote exists
-	forkedFromRemote = ""
+	defaultRemote = ""
 	// Will be updated to lab.User() in Execute() if forkedFrom is "origin"
 	forkRemote = ""
 )
@@ -120,19 +120,19 @@ func Execute() {
 	if git.InsideGitRepo() {
 		_, err := gitconfig.Local("remote.upstream.url")
 		if err == nil {
-			forkedFromRemote = "upstream"
+			defaultRemote = "upstream"
 		}
 		_, err = gitconfig.Local("remote.origin.url")
 		if err == nil {
-			forkedFromRemote = "origin"
+			defaultRemote = "origin"
 		}
 
-		if forkedFromRemote == "" {
+		if defaultRemote == "" {
 			// use the remote tracked by the default branch if set
 			if remote, err := gitconfig.Local("branch.main.remote"); err == nil {
-				forkedFromRemote = remote
+				defaultRemote = remote
 			} else if remote, err = gitconfig.Local("branch.master.remote"); err == nil {
-				forkedFromRemote = remote
+				defaultRemote = remote
 			} else {
 				// use the first remote added to .git/config file, which, usually, is
 				// the one from which the repo was clonned
@@ -141,7 +141,7 @@ func Execute() {
 					remotes := strings.Split(remotesStr, "\n")
 					// remotes format: remote.<name>.<url|fetch>
 					remoteName := strings.Split(remotes[0], ".")[1]
-					forkedFromRemote = remoteName
+					defaultRemote = remoteName
 				} else {
 					log.Println("No default remote found")
 				}
@@ -153,7 +153,7 @@ func Execute() {
 		if err == nil {
 			forkRemote = lab.User()
 		} else {
-			forkRemote = forkedFromRemote
+			forkRemote = defaultRemote
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,6 +113,14 @@ var (
 
 // Try to guess what should be the default remote.
 func guessDefaultRemote() string {
+	// Allow to force a default remote. If set, return early.
+	if config := getMainConfig(); config != nil {
+		defaultRemote := config.GetString("core.default_remote")
+		if defaultRemote != "" {
+			return defaultRemote
+		}
+	}
+
 	guess := ""
 
 	_, err := gitconfig.Local("remote.upstream.url")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -69,7 +69,7 @@ func TestMain(m *testing.M) {
 	// Make "origin" the default remote for test cases calling
 	// cmd.Run() directly, instead of launching the labBinaryPath
 	// for getting these vars correctly set through Execute().
-	forkedFromRemote = "origin"
+	defaultRemote = "origin"
 	forkRemote = "origin"
 	code := m.Run()
 

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -40,7 +40,7 @@ Optionally add a title & description with -m`,
 		if err != nil {
 			log.Fatal(err)
 		}
-		remote := forkedFromRemote
+		remote := defaultRemote
 		if len(args) > 0 {
 			ok, err := git.IsRemote(args[0])
 			if err != nil {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -134,7 +134,7 @@ func parseArgsRemoteAndID(args []string) (string, int64, error) {
 		}
 	}
 	if remote == "" {
-		remote = forkedFromRemote
+		remote = defaultRemote
 	}
 	rn, err := git.PathWithNameSpace(remote)
 	if err != nil {
@@ -158,7 +158,7 @@ func parseArgsRemoteAndProject(args []string) (string, string, error) {
 	}
 
 	if remote == "" {
-		remote = forkedFromRemote
+		remote = defaultRemote
 	}
 
 	remote, err = getRemoteName(remote)
@@ -276,7 +276,7 @@ func parseArgsWithGitBranchMR(args []string) (string, int64, error) {
 		}
 
 		if s == "" {
-			s = forkedFromRemote
+			s = defaultRemote
 		}
 		s, err = getRemoteName(s)
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -241,7 +241,8 @@ func LoadMainConfig() (string, string, string, string, bool) {
 	//		- if specified, lower order config files will not override
 	//		  the user specified config
 	//	3.  .config/lab/lab.toml (global config)
-	//	4.  .git/lab/lab/toml (worktree config)
+	//	4.  .git/lab/lab.toml or .git/worktrees/<name>/lab/lab.toml
+	//	    (worktree config)
 	//
 	// Values from the worktree config will override any global config settings.
 


### PR DESCRIPTION
The goal of this PR is to allow the user to configure what should be the default remote. The current logic tries to guess what should be the default remote by looking at the "origin" and "upstream" remotes if defined, and at branches such as "main" and "master". But having those remotes and branches is not always the case, and even so they could hold a wrong value (for lab).

This PR adds the ability to explicitly configure the default remote, using a new `core.default_remote` parameter in the configuration. While it is probably not a good idea to define this globally, the configuration file can also be in the repositories `.git` directories, as well as in the `.git/worktrees/` directories when using Git worktrees. In such cases, having the ability to explicitly set the default remote is quite handy.

This does not break any of the previous cases. When not set, `lab` will strill try to guess what should be the default remote. And commands allowing a remote as a parameter can still do so.

This PR starts with some cosmetic patches and then adds the new `core.default_remote` logic.

Thanks!