### PR TITLE
mr_merge: add option for merging immediately

### DIFF
--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -533,10 +533,8 @@ func MRRebase(pid interface{}, id int) error {
 }
 
 // MRMerge merges an mr on a GitLab project
-func MRMerge(pid interface{}, id int) error {
-	_, _, err := lab.MergeRequests.AcceptMergeRequest(pid, int(id), &gitlab.AcceptMergeRequestOptions{
-		MergeWhenPipelineSucceeds: gitlab.Bool(true),
-	})
+func MRMerge(pid interface{}, id int, opts *gitlab.AcceptMergeRequestOptions) error {
+	_, _, err := lab.MergeRequests.AcceptMergeRequest(pid, int(id), opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Today, the `lab mr merge` command set, by default, the option of merging
only when pipeline succeeds, however, in some workflows (e.g. mine) it's not
entirely true: it's sometimes desirable a merge happens regardless the
pipeline results, for many different reasons.

This patch adds the `lab mr merge --pipeline-succeeds` (or `-p`) for
enabling it, while the default now is to merge directly.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>

Fixes #653 