### PR TITLE
mr_list_test: Change latest created MR value

### DIFF
--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -124,7 +124,7 @@ func Test_mrFilterByTargetBranch(t *testing.T) {
 }
 
 var (
-	latestCreatedTestMR = "!19 MR for closing and reopening"
+	latestCreatedTestMR = "!329 MR for approve and review commands"
 	latestUpdatedTestMR = "!19 MR for closing and reopening"
 )
 


### PR DESCRIPTION
A new proposed test has been added that adds an MR to lab-testing.  Change
the latestCreatedTestMR to point to the new MR.

Change the latest created MR value in the 'lab mr list' tests.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>