### PR TITLE
add multi-project CI pipeline support

### DIFF
--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -4,6 +4,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Hold --follow flag value that is common for all ci command
+var followBridge bool
+
 // ciCmd represents the ci command
 var ciCmd = &cobra.Command{
 	Use:   "ci",
@@ -12,5 +15,6 @@ var ciCmd = &cobra.Command{
 }
 
 func init() {
+	ciCmd.PersistentFlags().Bool("follow", false, "Follow downstream pipelines in a multi-projects setup")
 	RootCmd.AddCommand(ciCmd)
 }

--- a/cmd/ci_artifacts.go
+++ b/cmd/ci_artifacts.go
@@ -33,6 +33,11 @@ var ciArtifactsCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		followBridge, err = cmd.Flags().GetBool("follow")
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		path, err := cmd.Flags().GetString("artifact-path")
 		if err != nil {
 			log.Fatal(err)
@@ -49,7 +54,7 @@ var ciArtifactsCmd = &cobra.Command{
 		}
 		projectID := project.ID
 
-		r, outpath, err := lab.CIArtifacts(projectID, pipelineID, jobName, path)
+		r, outpath, err := lab.CIArtifacts(projectID, pipelineID, jobName, path, followBridge)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -36,6 +36,11 @@ lab ci status --wait`,
 			log.Fatal(err)
 		}
 
+		followBridge, err = cmd.Flags().GetBool("follow")
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		rn, pipelineID, err := getPipelineFromArgs(args, forMR)
 		if err != nil {
 			log.Fatal(err)
@@ -53,14 +58,19 @@ lab ci status --wait`,
 			log.Fatal(err)
 		}
 
-		var jobs []*gitlab.Job
+		var jobStructList []lab.JobStruct
+		jobs := make([]*gitlab.Job, 0)
 
 		fmt.Fprintln(w, "Stage:\tName\t-\tStatus")
 		for {
 			// fetch all of the CI Jobs from the API
-			jobs, err = lab.CIJobs(pid, pipelineID)
+			jobStructList, err = lab.CIJobs(pid, pipelineID, followBridge)
 			if err != nil {
 				log.Fatal(errors.Wrap(err, "failed to find ci jobs"))
+			}
+
+			for _, jobStruct := range jobStructList {
+				jobs = append(jobs, jobStruct.Job)
 			}
 
 			// filter out old jobs

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -42,6 +42,11 @@ var ciTraceCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		followBridge, err = cmd.Flags().GetBool("follow")
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		rn, pipelineID, err := getPipelineFromArgs(branchArgs, forMR)
 		if err != nil {
 			log.Fatal(err)
@@ -72,7 +77,7 @@ func doTrace(ctx context.Context, w io.Writer, pid interface{}, pipelineID int, 
 		if ctx.Err() == context.Canceled {
 			break
 		}
-		trace, job, err := lab.CITrace(pid, pipelineID, name)
+		trace, job, err := lab.CITrace(pid, pipelineID, name, followBridge)
 		if err != nil || job == nil || trace == nil {
 			return errors.Wrap(err, "failed to find job")
 		}

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -57,6 +57,11 @@ Feedback Encouraged!: https://github.com/zaquestion/lab/issues`,
 			log.Fatal(err)
 		}
 
+		followBridge, err = cmd.Flags().GetBool("follow")
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		rn, pipelineID, err = getPipelineFromArgs(args, forMR)
 		if err != nil {
 			log.Fatal(err)
@@ -483,11 +488,17 @@ func updateJobs(app *tview.Application, jobsCh chan []*gitlab.Job) {
 			time.Sleep(time.Second * 1)
 			continue
 		}
-		jobs, err := lab.CIJobs(projectID, pipelineID)
-		if len(jobs) == 0 || err != nil {
+		jobStructList, err := lab.CIJobs(projectID, pipelineID, followBridge)
+		if len(jobStructList) == 0 || err != nil {
 			app.Stop()
 			log.Fatal(errors.Wrap(err, "failed to find ci jobs"))
 		}
+
+		jobs := make([]*gitlab.Job, 0)
+		for _, jobStruct := range jobStructList {
+			jobs = append(jobs, jobStruct.Job)
+		}
+
 		jobsCh <- latestJobs(jobs)
 		time.Sleep(time.Second * 5)
 	}

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/tcnksm/go-gitconfig v0.1.2
-	github.com/xanzy/go-gitlab v0.39.0
+	github.com/xanzy/go-gitlab v0.43.0
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	github.com/yuin/goldmark v1.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897

--- a/go.sum
+++ b/go.sum
@@ -488,12 +488,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
-github.com/xanzy/go-gitlab v0.33.1-0.20200713191942-71ea998bed24 h1:WmX8fdQSu32qQpsPZ6/h90HK930NhUmoh+yLDItvmYw=
-github.com/xanzy/go-gitlab v0.33.1-0.20200713191942-71ea998bed24/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
-github.com/xanzy/go-gitlab v0.38.1 h1:st5/Ag4h8CqVfp3LpOWW0Jd4jYHTGETwu0KksYDPnYE=
-github.com/xanzy/go-gitlab v0.38.1/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
-github.com/xanzy/go-gitlab v0.39.0 h1:7aiZ03fJfCdqoHFhsZq/SoVYp2lR91hfYWmiXLOU5Qo=
-github.com/xanzy/go-gitlab v0.39.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xanzy/go-gitlab v0.43.0 h1:rpOZQjxVJGW/ch+Jy4j7W4o7BB1mxkXJNVGuplZ7PUs=
+github.com/xanzy/go-gitlab v0.43.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1295,6 +1295,7 @@ func CIArtifacts(pid interface{}, id int, name, path string, followBridge bool) 
 		return nil, "", fmt.Errorf("Job %d has no artifacts", job.ID)
 	}
 
+	fmt.Println("Downloading artifacts...")
 	if path != "" {
 		r, _, err = lab.Jobs.DownloadSingleArtifactsFile(pid, job.ID, path, nil)
 		outpath = filepath.Base(path)


### PR DESCRIPTION
This MR enables `lab` to follow pipelines that are kept in other projects other than the current, where the source code is,
this is called [multi-projects pipeline](https://docs.gitlab.com/ee/ci/multi_project_pipelines.html).

For that, a new persistent flag was added to all `lab ci` commands:
```
  --follow   Follow downstream pipelines in a multi-projects setup
```
e.g.
```
$ lab ci artifacts upstream --follow --merge-request
```

One of the issues here is that we don't have a test infrastructure to properly test it.
I've tested within the company's infrastructure that I work and seems to be fully working.
I'm afraid the only thing we can do is to wait for people to use it.