### PR TITLE
mr_create: Add number of commits to create metadata

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -282,7 +282,7 @@ func mrText(base, head, sourceRemote, targetRemote string, coverLetterFormat boo
 	const tmpl = `{{if .InitMsg}}{{.InitMsg}}{{end}}
 
 {{if .Tmpl}}{{.Tmpl}}{{end}}
-{{.CommentChar}} Requesting a merge into {{.Base}} from {{.Head}}
+{{.CommentChar}} Requesting a merge into {{.Base}} from {{.Head}} ({{.NumCommits}} commits)
 {{.CommentChar}}
 {{.CommentChar}} Write a message for this merge request. The first block
 {{.CommentChar}} of text is the title and the rest is the description.{{if .CommitLogs}}
@@ -293,7 +293,7 @@ func mrText(base, head, sourceRemote, targetRemote string, coverLetterFormat boo
 
 	mrTmpl := lab.LoadGitLabTmpl(lab.TmplMR)
 
-	commitLogs, err := git.Log(remoteBase, head)
+	commitLogs, numCommits, err := git.Log(remoteBase, head)
 	if err != nil {
 		return "", err
 	}
@@ -319,6 +319,7 @@ func mrText(base, head, sourceRemote, targetRemote string, coverLetterFormat boo
 		Base        string
 		Head        string
 		CommitLogs  string
+		NumCommits  int
 	}{
 		InitMsg:     commitMsg,
 		Tmpl:        mrTmpl,
@@ -326,6 +327,7 @@ func mrText(base, head, sourceRemote, targetRemote string, coverLetterFormat boo
 		Base:        targetRemote + ":" + base,
 		Head:        sourceRemote + ":" + head,
 		CommitLogs:  commitLogs,
+		NumCommits:  numCommits,
 	}
 
 	var b bytes.Buffer

--- a/cmd/mr_create_test.go
+++ b/cmd/mr_create_test.go
@@ -17,7 +17,7 @@ func Test_mrText(t *testing.T) {
 	require.Contains(t, text, `
 
 I am the default merge request template for lab
-# Requesting a merge into origin:master from lab-testing:mrtest
+# Requesting a merge into origin:master from lab-testing:mrtest (12 commits)
 #
 # Write a message for this merge request. The first block
 # of text is the title and the rest is the description.
@@ -37,7 +37,7 @@ func Test_mrText_CoverLetter(t *testing.T) {
 	require.Contains(t, coverLetter, `
 
 I am the default merge request template for lab
-# Requesting a merge into origin:master from lab-testing:mrtest
+# Requesting a merge into origin:master from lab-testing:mrtest (12 commits)
 #
 # Write a message for this merge request. The first block
 # of text is the title and the rest is the description.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -129,7 +130,7 @@ func LastCommitMessage() (string, error) {
 }
 
 // Log produces a formatted gitlog between 2 git shas
-func Log(sha1, sha2 string) (string, error) {
+func Log(sha1, sha2 string) (string, int, error) {
 	cmd := New("-c", "log.showSignature=false",
 		"log",
 		"--no-color",
@@ -139,16 +140,28 @@ func Log(sha1, sha2 string) (string, error) {
 	cmd.Stdout = nil
 	outputs, err := cmd.Output()
 	if err != nil {
-		return "", errors.Errorf("Can't load git log %s..%s", sha1, sha2)
+		return "", 0, errors.Errorf("Can't load git log %s..%s", sha1, sha2)
 	}
 
 	diffCmd := New("diff", "--stat", sha1)
 	diffCmd.Stdout = nil
 	diffOutput, err := diffCmd.Output()
 	if err != nil {
-		return "", errors.Errorf("Can't load diffstat")
+		return "", 0, errors.Errorf("Can't load diffstat")
 	}
-	return string(outputs) + string(diffOutput), nil
+
+	numCommitsCmd := New("rev-list", "--count", fmt.Sprintf("%s...%s", sha1, sha2))
+	numCommitsCmd.Stdout = nil
+	numCommitsString, err := numCommitsCmd.Output()
+	if err != nil {
+		return "", 0, errors.Errorf("Can't determine number of commits")
+	}
+	numCommits, err := strconv.Atoi(strings.TrimSpace(string(numCommitsString)))
+	if err != nil {
+		return "", 0, errors.Errorf("Can't determine number of commits(%s)", numCommitsString)
+	}
+
+	return string(outputs) + string(diffOutput), numCommits, nil
 }
 
 // CurrentBranch returns the currently checked out branch

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -73,7 +73,7 @@ func TestLastCommitMessage(t *testing.T) {
 }
 
 func TestLog(t *testing.T) {
-	log, err := Log("HEAD~1", "HEAD")
+	log, count, err := Log("HEAD~1", "HEAD")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,6 +83,7 @@ func TestLog(t *testing.T) {
 	assert.Contains(t, log, expectedSHA)
 	assert.Contains(t, log, expectedAuthor)
 	assert.Contains(t, log, expectedMessage)
+	assert.Equal(t, 1, count)
 }
 
 func TestCurrentBranch(t *testing.T) {


### PR DESCRIPTION
First time GitLab users can make mistakes that result in a large merge
request being generated.  For example, new users may get the target branch
wrong, or push a branch that hasn't been updated, etc.  These errors always
result in way more commits than intended being pushed.

After a push to one of their hosted repositories, GitLab provides a URL
to a webpage that allows users to change the target branch and look at the
commits that are going to be pushed.  One convenient value on that page is
the number of commits that are being pushed.  In order to prevent users
from making simple mistakes, like the above, it would be good to also
provide that information the default 'lab mr create' message.

Provide the number of commits in 'lab mr create'.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>