### PR TITLE
mr,issue,snippet: make shorthand flags deprecated

### DIFF
--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -36,7 +36,10 @@ var issueCmd = &cobra.Command{
 
 func init() {
 	issueCmd.Flags().BoolP("list", "l", false, "list issues on a remote")
+	issueCmd.Flags().MarkDeprecated("list", "use the \"list\" subcommand instead")
 	issueCmd.Flags().BoolP("browse", "b", false, "view issue <id> in a browser")
+	issueCmd.Flags().MarkDeprecated("browse", "use the \"browse\" subcommand instead")
 	issueCmd.Flags().StringP("close", "d", "", "close issue <id> on remote")
+	issueCmd.Flags().MarkDeprecated("close", "use the \"close\" subcommand instead")
 	RootCmd.AddCommand(issueCmd)
 }

--- a/cmd/mr.go
+++ b/cmd/mr.go
@@ -37,7 +37,10 @@ var mrCmd = &cobra.Command{
 
 func init() {
 	mrCmd.Flags().BoolP("list", "l", false, "list merge requests on a remote")
+	mrCmd.Flags().MarkDeprecated("list", "use the \"list\" subcommand instead")
 	mrCmd.Flags().BoolP("browse", "b", false, "view merge request <id> in a browser")
+	mrCmd.Flags().MarkDeprecated("browse", "use the \"browse\" subcommand instead")
 	mrCmd.Flags().StringP("close", "d", "", "close merge request <id> on remote")
+	mrCmd.Flags().MarkDeprecated("close", "use the \"close\" subcommand instead")
 	RootCmd.AddCommand(mrCmd)
 }

--- a/cmd/snippet.go
+++ b/cmd/snippet.go
@@ -52,8 +52,11 @@ var (
 func init() {
 	snippetCmd.PersistentFlags().BoolVarP(&global, "global", "g", false, "create as a personal snippet")
 	snippetCmd.Flags().BoolP("list", "l", false, "list snippets")
+	snippetCmd.Flags().MarkDeprecated("list", "use the \"list\" subcommand instead")
 	snippetCmd.Flags().BoolP("browse", "b", false, "browse snippets")
+	snippetCmd.Flags().MarkDeprecated("browse", "use the \"browse\" subcommand instead")
 	snippetCmd.Flags().StringP("delete", "d", "", "delete snippet with id")
+	snippetCmd.Flags().MarkDeprecated("delete", "use the \"delete\" subcommand instead")
 	// Create flags added in snippetCreate.go
 	RootCmd.AddCommand(snippetCmd)
 }


### PR DESCRIPTION
Deprecate shorthand flags directly in the commands (mr, issue and snippet).

These shorthands don't really work as expected: the flags from the subcommands are not available for them, so it has been basically a shorthand for the default behavior of a subcommand: `lab mr list` == `lab mr --list`, and that's it. IMHO, the subcommand is easier to type than the shorthand, so I don't think it makes sense to keep them around.