### PR TITLE
use <url> in case of an empty <pushurl>

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -203,7 +203,7 @@ func UpstreamBranch(branch string) (string, error) {
 // Respects GitLab subgroups (https://docs.gitlab.com/ce/user/group/subgroups/)
 func PathWithNameSpace(remote string) (string, error) {
 	remoteURL, err := gitconfig.Local("remote." + remote + ".pushurl")
-	if err != nil {
+	if err != nil || remoteURL == "" {
 		remoteURL, err = gitconfig.Local("remote." + remote + ".url")
 		if err != nil {
 			return "", err

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -127,6 +127,12 @@ func TestPathWithNameSpace(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			desc:        "empty-pushurl",
+			remote:      "origin-empty-pushurl",
+			expected:    "zaquestion/test",
+			expectedErr: "",
+		},
+		{
 			desc:        "https://token@gitlab.com/org/repo",
 			remote:      "origin-https-token",
 			expected:    "zaquestion/test",

--- a/testdata/test.git/config
+++ b/testdata/test.git/config
@@ -34,6 +34,10 @@
 	url = garbageurl
 	pushurl = https://gitlab.com/zaquestion/test.git
 	fetch = +refs/heads/*:refs/remotes/origin-pushurl/*
+[remote "origin-empty-pushurl"]
+	url = https://gitlab.com/zaquestion/test.git
+	pushurl = 
+	fetch = +refs/heads/*:refs/remotes/origin-empty-pushurl/*
 [remote "origin-https-token"]
 	url = https://token@gitlab.com/zaquestion/test.git
 	fetch = +refs/heads/*:refs/remotes/origin-https-token/*


### PR DESCRIPTION
Some developers like to have the <pushurl> set to nothing (empty) to avoid pushing by mistake to that remote. This patch adds a check for an empty string against <pushurl> and use <url> instead.