### PR TITLE
mr_create: check for empty msg before acting

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -229,10 +229,10 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 
 	draft, _ := cmd.Flags().GetBool("draft")
 	if draft {
-		isWIP := strings.EqualFold(title[0:4], "wip:")
-		isDraft := strings.EqualFold(title[0:6], "draft:") ||
-			strings.EqualFold(title[0:7], "[draft]") ||
-			strings.EqualFold(title[0:7], "(draft)")
+		isWIP := hasPrefix(title, "wip:")
+		isDraft := hasPrefix(title, "draft:") ||
+			hasPrefix(title, "[draft]") ||
+			hasPrefix(title, "(draft)")
 
 		if !isWIP && !isDraft {
 			title = "Draft: " + title

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -218,6 +218,10 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	if title == "" {
+		log.Fatal("aborting MR due to empty MR msg")
+	}
+
 	linebreak, _ := cmd.Flags().GetBool("force-linebreak")
 	if linebreak {
 		body = textToMarkdown(body)
@@ -238,10 +242,6 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	removeSourceBranch, _ := cmd.Flags().GetBool("remove-source-branch")
 	squash, _ := cmd.Flags().GetBool("squash")
 	allowCollaboration, _ := cmd.Flags().GetBool("allow-collaboration")
-
-	if title == "" {
-		log.Fatal("aborting MR due to empty MR msg")
-	}
 
 	mrURL, err := lab.MRCreate(sourceProjectName, &gitlab.CreateMergeRequestOptions{
 		SourceBranch:       &branch,

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -498,6 +498,14 @@ func determineSourceRemote(branch string) string {
 	return forkRemote
 }
 
+// Check of a case-insensitive prefix in a string
+func hasPrefix(str, prefix string) bool {
+	if len(str) < len(prefix) {
+		return false
+	}
+	return strings.EqualFold(str[0:len(prefix)], prefix)
+}
+
 // union returns all the unique elements in a and b
 func union(a, b []string) []string {
 	mb := map[string]bool{}


### PR DESCRIPTION
Fix panic during a `lab mr create -c --draft` with an empty cover-letter.

Fixes #587 