### PR TITLE
fix: (mr_note) move tests to new dumping ground

### DIFF
--- a/cmd/mr_discussion_test.go
+++ b/cmd/mr_discussion_test.go
@@ -12,7 +12,7 @@ import (
 
 func Test_mrCreateDiscussion(t *testing.T) {
 	repo := copyTestRepo(t)
-	cmd := exec.Command(labBinaryPath, "mr", "discussion", "lab-testing", "1",
+	cmd := exec.Command(labBinaryPath, "mr", "discussion", "lab-testing", mrCommentSlashDiscussionDumpsterID,
 		"-m", "discussion text")
 	cmd.Dir = repo
 
@@ -22,7 +22,7 @@ func Test_mrCreateDiscussion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/merge_requests/1#note_")
+	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/merge_requests/"+mrCommentSlashDiscussionDumpsterID+"#note_")
 }
 
 func Test_mrCreateDiscussion_file(t *testing.T) {
@@ -33,7 +33,7 @@ func Test_mrCreateDiscussion_file(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command(labBinaryPath, "mr", "discussion", "lab-testing", "1",
+	cmd := exec.Command(labBinaryPath, "mr", "discussion", "lab-testing", mrCommentSlashDiscussionDumpsterID,
 		"-F", "hellolab.txt")
 	cmd.Dir = repo
 
@@ -43,7 +43,7 @@ func Test_mrCreateDiscussion_file(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/merge_requests/1#note_")
+	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/merge_requests/"+mrCommentSlashDiscussionDumpsterID+"#note_")
 }
 
 func Test_mrDiscussionMsg(t *testing.T) {

--- a/cmd/mr_note_test.go
+++ b/cmd/mr_note_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// #3952 is not special, it's just a place to dump discussions as mr #1 filled up, long term should update the tests clean up what they create
+const mrCommentSlashDiscussionDumpsterID = "3952"
+
 func Test_mrCreateNote(t *testing.T) {
 	tests := []struct {
 		Name         string
@@ -19,16 +22,16 @@ func Test_mrCreateNote(t *testing.T) {
 	}{
 		{
 			Name:         "Normal text",
-			Args:         []string{"lab-testing", "1", "-m", "note text"},
-			ExpectedBody: "https://gitlab.com/lab-testing/test/merge_requests/1#note_",
+			Args:         []string{"lab-testing", mrCommentSlashDiscussionDumpsterID, "-m", "note text"},
+			ExpectedBody: "https://gitlab.com/lab-testing/test/merge_requests/" + mrCommentSlashDiscussionDumpsterID + "#note_",
 		},
 		{
 			// Escaped sequence text direct in the argument list as the
 			// following one was already a problem:
 			// https://github.com/zaquestion/lab/issues/376
 			Name:         "Escape char",
-			Args:         []string{"lab-testing", "1", "-m", "{\"key\": \"value\"}"},
-			ExpectedBody: "https://gitlab.com/lab-testing/test/merge_requests/1#note_",
+			Args:         []string{"lab-testing", mrCommentSlashDiscussionDumpsterID, "-m", "{\"key\": \"value\"}"},
+			ExpectedBody: "https://gitlab.com/lab-testing/test/merge_requests/" + mrCommentSlashDiscussionDumpsterID + "#note_",
 		},
 	}
 	noteCmd := []string{"mr", "note"}
@@ -58,7 +61,7 @@ func Test_mrCreateNote_file(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command(labBinaryPath, "mr", "note", "lab-testing", "1",
+	cmd := exec.Command(labBinaryPath, "mr", "note", "lab-testing", mrCommentSlashDiscussionDumpsterID,
 		"-F", "hellolab.txt")
 	cmd.Dir = repo
 
@@ -68,13 +71,13 @@ func Test_mrCreateNote_file(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/merge_requests/1#note_")
+	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/merge_requests/"+mrCommentSlashDiscussionDumpsterID+"#note_")
 }
 
 func Test_mrReplyAndResolve(t *testing.T) {
 	repo := copyTestRepo(t)
 
-	cmd := exec.Command(labBinaryPath, "mr", "note", "lab-testing", "1", "-m", "merge request text")
+	cmd := exec.Command(labBinaryPath, "mr", "note", "lab-testing", mrCommentSlashDiscussionDumpsterID, "-m", "merge request text")
 	cmd.Dir = repo
 
 	a, err := cmd.CombinedOutput()
@@ -87,7 +90,7 @@ func Test_mrReplyAndResolve(t *testing.T) {
 	noteID := noteIDs[1]
 
 	// add reply to the noteID
-	reply := exec.Command(labBinaryPath, "mr", "reply", "lab-testing", "1:"+noteID, "-m", "reply to note")
+	reply := exec.Command(labBinaryPath, "mr", "reply", "lab-testing", mrCommentSlashDiscussionDumpsterID+":"+noteID, "-m", "reply to note")
 	reply.Dir = repo
 	c, err := reply.CombinedOutput()
 	if err != nil {
@@ -98,7 +101,7 @@ func Test_mrReplyAndResolve(t *testing.T) {
 	replyIDs := strings.Split(_replyIDs[0], "#note_")
 	replyID := replyIDs[1]
 
-	show := exec.Command(labBinaryPath, "mr", "show", "lab-testing", "1", "--comments")
+	show := exec.Command(labBinaryPath, "mr", "show", "lab-testing", mrCommentSlashDiscussionDumpsterID, "--comments")
 	show.Dir = repo
 	d, err := show.CombinedOutput()
 	if err != nil {
@@ -106,7 +109,7 @@ func Test_mrReplyAndResolve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resolve := exec.Command(labBinaryPath, "mr", "resolve", "lab-testing", "1:"+noteID)
+	resolve := exec.Command(labBinaryPath, "mr", "resolve", "lab-testing", mrCommentSlashDiscussionDumpsterID+":"+noteID)
 	resolve.Dir = repo
 	e, err := resolve.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
not sustainable and these test should be dealt with as they will pass
for the most part if any one of them does as they only verify the
presence of a note / discussions

Perhaps they should just be removed?