### PR TITLE
mr_edit: allow user to reset MR description from file

### DIFF
--- a/cmd/edit_common.go
+++ b/cmd/edit_common.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bufio"
+	"os"
 	"strings"
 
 	"github.com/zaquestion/lab/internal/git"
@@ -40,8 +42,9 @@ func getUpdateAssignees(currentAssignees []string, assignees []string, unassigne
 	return assigneeIDs, assigneesChanged, nil
 }
 
-// editGetTitleDescription returns a title and description based on the current
-// issue title and description and various flags from the command line
+// editGetTitleDescription returns a title and description based on the
+// current issue title and description and various flags from the command
+// line
 func editGetTitleDescription(title string, body string, msgs []string, nFlag int) (string, string, error) {
 	if len(msgs) > 0 {
 		title = msgs[0]
@@ -65,4 +68,30 @@ func editGetTitleDescription(title string, body string, msgs []string, nFlag int
 		return "", "", err
 	}
 	return git.Edit("EDIT", text)
+}
+
+// editGetTitleDescFromFile returns the new title and description based on
+// the content of a file. The first line is considered the title, the
+// remaining is the description.
+func editGetTitleDescFromFile(filename string) (string, string, error) {
+	var title, body string
+
+	file, err := os.Open(filename)
+	if err != nil {
+		return "", "", nil
+	}
+	defer file.Close()
+
+	fileScan := bufio.NewScanner(file)
+	fileScan.Split(bufio.ScanLines)
+
+	// The first line in the file is the title.
+	fileScan.Scan()
+	title = fileScan.Text()
+
+	for fileScan.Scan() {
+		body = body + fileScan.Text() + "\n"
+	}
+
+	return title, body, nil
 }

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"log"
@@ -192,23 +191,10 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 			log.Fatal("option -F cannot be combined with -m/-c")
 		}
 
-		file, err := os.Open(filename)
+		title, body, err = editGetTitleDescFromFile(filename)
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		fileScan := bufio.NewScanner(file)
-		fileScan.Split(bufio.ScanLines)
-
-		// The first line in the file is the title.
-		fileScan.Scan()
-		title = fileScan.Text()
-
-		for fileScan.Scan() {
-			body = body + fileScan.Text() + "\n"
-		}
-
-		file.Close()
 	} else if len(msgs) > 0 {
 		if coverLetterFormat {
 			log.Fatal("option -m cannot be combined with -c/-F")

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -99,6 +99,11 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 			log.Fatal(err)
 		}
 
+		filename, err := cmd.Flags().GetString("file")
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		draft, err := cmd.Flags().GetBool("draft")
 		if err != nil {
 			log.Fatal(err)
@@ -156,11 +161,27 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 		if err != nil {
 			log.Fatal(err)
 		}
-		title, body, err := editGetTitleDescription(mr.Title, mr.Description, msgs, cmd.Flags().NFlag())
-		if err != nil {
-			_, f, l, _ := runtime.Caller(0)
-			log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
+
+		var title, body string
+
+		if filename != "" {
+			if len(msgs) > 0 {
+				log.Fatal("option -F cannot be combined with -m")
+			}
+
+			title, body, err = editGetTitleDescFromFile(filename)
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			title, body, err = editGetTitleDescription(
+				mr.Title, mr.Description, msgs, cmd.Flags().NFlag())
+			if err != nil {
+				_, f, l, _ := runtime.Caller(0)
+				log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
+			}
 		}
+
 		if title == "" {
 			log.Fatal("aborting: empty mr title")
 		}
@@ -288,6 +309,7 @@ func init() {
 	mrEditCmd.Flags().StringSliceP("unassign", "", []string{}, "remove an assignee by username")
 	mrEditCmd.Flags().String("milestone", "", "set milestone")
 	mrEditCmd.Flags().StringP("target-branch", "t", "", "set target branch")
+	mrEditCmd.Flags().StringP("file", "F", "", "use the given file as the description")
 	mrEditCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	mrEditCmd.Flags().Bool("draft", false, "mark the merge request as draft")
 	mrEditCmd.Flags().Bool("ready", false, "mark the merge request as ready")


### PR DESCRIPTION
Add `-F` option to mr_edit, allowing the user to pass a file as input for resetting the MR description.