### PR TITLE
allow user to set custom remote name on fork

### DIFF
--- a/cmd/fork_test.go
+++ b/cmd/fork_test.go
@@ -181,15 +181,18 @@ func Test_forkWait(t *testing.T) {
 func Test_determineForkRemote(t *testing.T) {
 	tests := []struct {
 		desc     string
+		custom   string
 		project  string
 		expected string
 	}{
-		{"project is forked from repo", "zaquestion", "lab-testing"},
-		{"project is user", "lab-testing", "upstream"},
+		{"project is forked from repo", "", "zaquestion", "lab-testing"},
+		{"project is user", "", "lab-testing", "upstream"},
+		{"project is user", "custom-test", "lab-testing", "custom-test"},
 	}
 
 	for _, test := range tests {
 		test := test
+		remoteName = test.custom
 		t.Run(test.desc, func(t *testing.T) {
 			require.Equal(t, test.expected, determineForkRemote(test.project))
 		})


### PR DESCRIPTION
Today, `lab` only allows the user to setup the <user> or "upstream" remotes in a fork or clone process. This patch enables the option `--remote-name` (or `-r`) for setting a custom remote name. Somewhat the same behavior as `git clone -o`.