### PR TITLE
mr edit: Fix reviewers check

### DIFF
--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -229,7 +229,7 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 
 		abortUpdate := (title == mr.Title && body == mr.Description &&
 			!labelsChanged && !assigneesChanged && !updateMilestone &&
-			!targetBranchChanged)
+			!targetBranchChanged && !reviewersChanged)
 		if abortUpdate {
 			log.Fatal("aborting: no changes")
 		}


### PR DESCRIPTION
The mr edit option --reviewers, incorrectly fails with "aborting: no
changes" because the change to the reviewers is not verified.

Add verification of the reviewers change to the "no changes" check.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>