### PR TITLE
edit.go: Add core.editor for default editor

### DIFF
--- a/internal/git/edit.go
+++ b/internal/git/edit.go
@@ -71,11 +71,21 @@ func EditFile(filePrefix, message string) (string, error) {
 func editorPath() (string, error) {
 	cmd := New("var", "GIT_EDITOR")
 	cmd.Stdout = nil
-	e, err := cmd.Output()
+	a, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(e)), nil
+	editor := strings.TrimSpace(string(a))
+	if editor == "" {
+		cmd = New("config", "--get", "core.editor")
+		cmd.Stdout = nil
+		b, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		editor = strings.TrimSpace(string(b))
+	}
+	return editor, nil
 }
 
 func editorCMD(editorPath, filePath string) *exec.Cmd {


### PR DESCRIPTION
The editor can also be set with the output of 'git config --get
core.editor'.  Use that if $GIT_EDITOR is not set.

Add core.editor as an additional option to pick the default editor.

Closes #609 

Signed-off-by: Prarit Bhargava <prarit@redhat.com>