### PR TITLE
root: make "upstream" the defaultRemote preference

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -128,15 +128,24 @@ func guessDefaultRemote() string {
 
 	guess := ""
 
-	_, err := gitconfig.Local("remote.upstream.url")
-	if err == nil {
-		guess = "upstream"
-	}
-	_, err = gitconfig.Local("remote.origin.url")
+	// defaultRemote should try to always point to the upstream project.
+	// Since "origin" may have two different meanings depending on how the
+	// user forked the project, thus make "upstream" as the most significant
+	// remote.
+	// In forkFromOrigin approach, "origin" remote is the one pointing to
+	// the upstream project.
+	_, err := gitconfig.Local("remote.origin.url")
 	if err == nil {
 		guess = "origin"
 	}
+	// In forkToUpstream approach, "upstream" remote is the one pointing to
+	// the upstream project
+	_, err = gitconfig.Local("remote.upstream.url")
+	if err == nil {
+		guess = "upstream"
+	}
 
+	// But it's still possible the user used a custom name
 	if guess == "" {
 		// use the remote tracked by the default branch if set
 		if remote, err := gitconfig.Local("branch.main.remote"); err == nil {


### PR DESCRIPTION
When a user fork a project from nothing the "forkToUpstream" approach is
used, where two remotes are set in the resulting git directory: "origin" and
"upstream", with obvious meanings. However, when the user fork a project
directly from a git directory, where the "origin" remote is already set,
then a new remote with user's username is set for the fork.

The current code for defaultRemote has "origin" as the dominant remote,
however, this remote has two different meanings depending on how the fork
was created: in the first approach, mentioned earlier, "origin" points to
the fork, while in the second it points to the actual upstream project. With
that, users get quite confused why `lab mr list` sometimes lists the MR
against upstream project and other times it lists MRs from the fork.

From what I've seen/used and read from the code, defaultRemote should always
point to the upstream project whenever possible. This patch does exact it.
The change is pretty simple: turn "upstream" remote as the prefereble one,
but the result is far more consistent to the user experience.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>