### PR TITLE
mr show: Display output for approvers and reviewers

### DIFF
--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -35,6 +35,9 @@ Status: Open
 Assignee: zaquestion
 Author: zaquestion
 Approved By: None
+Approvers: None
+Approval Groups: None
+Reviewers: None
 Milestone: 1.0
 Labels: documentation
 Issues Closed by this MR: 

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1635,24 +1635,18 @@ func MoveIssue(project string, issueNum int, dest string) (string, error) {
 	return fmt.Sprintf("%s/issues/%d", destProject.WebURL, issue.IID), nil
 }
 
-func GetMRApprovedBys(project string, mrNum int) ([]string, error) {
-	var retArray []string
-
+func GetMRApprovalsConfiguration(project string, mrNum int) (*gitlab.MergeRequestApprovals, error) {
 	p, err := FindProject(project)
 	if err != nil {
-		return retArray, err
+		return nil, err
 	}
 
 	configuration, _, err := lab.MergeRequestApprovals.GetConfiguration(p.ID, mrNum)
 	if err != nil {
-		return retArray, err
+		return nil, err
 	}
 
-	for _, approvedby := range configuration.ApprovedBy {
-		retArray = append(retArray, approvedby.User.Username)
-	}
-
-	return retArray, err
+	return configuration, err
 }
 
 func ResolveMRDiscussion(project string, mrNum int, discussionID string, noteID int) (string, error) {


### PR DESCRIPTION
Several users have requested that the list of approvers and reviewers be
added to the output of the 'lab mr show' command.  This list is useful for
authors to know who to request reviews from, and to see the eligible list
of approvers.

Add Approvers, Approval Groups, and Reviewers to the output of 'lab mr
show'.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>