### PR TITLE
allow user to update target branch while editing an MR

### DIFF
--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -133,6 +134,23 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 			milestoneID = ms.ID
 		}
 
+		targetBranchName, err := cmd.Flags().GetString("target-branch")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		targetBranchChanged := false
+		if targetBranchName != "" {
+			targetBranchName, err = getBranchName(rn, targetBranchName)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if targetBranchName != mr.TargetBranch {
+				targetBranchChanged = true
+			}
+		}
+
 		// get all of the "message" flags
 		msgs, err := cmd.Flags().GetStringSlice("message")
 		if err != nil {
@@ -170,7 +188,9 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 			}
 		}
 
-		abortUpdate := title == mr.Title && body == mr.Description && !labelsChanged && !assigneesChanged && !updateMilestone
+		abortUpdate := (title == mr.Title && body == mr.Description &&
+			!labelsChanged && !assigneesChanged && !updateMilestone &&
+			!targetBranchChanged)
 		if abortUpdate {
 			log.Fatal("aborting: no changes")
 		}
@@ -196,6 +216,10 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 			opts.MilestoneID = &milestoneID
 		}
 
+		if targetBranchChanged {
+			opts.TargetBranch = &targetBranchName
+		}
+
 		mrURL, err := lab.MRUpdate(rn, int(mrNum), opts)
 		if err != nil {
 			log.Fatal(err)
@@ -216,6 +240,46 @@ func mrGetCurrentAssignees(mr *gitlab.MergeRequest) []string {
 	return currentAssignees
 }
 
+// getBranchName considers the possible ambiguity of different branch names
+func getBranchName(project, branch string) (string, error) {
+	opts := &gitlab.ListBranchesOptions{
+		Search: &branch,
+	}
+
+	projectBranches, err := lab.BranchList(project, opts)
+	if err != nil {
+		return "", err
+	}
+
+	// Branch API accepts a search parameter, so we may get the answer
+	// right away, however, the search term may match as a substring, so we
+	// also need to check for multiple branch names and their ambiguity
+	var match string
+
+	switch len(projectBranches) {
+	case 0:
+		return "", errors.Errorf("Branch '%s' not found\n", branch)
+	case 1:
+		match = projectBranches[0].Name
+	default:
+		branchNames := make([]string, len(projectBranches))
+		for _, branch := range projectBranches {
+			branchNames = append(branchNames, branch.Name)
+		}
+
+		// Handle term ambiguity for multiple matched branch names
+		matches, err := matchTerms([]string{branch}, branchNames)
+		if err != nil {
+			return "", errors.Errorf("Branch %s\n", err.Error())
+		}
+
+		// we only asked for a single term
+		match = matches[0]
+	}
+
+	return match, nil
+}
+
 func init() {
 	mrEditCmd.Flags().StringSliceP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	mrEditCmd.Flags().StringSliceP("label", "l", []string{}, "add the given label(s) to the merge request")
@@ -223,6 +287,7 @@ func init() {
 	mrEditCmd.Flags().StringSliceP("assign", "a", []string{}, "add an assignee by username")
 	mrEditCmd.Flags().StringSliceP("unassign", "", []string{}, "remove an assignee by username")
 	mrEditCmd.Flags().String("milestone", "", "set milestone")
+	mrEditCmd.Flags().StringP("target-branch", "t", "", "set target branch")
 	mrEditCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	mrEditCmd.Flags().Bool("draft", false, "mark the merge request as draft")
 	mrEditCmd.Flags().Bool("ready", false, "mark the merge request as ready")

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -361,6 +361,64 @@ func Test_determineSourceRemote(t *testing.T) {
 	os.Chdir(oldWd)
 }
 
+func Test_matchTerms(t *testing.T) {
+	tests := []struct {
+		desc        string
+		search      []string
+		existent    []string
+		expected    []string
+		expectedErr string
+	}{
+		{
+			desc:        "no match",
+			search:      []string{"asd", "zxc"},
+			existent:    []string{"dsa", "cxz"},
+			expected:    []string{""},
+			expectedErr: "'asd' not found",
+		},
+		{
+			desc:        "full match",
+			search:      []string{"asd", "zxc"},
+			existent:    []string{"asd", "zxc"},
+			expected:    []string{"asd", "zxc"},
+			expectedErr: "",
+		},
+		{
+			desc:        "substring match",
+			search:      []string{"as", "zx"},
+			existent:    []string{"as", "asd", "zxc"},
+			expected:    []string{"as", "zxc"},
+			expectedErr: "",
+		},
+		{
+			desc:        "ambiguous terms",
+			search:      []string{"as", "zx"},
+			existent:    []string{"asd", "asf", "zxc", "zxv"},
+			expected:    []string{""},
+			expectedErr: "'as' has no exact match and is ambiguous",
+		},
+	}
+
+	t.Parallel()
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			matches, err := matchTerms(test.search, test.existent)
+			if test.expected[0] != "" {
+				assert.Equal(t, test.expected, matches)
+			} else {
+				assert.Nil(t, matches)
+			}
+
+			if test.expectedErr != "" {
+				assert.EqualError(t, err, test.expectedErr)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
 func Test_same(t *testing.T) {
 	t.Parallel()
 	assert.True(t, same([]string{}, []string{}))

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -874,6 +874,32 @@ func LabelDelete(project, name string) error {
 	return err
 }
 
+// BranchList get all branches from the project that somehow matches the
+// requested options
+func BranchList(project string, opts *gitlab.ListBranchesOptions) ([]*gitlab.Branch, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return nil, err
+	}
+
+	branches := []*gitlab.Branch{}
+	opts.ListOptions.Page = 1
+	for {
+		bList, resp, err := lab.Branches.ListBranches(p.ID, opts)
+		if err != nil {
+			return nil, err
+		}
+		branches = append(branches, bList...)
+
+		if opts.Page >= resp.TotalPages {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return branches, nil
+}
+
 func MilestoneGet(project string, name string) (*gitlab.Milestone, error) {
 	opts := &gitlab.ListMilestonesOptions{
 		Search: &name,


### PR DESCRIPTION
Add the `--target-branch` (or `-t`) flag to the mr_edit command, allowing the user to update the target branch for that specific MR through `lab`.