### PR TITLE
main: Also skip init for subcommand help

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,8 +29,13 @@ func main() {
 }
 
 func skipInit() bool {
-	if len(os.Args) <= 1 {
+	nArgs := len(os.Args)
+	if nArgs <= 1 {
 		return false
+	}
+	switch os.Args[nArgs-1] {
+	case "-h", "--help":
+		return true
 	}
 	switch os.Args[1] {
 	case "--version", "version":


### PR DESCRIPTION
We skip init when the first argument is help (`lab help mr`), do the
same for the last argument as well (`lab mr create --help`).

This allows printing out subcommand help from a git tree without
a corresponding gitlab token.
