### PR TITLE
util: fix dup2() usage for Linux and Darwin

### DIFF
--- a/cmd/util_darwin.go
+++ b/cmd/util_darwin.go
@@ -1,0 +1,32 @@
+// This file contains Darwin (MacOS) specific calls.
+
+// +build darwin
+
+package cmd
+
+// Unfortunatelly MacOS don't have the DUP3() system call, which is forced
+// by Linux ARM64 not having the DUP2() anymore. With that, we need to
+// repeat the other code and func declarations that are the same.
+
+// FIXME: there MUST be some better way to do that... only dupFD2() should be
+// here.
+
+import "syscall"
+
+var (
+	sysStdout = syscall.Stdout
+	sysStderr = syscall.Stderr
+)
+
+func closeFD(fd int) error {
+	return syscall.Close(fd)
+}
+
+func dupFD(fd int) (int, error) {
+	return syscall.Dup(fd)
+}
+
+// From what I've seen, darwin is the only OS without DUP3() support
+func dupFD2(newFD, oldFD int) error {
+	return syscall.Dup2(newFD, oldFD)
+}

--- a/cmd/util_unix.go
+++ b/cmd/util_unix.go
@@ -1,13 +1,13 @@
 // This file contains Linux specific calls.
 
-// +build !windows
+// +build !windows,!darwin
 
 package cmd
 
 // Since we're using some system calls that are platform-specific, we need
 // to make sure we have a small layer of compatibility for Unix-like and
 // Windows operating systems. For now, this file is still valid for BSDs
-// (MacOS included).
+// (MacOS NOT included)
 
 import "syscall"
 
@@ -27,6 +27,8 @@ func dupFD(fd int) (int, error) {
 	return syscall.Dup(fd)
 }
 
+// Dup2() is not supported in Linux arm64, so we need to change it.
+// Dup3() is available in all Linux arches and BSD* variants, but not darwin.
 func dupFD2(newFD, oldFD int) error {
-	return syscall.Dup2(newFD, oldFD)
+	return syscall.Dup3(newFD, oldFD, 0)
 }


### PR DESCRIPTION
And we have yet another OS-specific issue to solve.
This time is a diff between Linux and Darwin (MacOS):
* Linux ARM64 lacks DUP2() syscall, so we need to use DUP3(), however...
* Darwin lacks DUP3(), so we need to create a specific file for it.

Down side of that is: great part of _unix.go file must be replicated in _darwin.go one.
For the sake of getting a new release out of the door, I'm literally copying+pasting the code, but it should (I HOPE) have a better way to handle this "partial" incompatibility.

EDIT: dup3() is available from userspace in Linux ARM64 glibc, but we don't have access to it from Go lib and we can't rely every system uses glibc.