### PR TITLE
lab: introduce todo command

### DIFF
--- a/cmd/todo.go
+++ b/cmd/todo.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var todoCmd = &cobra.Command{
+	Use:              "todo",
+	Short:            `Check out the todo list for MR or issues`,
+	Long:             ``,
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		if list, _ := cmd.Flags().GetBool("list"); list {
+			todoListCmd.Run(cmd, args)
+			return
+		}
+
+		if len(args) == 0 || len(args) > 2 {
+			cmd.Help()
+			return
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(todoCmd)
+}

--- a/cmd/todo_list.go
+++ b/cmd/todo_list.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	gitlab "github.com/xanzy/go-gitlab"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var (
+	todoType   string
+	todoNumRet string
+	targetType string
+)
+
+var todoListCmd = &cobra.Command{
+	Use:              "list",
+	Aliases:          []string{"ls"},
+	Short:            "List todos",
+	Long:             ``,
+	Example:          `lab todo list                        # list open todos"`,
+	PersistentPreRun: LabPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		todos, err := todoList(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		pager := NewPager(cmd.Flags())
+		defer pager.Close()
+
+		for _, todo := range todos {
+			fmt.Printf("%d %s\n", todo.ID, todo.TargetURL)
+		}
+	},
+}
+
+func todoList(args []string) ([]*gitlab.Todo, error) {
+	num, err := strconv.Atoi(todoNumRet)
+	if err != nil {
+		num = -1
+	}
+
+	opts := gitlab.ListTodosOptions{
+		ListOptions: gitlab.ListOptions{
+			PerPage: num,
+		},
+	}
+
+	var lstr = strings.ToLower(todoType)
+	switch {
+	case lstr == "mr":
+		targetType = "MergeRequest"
+		opts.Type = &targetType
+	case lstr == "issue":
+		targetType = "Issue"
+		opts.Type = &targetType
+	}
+
+	return lab.TodoList(opts, num)
+}
+
+func init() {
+	todoListCmd.Flags().StringVarP(
+		&todoType, "type", "t", "all",
+		"filter todos by type (all/mr/issue)")
+	todoListCmd.Flags().StringVarP(
+		&todoNumRet, "number", "n", "10",
+		"number of todos to return")
+
+	todoCmd.AddCommand(todoListCmd)
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1682,3 +1682,38 @@ func ResolveMRDiscussion(project string, mrNum int, discussionID string, noteID 
 	}
 	return fmt.Sprintf("Resolved %s/merge_requests/%d#note_%d", p.WebURL, mrNum, noteID), nil
 }
+
+func TodoList(opts gitlab.ListTodosOptions, n int) ([]*gitlab.Todo, error) {
+	if n == -1 {
+		opts.PerPage = 100
+	}
+
+	list, resp, err := lab.Todos.ListTodos(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.CurrentPage == resp.TotalPages {
+		return list, nil
+	}
+
+	opts.Page = resp.NextPage
+	for len(list) < n || n == -1 {
+		if n != -1 {
+			opts.PerPage = n - len(list)
+		}
+
+		todos, resp, err := lab.Todos.ListTodos(&opts)
+		if err != nil {
+			return nil, err
+		}
+
+		opts.Page = resp.NextPage
+		list = append(list, todos...)
+		if resp.CurrentPage == resp.TotalPages {
+			break
+		}
+	}
+
+	return list, nil
+}


### PR DESCRIPTION
Introduce the bare bones for the TODOs command
with a simple way to list the todo target URLs
so others can incrementally build upon demand.

Signed-off-by: Rafael Aquini <aquini@redhat.com>