### PR TITLE
mr_show: fix line wrapping

### DIFF
--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -94,10 +94,10 @@ func printIssue(issue *gitlab.Issue, project string, renderMarkdown bool) {
 	}
 
 	if renderMarkdown {
-		r, _ := glamour.NewTermRenderer(
-			glamour.WithStandardStyle("auto"),
-		)
-
+		r, err := getTermRenderer(glamour.WithAutoStyle())
+		if err != nil {
+			log.Fatal(err)
+		}
 		issue.Description, _ = r.Render(issue.Description)
 	}
 

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -151,10 +151,10 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 	}
 
 	if renderMarkdown {
-		r, _ := glamour.NewTermRenderer(
-			glamour.WithStandardStyle("auto"),
-		)
-
+		r, err := getTermRenderer(glamour.WithAutoStyle())
+		if err != nil {
+			log.Fatal(err)
+		}
 		mr.Description, _ = r.Render(mr.Description)
 	}
 

--- a/cmd/show_common.go
+++ b/cmd/show_common.go
@@ -160,6 +160,14 @@ func getBoldStyle() ansi.StyleConfig {
 	return style
 }
 
+func getTermRenderer(style glamour.TermRendererOption) (*glamour.TermRenderer, error) {
+	r, err := glamour.NewTermRenderer(
+		glamour.WithWordWrap(0),
+		style,
+	)
+	return r, err
+}
+
 func printDiscussions(discussions []*gitlab.Discussion, since string, idstr string, idNum int, renderMarkdown bool) {
 	newAccessTime := time.Now().UTC()
 
@@ -179,10 +187,8 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 		sinceIsSet = false
 	}
 
-	mdRendererNormal, _ := glamour.NewTermRenderer(
-		glamour.WithAutoStyle())
-	mdRendererBold, _ := glamour.NewTermRenderer(
-		glamour.WithStyles(getBoldStyle()))
+	mdRendererNormal, _ := getTermRenderer(glamour.WithAutoStyle())
+	mdRendererBold, _ := getTermRenderer(glamour.WithStyles(getBoldStyle()))
 
 	// for available fields, see
 	// https://godoc.org/github.com/xanzy/go-gitlab#Note

--- a/cmd/show_common.go
+++ b/cmd/show_common.go
@@ -163,6 +163,9 @@ func getBoldStyle() ansi.StyleConfig {
 func getTermRenderer(style glamour.TermRendererOption) (*glamour.TermRenderer, error) {
 	r, err := glamour.NewTermRenderer(
 		glamour.WithWordWrap(0),
+		// There are PAGERs and TERMs that supports only 16 colors,
+		// since we aren't a beauty-driven project, lets use it.
+		glamour.WithColorProfile(termenv.ANSI),
 		style,
 	)
 	return r, err


### PR DESCRIPTION
This PR fixes two issues: 
1. the line wrapping behavior that `glamour` lib has enabled by default at the mark of 80 columns, which I think shouldn't, since the user is expecting to see what was exactly sent;
2. use only 16 ANSI colors pallet to allow more simple terminals and pagers to work properly.

If item 2 isn't desirable, I'm fine with dropping it.
Fixes #632.