### PR TITLE
Completely drop hub support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,13 @@
 
 <p align="center"><img src="https://user-images.githubusercontent.com/1964720/42740177-6478d834-8858-11e8-9667-97f193ecb404.gif" align="center"></p>
 
-Lab wraps Git or [Hub](https://github.com/github/hub), making it simple to clone, fork, and interact with repositories on GitLab, including seamless workflows for creating merge requests, issues and snippets.
+Lab wraps Git, making it simple to clone, fork, and interact with repositories on GitLab, including seamless workflows for creating merge requests, issues and snippets.
 
 ```
 $ lab clone gitlab-com/infrastructure
 
 # expands to:
 $ git clone git@gitlab.com:gitlab-com/infrastructure
-```
-
-## hub + <img src="https://user-images.githubusercontent.com/3167497/34473826-40b4987c-ef2c-11e7-90b9-5ff322c4966f.png" width="30" height="30"> = hublab??
-
-lab will look for hub and uses that as your git binary when available so you don't have to give up hub to use lab
-```
-$ lab version
-git version 2.11.0
-hub version 2.3.0-pre9
-lab version 0.20.0
 ```
 
 # Inspiration
@@ -29,7 +19,7 @@ The [hub](https://github.com/github/hub) tool made my life significantly easier 
 
 Dependencies
 
-* `git` or `hub`
+* `git`
 
 ### Homebrew
 ```
@@ -147,7 +137,7 @@ source <(lab completion zsh)
 
 # Aliasing
 
-Like hub, lab feels best when aliased as `git`, however it's perfectly reasonable to use as a standalone tool. In your `.bashrc` or `.bash_profile`:
+`lab` feels best when aliased as `git`, however it's perfectly reasonable to use as a standalone tool. In your `.bashrc` or `.bash_profile`:
 
 ```
 alias git=lab

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -87,19 +87,6 @@ func forkFromOrigin(project string) {
 		log.Fatal("remote: upstream already exists")
 	}
 
-	remoteURL, err := gitconfig.Local("remote.origin.url")
-	if err != nil {
-		log.Fatal(err)
-	}
-	if git.IsHub && strings.Contains(remoteURL, "github.com") {
-		git := git.New("fork")
-		git.Run()
-		if err != nil {
-			log.Fatal(err)
-		}
-		return
-	}
-
 	forkRemoteURL, err := lab.Fork(project, forkOpts, useHTTP, waitFork)
 	if err != nil {
 		if err.Error() == "not finished" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,11 +76,8 @@ func helpFunc(cmd *cobra.Command, args []string) {
 		}
 		return
 	}
-	formatChar := "\n"
-	if git.IsHub {
-		formatChar = ""
-	}
 
+	formatChar := "\n"
 	git := git.New()
 	git.Stdout = nil
 	git.Stderr = nil
@@ -182,7 +179,6 @@ func Execute() {
 	if err != nil || cmd.Use == "clone" {
 		// Determine if any undefined flags were passed to "clone"
 		// TODO: Evaluate and support some of these flags
-		// NOTE: `hub help -a` wraps the `git help -a` output
 		if (cmd.Use == "clone" && len(os.Args) > 2) || os.Args[1] == "help" {
 			// ParseFlags will err in these cases
 			err = cmd.ParseFlags(os.Args[1:])
@@ -193,17 +189,6 @@ func Execute() {
 				}
 				return
 			}
-		}
-
-		// Lab passthrough for these commands can cause confusion. See #163
-		if os.Args[1] == "create" {
-			log.Fatalf("Please call `hub create` directly for github, the lab equivalent is `lab project create`")
-		}
-		if os.Args[1] == "browse" {
-			log.Fatalf("Please call `hub browse` directly for github, the lab equivalent is `lab <object> browse`")
-		}
-		if os.Args[1] == "alias" {
-			log.Fatalf("Please call `hub alias` directly for github, there is no lab equivalent`")
 		}
 
 		// Passthrough to git for any unrecognized commands

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -19,24 +19,11 @@ import (
 	gitconfig "github.com/tcnksm/go-gitconfig"
 )
 
-// IsHub is true when using "hub" as the git binary
-var IsHub bool
-
-func init() {
-	_, err := exec.LookPath("hub")
-	if err == nil {
-		IsHub = true
-	}
-}
-
-// New looks up the hub or git binary and returns a cmd which outputs to stdout
+// New looks up the git binary and returns a cmd which outputs to stdout
 func New(args ...string) *exec.Cmd {
-	gitPath, err := exec.LookPath("hub")
+	gitPath, err := exec.LookPath("git")
 	if err != nil {
-		gitPath, err = exec.LookPath("git")
-		if err != nil {
-			log.Fatal(err)
-		}
+		log.Fatal(err)
 	}
 
 	cmd := exec.Command(gitPath, args...)


### PR DESCRIPTION
We have partially supported the `hub` tool for a while, but considering it's now deprecated we should just remove any mention of it as "part of" `lab`, or `lab` wrapping it.