### PR TITLE
add "all" state to completion action values for MR and Issues

### DIFF
--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -116,7 +116,7 @@ func init() {
 
 	issueCmd.AddCommand(issueListCmd)
 	carapace.Gen(issueListCmd).FlagCompletion(carapace.ActionMap{
-		"state": carapace.ActionValues("opened", "closed"),
+		"state": carapace.ActionValues("all", "opened", "closed"),
 	})
 	carapace.Gen(issueListCmd).PositionalCompletion(
 		action.Remotes(),

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -184,7 +184,7 @@ func init() {
 
 	mrCmd.AddCommand(listCmd)
 	carapace.Gen(listCmd).FlagCompletion(carapace.ActionMap{
-		"state": carapace.ActionValues("opened", "closed", "merged"),
+		"state": carapace.ActionValues("all", "opened", "closed", "merged"),
 	})
 
 	carapace.Gen(listCmd).PositionalCompletion(


### PR DESCRIPTION
The "all" state was not being added to the completion code. This patch adds it alongside the other options.