### PR TITLE
mr: add delete command

### DIFF
--- a/cmd/mr_close.go
+++ b/cmd/mr_close.go
@@ -12,7 +12,6 @@ import (
 
 var mrCloseCmd = &cobra.Command{
 	Use:              "close [remote] <id>",
-	Aliases:          []string{"delete"},
 	Short:            "Close merge request",
 	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,

--- a/cmd/mr_delete.go
+++ b/cmd/mr_delete.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+
+	"fmt"
+	"log"
+)
+
+var mrDeleteCmd = &cobra.Command{
+	Use:              "delete [remote] <id>",
+	Aliases:          []string{"del"},
+	Short:            "Delete a merge request on GitLab",
+	Long:             `Delete a merge request (default: MR created on default branch of origin)`,
+	Args:             cobra.MaximumNArgs(2),
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		remote, id, err := parseArgsWithGitBranchMR(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+		mrNum := int(id)
+
+		err = lab.MRDelete(remote, mrNum)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf("Merge request #%d deleted\n", mrNum)
+	},
+}
+
+func init() {
+	mrCmd.AddCommand(mrDeleteCmd)
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -368,6 +368,23 @@ func MRUpdate(project string, mrNum int, opts *gitlab.UpdateMergeRequestOptions)
 	return issue.WebURL, nil
 }
 
+// MRDelete deletes an merge request on a GitLab project
+func MRDelete(project string, mrNum int) error {
+	p, err := FindProject(project)
+	if err != nil {
+		return err
+	}
+	resp, err := lab.MergeRequests.DeleteMergeRequest(p.ID, mrNum)
+	if resp != nil && resp.StatusCode == http.StatusForbidden {
+		return ErrStatusForbidden
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // MRCreateNote adds a note to a merge request on GitLab
 func MRCreateNote(project string, mrNum int, opts *gitlab.CreateMergeRequestNoteOptions) (string, error) {
 	p, err := FindProject(project)


### PR DESCRIPTION
This PR adds the ability to delete an MR and also change any occurrence of mr "delete" to mr "close", since `lab mr delete` was being used as an alias to `lab mr close`, which is really misleading considering these are two different actions to GitLab API.