### PR TITLE
Add subscribe/unsubscribe subcommands

### DIFF
--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -68,6 +68,7 @@ func printIssue(issue *gitlab.Issue, project string, renderMarkdown bool) {
 	milestone := "None"
 	timestats := "None"
 	dueDate := "None"
+	subscribed := "No"
 	state := map[string]string{
 		"opened": "Open",
 		"closed": "Closed",
@@ -109,6 +110,10 @@ func printIssue(issue *gitlab.Issue, project string, renderMarkdown bool) {
 		log.Fatal(err)
 	}
 
+	if issue.Subscribed {
+		subscribed = "Yes"
+	}
+
 	fmt.Printf(`
 #%d %s
 ===================================
@@ -124,6 +129,7 @@ Time Stats: %s
 Labels: %s
 Related MRs: %s
 MRs that will close this Issue: %s
+Subscribed: %s
 WebURL: %s
 `,
 		issue.IID, issue.Title, issue.Description, project, state, strings.Join(assignees, ", "),
@@ -131,7 +137,7 @@ WebURL: %s
 		strings.Join(issue.Labels, ", "),
 		strings.Trim(strings.Replace(fmt.Sprint(relatedMRs), " ", ",", -1), "[]"),
 		strings.Trim(strings.Replace(fmt.Sprint(closingMRs), " ", ",", -1), "[]"),
-		issue.WebURL,
+		subscribed, issue.WebURL,
 	)
 }
 

--- a/cmd/issue_show_test.go
+++ b/cmd/issue_show_test.go
@@ -36,6 +36,7 @@ Time Stats: Estimated 40h, Spent 8h
 Labels: bug
 Related MRs: 1
 MRs that will close this Issue: 
+Subscribed: No
 WebURL: https://gitlab.com/zaquestion/test/-/issues/1
 `)
 

--- a/cmd/issue_subscribe.go
+++ b/cmd/issue_subscribe.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var issueSubscribeCmd = &cobra.Command{
+	Use:              "subscribe [remote] <id>",
+	Aliases:          []string{},
+	Short:            "Subscribe to issue",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, id, err := parseArgsRemoteAndID(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		p, err := lab.FindProject(rn)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = lab.IssueSubscribe(p.ID, int(id))
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Subscribed to issue #%d\n", id)
+	},
+}
+
+func init() {
+	issueCmd.AddCommand(issueSubscribeCmd)
+	carapace.Gen(issueSubscribeCmd).PositionalCompletion(
+		action.Remotes(),
+		action.Issues(issueList),
+	)
+}

--- a/cmd/issue_subscribe_test.go
+++ b/cmd/issue_subscribe_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/acarl005/stripansi"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_issueSubscribeSetup(t *testing.T) {
+	repo := copyTestRepo(t)
+	orig := exec.Command(labBinaryPath, "issue", "show", "1")
+	orig.Dir = repo
+
+	b, err := orig.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	origOutput := string(b)
+	origOutput = stripansi.Strip(origOutput)
+
+	require.Contains(t, origOutput, `Subscribed: No`)
+}
+
+func Test_issueSubscribe(t *testing.T) {
+	repo := copyTestRepo(t)
+	orig := exec.Command(labBinaryPath, "issue", "subscribe", "1")
+	orig.Dir = repo
+
+	b, err := orig.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	origOutput := string(b)
+	origOutput = stripansi.Strip(origOutput)
+
+	require.Contains(t, origOutput, `Subscribed to issue #1`)
+}
+
+func Test_issueUnsubscribe(t *testing.T) {
+	repo := copyTestRepo(t)
+	orig := exec.Command(labBinaryPath, "issue", "unsubscribe", "1")
+	orig.Dir = repo
+
+	b, err := orig.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	origOutput := string(b)
+	origOutput = stripansi.Strip(origOutput)
+
+	require.Contains(t, origOutput, `Unsubscribed from issue #1`)
+}

--- a/cmd/issue_unsubscribe.go
+++ b/cmd/issue_unsubscribe.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var issueUnsubscribeCmd = &cobra.Command{
+	Use:              "unsubscribe [remote] <id>",
+	Aliases:          []string{},
+	Short:            "Unubscribe from issue",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, id, err := parseArgsRemoteAndID(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		p, err := lab.FindProject(rn)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = lab.IssueUnsubscribe(p.ID, int(id))
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Unsubscribed from issue #%d\n", id)
+	},
+}
+
+func init() {
+	issueCmd.AddCommand(issueUnsubscribeCmd)
+	carapace.Gen(issueUnsubscribeCmd).PositionalCompletion(
+		action.Remotes(),
+		action.Issues(issueList),
+	)
+}

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -124,6 +124,7 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 	milestone := "None"
 	labels := "None"
 	approvedByUsers := "None"
+	subscribed := "No"
 	state := map[string]string{
 		"opened": "Open",
 		"closed": "Closed",
@@ -165,6 +166,10 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 		approvedByUsers = strings.Join(approvedBys, ", ")
 	}
 
+	if mr.Subscribed {
+		subscribed = "Yes"
+	}
+
 	fmt.Printf(`
 !%d %s
 ===================================
@@ -179,13 +184,14 @@ Approved By: %s
 Milestone: %s
 Labels: %s
 Issues Closed by this MR: %s
+Subscribed: %s
 WebURL: %s
 `,
 		mr.IID, mr.Title, mr.Description, project, mr.SourceBranch,
 		mr.TargetBranch, state, assignee,
 		mr.Author.Username, approvedByUsers, milestone, labels,
 		strings.Trim(strings.Replace(fmt.Sprint(closingIssues), " ", ",", -1), "[]"),
-		mr.WebURL,
+		subscribed, mr.WebURL,
 	)
 }
 

