### PR TITLE
gitlab: remove duplicate function for getting used ID

### DIFF
--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -80,19 +80,17 @@ func issueList(args []string) ([]*gitlab.Issue, error) {
 	// because of that we need to get user's ID for both assignee and
 	// author.
 	if issueAuthor != "" {
-		authorID, err := lab.UserIDByUserName(issueAuthor)
-		if err != nil {
-			log.Fatal(err)
+		issueAuthorID := getUserID(issueAuthor)
+		if issueAuthorID == nil {
+			log.Fatal(fmt.Errorf("%s user not found\n", issueAuthor))
 		}
-		issueAuthorID = &authorID
 	}
 
 	if issueAssignee != "" {
-		assigneeID, err := lab.UserIDByUserName(issueAssignee)
-		if err != nil {
-			log.Fatal(err)
+		issueAssigneeID := getUserID(issueAssignee)
+		if issueAssigneeID == nil {
+			log.Fatal(fmt.Errorf("%s user not found\n", issueAssignee))
 		}
-		issueAssigneeID = &assigneeID
 	}
 
 	opts := gitlab.ListProjectIssuesOptions{

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -80,11 +80,10 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 	// gitlab lib still doesn't have search by assignee and author username
 	// for merge requests, because of that we need to get the ID for both.
 	if mrAssignee != "" {
-		assigneeID, err := lab.UserIDByUserName(mrAssignee)
-		if err != nil {
-			log.Fatal(err)
+		mrAssigneeID := getUserID(mrAssignee)
+		if mrAssigneeID == nil {
+			log.Fatal(fmt.Errorf("%s user not found\n", mrAssignee))
 		}
-		mrAssigneeID = &assigneeID
 	} else if mrMine {
 		assigneeID, err := lab.UserID()
 		if err != nil {
@@ -94,11 +93,10 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 	}
 
 	if mrAuthor != "" {
-		authorID, err := lab.UserIDByUserName(mrAuthor)
-		if err != nil {
-			log.Fatal(err)
+		mrAuthorID := getUserID(mrAuthor)
+		if mrAuthorID == nil {
+			log.Fatal(fmt.Errorf("%s user not found\n", mrAuthor))
 		}
-		mrAuthorID = &authorID
 	}
 
 	if mrMilestone != "" {

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -59,24 +59,6 @@ func UserID() (int, error) {
 	return u.ID, nil
 }
 
-func UserIDByUserName(username string) (int, error) {
-	opts := gitlab.ListUsersOptions{
-		ListOptions: gitlab.ListOptions{
-			PerPage: 1,
-		},
-		Username: &username,
-	}
-	users, _, err := lab.Users.ListUsers(&opts)
-	if err != nil {
-		return 0, err
-	}
-	for _, user := range users {
-		return user.ID, nil
-	}
-
-	return 0, errors.New("No user found with username " + username)
-}
-
 // Init initializes a gitlab client for use throughout lab.
 func Init(_host, _user, _token string, allowInsecure bool) {
 	if len(_host) > 0 && _host[len(_host)-1:][0] == '/' {


### PR DESCRIPTION
There were two functions to get the userID from API, UserIDFromUsername and
UserIDByUserName, both were doing basically the same operation. For
simplicity, I removed the second one so now we have UserIDFromUsername and
UserIDFromEmail.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>