### PR TITLE
mr_create: Check for zero commits in a Merge Request

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -22,7 +22,7 @@ import (
 
 // mrCmd represents the mr command
 var mrCreateCmd = &cobra.Command{
-	Use:              "create [remote [branch]]",
+	Use:              "create [remote [remote_branch]]",
 	Aliases:          []string{"new"},
 	Short:            "Open a merge request on GitLab",
 	Long:             `Creates a merge request (default: MR created on default branch of origin)`,

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -286,11 +286,16 @@ func mrText(base, head, sourceRemote, targetRemote string, coverLetterFormat boo
 	)
 	remoteBase := fmt.Sprintf("%s/%s", targetRemote, base)
 	commitMsg = ""
-	if git.NumberCommits(remoteBase, head) == 1 {
+
+	numCommits := git.NumberCommits(remoteBase, head)
+	if numCommits == 1 {
 		commitMsg, err = git.LastCommitMessage()
 		if err != nil {
 			return "", err
 		}
+	}
+	if numCommits == 0 {
+		return "", errors.New("Aborting: Resulting Merge Request would have had 0 commits.")
 	}
 
 	const tmpl = `{{if .InitMsg}}{{.InitMsg}}{{end}}
@@ -307,10 +312,11 @@ func mrText(base, head, sourceRemote, targetRemote string, coverLetterFormat boo
 
 	mrTmpl := lab.LoadGitLabTmpl(lab.TmplMR)
 
-	commitLogs, numCommits, err := git.Log(remoteBase, head)
+	commitLogs, err := git.Log(remoteBase, head)
 	if err != nil {
 		return "", err
 	}
+
 	commitLogs = strings.TrimSpace(commitLogs)
 	commentChar := git.CommentChar()
 

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -285,9 +285,10 @@ func mrText(base, head, sourceRemote, targetRemote string, coverLetterFormat boo
 		err       error
 	)
 	remoteBase := fmt.Sprintf("%s/%s", targetRemote, base)
+	targetBase := fmt.Sprintf("%s/%s", sourceRemote, head)
 	commitMsg = ""
 
-	numCommits := git.NumberCommits(remoteBase, head)
+	numCommits := git.NumberCommits(remoteBase, targetBase)
 	if numCommits == 1 {
 		commitMsg, err = git.LastCommitMessage()
 		if err != nil {
@@ -295,7 +296,7 @@ func mrText(base, head, sourceRemote, targetRemote string, coverLetterFormat boo
 		}
 	}
 	if numCommits == 0 {
-		return "", errors.New("Aborting: Resulting Merge Request would have had 0 commits.")
+		return "", fmt.Errorf("Aborting: The resulting Merge Request from %s to %s has 0 commits.", remoteBase, targetBase)
 	}
 
 	const tmpl = `{{if .InitMsg}}{{.InitMsg}}{{end}}
@@ -312,7 +313,7 @@ func mrText(base, head, sourceRemote, targetRemote string, coverLetterFormat boo
 
 	mrTmpl := lab.LoadGitLabTmpl(lab.TmplMR)
 
-	commitLogs, err := git.Log(remoteBase, head)
+	commitLogs, err := git.Log(remoteBase, targetBase)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/mr_create_test.go
+++ b/cmd/mr_create_test.go
@@ -9,7 +9,7 @@ import (
 // MR Create is tested in cmd/mr_test.go
 
 func Test_mrText(t *testing.T) {
-	text, err := mrText("master", "mrtest", "origin", "origin", false)
+	text, err := mrText("origin", "mrtest", "origin", "master", false)
 	if err != nil {
 		t.Log(text)
 		t.Fatal(err)
@@ -29,7 +29,7 @@ I am the default merge request template for lab
 }
 
 func Test_mrText_CoverLetter(t *testing.T) {
-	coverLetter, err := mrText("master", "mrtest", "origin", "origin", true)
+	coverLetter, err := mrText("origin", "mrtest", "origin", "master", true)
 	if err != nil {
 		t.Log(coverLetter)
 		t.Fatal(err)

--- a/cmd/mr_create_test.go
+++ b/cmd/mr_create_test.go
@@ -9,7 +9,7 @@ import (
 // MR Create is tested in cmd/mr_test.go
 
 func Test_mrText(t *testing.T) {
-	text, err := mrText("master", "mrtest", "lab-testing", "origin", false)
+	text, err := mrText("master", "mrtest", "origin", "origin", false)
 	if err != nil {
 		t.Log(text)
 		t.Fatal(err)
@@ -17,7 +17,7 @@ func Test_mrText(t *testing.T) {
 	require.Contains(t, text, `
 
 I am the default merge request template for lab
-# Requesting a merge into origin:master from lab-testing:mrtest (12 commits)
+# Requesting a merge into origin:master from origin:mrtest (12 commits)
 #
 # Write a message for this merge request. The first block
 # of text is the title and the rest is the description.
@@ -29,7 +29,7 @@ I am the default merge request template for lab
 }
 
 func Test_mrText_CoverLetter(t *testing.T) {
-	coverLetter, err := mrText("master", "mrtest", "lab-testing", "origin", true)
+	coverLetter, err := mrText("master", "mrtest", "origin", "origin", true)
 	if err != nil {
 		t.Log(coverLetter)
 		t.Fatal(err)
@@ -37,7 +37,7 @@ func Test_mrText_CoverLetter(t *testing.T) {
 	require.Contains(t, coverLetter, `
 
 I am the default merge request template for lab
-# Requesting a merge into origin:master from lab-testing:mrtest (12 commits)
+# Requesting a merge into origin:master from origin:mrtest (12 commits)
 #
 # Write a message for this merge request. The first block
 # of text is the title and the rest is the description.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -368,8 +368,8 @@ func NumberCommits(sha1, sha2 string) int {
 	cmd.Stderr = nil
 	CmdOut, err := cmd.Output()
 	if err != nil {
-		fmt.Printf("There are no commits between %s and %s\n", sha1, sha2)
-		log.Fatal(err)
+		// silently fail and handle the return of 0 at caller
+		return 0
 	}
 	numLines := strings.Count(string(CmdOut), "\n")
 	return numLines

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -117,7 +116,7 @@ func LastCommitMessage() (string, error) {
 }
 
 // Log produces a formatted gitlog between 2 git shas
-func Log(sha1, sha2 string) (string, int, error) {
+func Log(sha1, sha2 string) (string, error) {
 	cmd := New("-c", "log.showSignature=false",
 		"log",
 		"--no-color",
@@ -127,28 +126,17 @@ func Log(sha1, sha2 string) (string, int, error) {
 	cmd.Stdout = nil
 	outputs, err := cmd.Output()
 	if err != nil {
-		return "", 0, errors.Errorf("Can't load git log %s..%s", sha1, sha2)
+		return "", errors.Errorf("Can't load git log %s..%s", sha1, sha2)
 	}
 
 	diffCmd := New("diff", "--stat", sha1)
 	diffCmd.Stdout = nil
 	diffOutput, err := diffCmd.Output()
 	if err != nil {
-		return "", 0, errors.Errorf("Can't load diffstat")
+		return "", errors.Errorf("Can't load diffstat")
 	}
 
-	numCommitsCmd := New("rev-list", "--count", fmt.Sprintf("%s...%s", sha1, sha2))
-	numCommitsCmd.Stdout = nil
-	numCommitsString, err := numCommitsCmd.Output()
-	if err != nil {
-		return "", 0, errors.Errorf("Can't determine number of commits")
-	}
-	numCommits, err := strconv.Atoi(strings.TrimSpace(string(numCommitsString)))
-	if err != nil {
-		return "", 0, errors.Errorf("Can't determine number of commits(%s)", numCommitsString)
-	}
-
-	return string(outputs) + string(diffOutput), numCommits, nil
+	return string(outputs) + string(diffOutput), nil
 }
 
 // CurrentBranch returns the currently checked out branch

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -73,10 +73,11 @@ func TestLastCommitMessage(t *testing.T) {
 }
 
 func TestLog(t *testing.T) {
-	log, count, err := Log("HEAD~1", "HEAD")
+	log, err := Log("HEAD~1", "HEAD")
 	if err != nil {
 		t.Fatal(err)
 	}
+	count := NumberCommits("HEAD~1", "HEAD")
 	expectedSHA := "09b519c"
 	expectedAuthor := "Zaq? Wiedmann"
 	expectedMessage := "(ci) jobs with interleaved sleeps and prints"


### PR DESCRIPTION
'lab mr create' can incorrectly report the number of commits in a merge reuqest.  This is because the code incorrectly looks at the local source branch rather than the remote source branch when checking the number of commits.  Additionally, the 'lab mr create' also does not error if there are zero commits found between the remote source and remote target branches. 

Fix the number of commits reported by examining the remote source branch and return an error if the number of commits is zero.  

Signed-off-by: Prarit Bhargava <prarit@redhat.com>