### PR TITLE
mr_list: fix help message wrt MR state

### DIFF
--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -100,7 +100,7 @@ func init() {
 		"filter issues by label")
 	issueListCmd.Flags().StringVarP(
 		&issueState, "state", "s", "opened",
-		"filter issues by state (opened/closed)")
+		"filter issues by state (all/opened/closed)")
 	issueListCmd.Flags().IntVarP(
 		&issueNumRet, "number", "n", 10,
 		"number of issues to return")

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -160,7 +160,7 @@ func init() {
 		&mrLabels, "label", "l", []string{}, "filter merge requests by label")
 	listCmd.Flags().StringVarP(
 		&mrState, "state", "s", "opened",
-		"filter merge requests by state (opened/closed/merged)")
+		"filter merge requests by state (all/opened/closed/merged)")
 	listCmd.Flags().IntVarP(
 		&mrNumRet, "number", "n", 10,
 		"number of merge requests to return")


### PR DESCRIPTION
Add `all` to the `lab mr list --help` command under `-s, --state string` paramenter.
With that the user don't need to guess this option is available.