--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -38,6 +38,7 @@ Approved By: None
 Milestone: 1.0
 Labels: documentation
 Issues Closed by this MR: 
+Subscribed: Yes
 WebURL: https://gitlab.com/zaquestion/test/-/merge_requests/1`)
 	require.Contains(t, string(b), `commented at`)
 	require.Contains(t, string(b), `updated comment at`)

--- a/cmd/mr_subscribe.go
+++ b/cmd/mr_subscribe.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var mrSubscribeCmd = &cobra.Command{
+	Use:              "subscribe [remote] <id>",
+	Aliases:          []string{},
+	Short:            "Subscribe to merge request",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, id, err := parseArgsWithGitBranchMR(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		p, err := lab.FindProject(rn)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = lab.MRSubscribe(p.ID, int(id))
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Subscribed to merge request !%d\n", id)
+	},
+}
+
+func init() {
+	mrCmd.AddCommand(mrSubscribeCmd)
+	carapace.Gen(mrSubscribeCmd).PositionalCompletion(
+		action.Remotes(),
+		action.MergeRequests(mrList),
+	)
+}

--- a/cmd/mr_subscribe_test.go
+++ b/cmd/mr_subscribe_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/acarl005/stripansi"
+	"github.com/stretchr/testify/require"
+)
+
+// https://gitlab.com/zaquestion/test/-/merge_requests/18 was opened for these
+// tests
+
+func Test_mrSubscribeSetup(t *testing.T) {
+	repo := copyTestRepo(t)
+	orig := exec.Command(labBinaryPath, "mr", "show", "18")
+	orig.Dir = repo
+
+	b, err := orig.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	origOutput := string(b)
+	origOutput = stripansi.Strip(origOutput)
+
+	require.Contains(t, origOutput, `Subscribed: No`)
+}
+
+func Test_mrSubscribe(t *testing.T) {
+	repo := copyTestRepo(t)
+	orig := exec.Command(labBinaryPath, "mr", "subscribe", "18")
+	orig.Dir = repo
+
+	b, err := orig.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	origOutput := string(b)
+	origOutput = stripansi.Strip(origOutput)
+
+	require.Contains(t, origOutput, `Subscribed to merge request !18`)
+}
+
+func Test_mrUnsubscribe(t *testing.T) {
+	repo := copyTestRepo(t)
+	orig := exec.Command(labBinaryPath, "mr", "unsubscribe", "18")
+	orig.Dir = repo
+
+	b, err := orig.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	origOutput := string(b)
+	origOutput = stripansi.Strip(origOutput)
+
+	require.Contains(t, origOutput, `Unsubscribed from merge request !18`)
+}

--- a/cmd/mr_unsubscribe.go
+++ b/cmd/mr_unsubscribe.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var mrUnsubscribeCmd = &cobra.Command{
+	Use:              "unsubscribe [remote] <id>",
+	Aliases:          []string{},
+	Short:            "Unubscribe from merge request",
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, id, err := parseArgsWithGitBranchMR(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		p, err := lab.FindProject(rn)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = lab.MRUnsubscribe(p.ID, int(id))
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Unsubscribed from merge request !%d\n", id)
+	},
+}
+
+func init() {
+	mrCmd.AddCommand(mrUnsubscribeCmd)
+	carapace.Gen(mrUnsubscribeCmd).PositionalCompletion(
+		action.Remotes(),
+		action.MergeRequests(mrList),
+	)
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -535,6 +535,30 @@ func MRUnapprove(pid interface{}, id int) error {
 	return nil
 }
 
+// MRSubscribe subscribes to an mr on a GitLab project
+func MRSubscribe(pid interface{}, id int) error {
+	_, resp, err := lab.MergeRequests.SubscribeToMergeRequest(pid, id, nil)
+	if resp != nil && resp.StatusCode == http.StatusNotModified {
+		return errors.New("Already subscribed")
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MRUnsubscribe unsubscribes from a previously mr on a GitLab project
+func MRUnsubscribe(pid interface{}, id int) error {
+	_, resp, err := lab.MergeRequests.UnsubscribeFromMergeRequest(pid, id, nil)
+	if resp != nil && resp.StatusCode == http.StatusNotModified {
+		return errors.New("Not subscribed")
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // MRThumbUp places a thumb up/down on a merge request
 func MRThumbUp(pid interface{}, id int) error {
 	_, _, err := lab.AwardEmoji.CreateMergeRequestAwardEmoji(pid, id, &gitlab.CreateAwardEmojiOptions{
@@ -742,6 +766,30 @@ func IssueListDiscussions(project string, issueNum int) ([]*gitlab.Discussion, e
 	}
 
 	return discussions, nil
+}
+
+// IssueSubscribe subscribes to an issue on a GitLab project
+func IssueSubscribe(pid interface{}, id int) error {
+	_, resp, err := lab.Issues.SubscribeToIssue(pid, id, nil)
+	if resp != nil && resp.StatusCode == http.StatusNotModified {
+		return errors.New("Already subscribed")
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// IssueUnsubscribe unsubscribes from an issue on a GitLab project
+func IssueUnsubscribe(pid interface{}, id int) error {
+	_, resp, err := lab.Issues.UnsubscribeFromIssue(pid, id, nil)
+	if resp != nil && resp.StatusCode == http.StatusNotModified {
+		return errors.New("Not subscribed")
+	}
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // GetCommit returns top Commit by ref (hash, branch or tag).


### PR DESCRIPTION
For projects where one is only tangentially involved, it sometimes
makes sense to subscribe to an individual issue or merge request
rather than the project as a whole.
    
Support that with corresponding subcommands.
