### PR TITLE
mr show: Fix --no-color-diff help

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -201,7 +201,7 @@ func init() {
 	mrShowCmd.Flags().StringP("since", "s", "", "show comments since specified date (format: 2020-08-21 14:57:46.808 +0000 UTC)")
 	mrShowCmd.Flags().BoolVarP(&mrShowPatch, "patch", "p", false, "show MR patches")
 	mrShowCmd.Flags().BoolVarP(&mrShowPatchReverse, "reverse", "", false, "reverse order when showing MR patches (chronological instead of anti-chronological)")
-	mrShowCmd.Flags().BoolVarP(&mrShowNoColorDiff, "no-color-diff", "", false, "show color diffs in comments")
+	mrShowCmd.Flags().BoolVarP(&mrShowNoColorDiff, "no-color-diff", "", false, "do not show color diffs in comments")
 	mrCmd.AddCommand(mrShowCmd)
 	carapace.Gen(mrShowCmd).PositionalCompletion(
 		action.Remotes(),

--- a/docs/lab_mr_show.md
+++ b/docs/lab_mr_show.md
@@ -11,7 +11,7 @@ lab mr show [remote] <id> [flags]
 ```
   -c, --comments        show comments for the merge request
   -h, --help            help for show
-      --no-color-diff   show color diffs in comments
+      --no-color-diff   do not show color diffs in comments
   -M, --no-markdown     don't use markdown renderer to print the issue description
   -p, --patch           show MR patches
       --reverse         reverse order when showing MR patches (chronological instead of anti-chronological)


### PR DESCRIPTION
The help for '--no-color-diff' is exactly wrong.

Fix --no-color-diff so that it outputs the correct message.

Reported by: Lenny Szubowicz <lszubowi@redhat.com>
Signed-off-by: Prarit Bhargava <prarit@redhat.com>