### PR TITLE
merge_request: deprecate command

### DIFF
--- a/cmd/merge_request.go
+++ b/cmd/merge_request.go
@@ -8,6 +8,7 @@ import (
 
 var mergeRequestCmd = &cobra.Command{
 	Use:              "merge-request [remote [branch]]",
+	Deprecated:       "use the `mr create` command instead",
 	Short:            mrCreateCmd.Short,
 	Long:             mrCreateCmd.Long,
 	Args:             mrCreateCmd.Args,


### PR DESCRIPTION
The `lab merge-request` command was being used as a shorthand for `lab mr
create`, which, IMO, doesn't make much sense today. And since we already
deprecated most of the shorthand flags for other subcommands, this one seems
a good candidate for deprecation.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>