### PR TITLE
mr_create: fix output messages

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -73,7 +73,7 @@ func init() {
 
 func verifyRemoteAndBranch(projectID int, remote string, branch string) error {
 	if _, err := lab.GetCommit(projectID, branch); err != nil {
-		return fmt.Errorf("Aborting MR create, %s:%s is not a valid target\n", remote, branch)
+		return fmt.Errorf("Aborting MR create, %s:%s is not a valid reference\n", remote, branch)
 	}
 	return nil
 }
@@ -146,7 +146,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	// verify the source branch and remote
 	err = verifyRemoteAndBranch(sourceProject.ID, sourceRemote, sourceBranch)
 	if err != nil {
-		log.Fatal(fmt.Errorf("Did you forget to 'git push'?\n"))
+		log.Fatal(err)
 	}
 
 	targetRemote := defaultRemote
@@ -170,7 +170,10 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	if len(args) > 1 && targetBranch != args[1] {
 		targetBranch = args[1]
 		// verify the target branch and remote
-		verifyRemoteAndBranch(targetProject.ID, targetRemote, targetBranch)
+		err = verifyRemoteAndBranch(targetProject.ID, targetRemote, targetBranch)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	labelTerms, err := cmd.Flags().GetStringSlice("label")

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -125,7 +124,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		sourceRemote = sourceParts[0]
 		sourceBranch = sourceParts[1]
 		if sourceRemote == "" || sourceBranch == "" {
-			log.Fatal(errors.New("Error: Source remote must have format remote:remote_branch.\n"))
+			log.Fatal(fmt.Errorf("Error: Source remote must have format remote:remote_branch.\n"))
 		}
 
 		_, err := git.IsRemote(sourceRemote)
@@ -147,7 +146,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	// verify the source branch and remote
 	err = verifyRemoteAndBranch(sourceProject.ID, sourceRemote, sourceBranch)
 	if err != nil {
-		log.Fatal(errors.Wrapf(err, "Did you forget to 'git push'?"))
+		log.Fatal(fmt.Errorf("Did you forget to 'git push'?\n"))
 	}
 
 	targetRemote := defaultRemote
@@ -155,7 +154,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		targetRemote = args[0]
 		ok, err := git.IsRemote(targetRemote)
 		if err != nil || !ok {
-			log.Fatal(errors.Wrapf(err, "%s is not a valid remote", targetRemote))
+			log.Fatal(fmt.Errorf("%s is not a valid remote\n", targetRemote))
 		}
 	}
 	targetProjectName, err := git.PathWithNameSpace(targetRemote)
@@ -291,7 +290,7 @@ func mrText(sourceRemote, sourceBranch, targetRemote, targetBranch string, cover
 		}
 	}
 	if numCommits == 0 {
-		return "", fmt.Errorf("Aborting: The resulting Merge Request from %s to %s has 0 commits.", target, source)
+		return "", fmt.Errorf("Aborting: The resulting Merge Request from %s to %s has 0 commits\n", target, source)
 	}
 
 	const tmpl = `{{if .InitMsg}}{{.InitMsg}}{{end}}

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -461,7 +461,7 @@ func Test_mrCmd_source(t *testing.T) {
 		b, _ = cmd.CombinedOutput()
 		out := string(b)
 		t.Log(out)
-		require.Contains(t, out, "Aborting MR create, origin:mrtestDoesNotExist is not a valid target")
+		require.Contains(t, out, "Aborting MR create, origin:mrtestDoesNotExist is not a valid reference")
 	})
 	t.Run("create_valid", func(t *testing.T) {
 		git := exec.Command("git", "checkout", "mrtest")


### PR DESCRIPTION
`errors.Wrapf()` was being used within `log.Fatal()` calls, but it's not the
correct way of doing it. The first adds a message to the error and return
_another_ error if something goes wrong, but if the messages is added
correctly, it returns <nil>. So, whenever this errors were printed, `<nil>`
was being prompted to the user.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>