### PR TITLE
Add internal leveled logger

### DIFF
--- a/cmd/ci_artifacts.go
+++ b/cmd/ci_artifacts.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 
 	"github.com/rsteube/carapace"

--- a/cmd/ci_lint.go
+++ b/cmd/ci_lint.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 
 	"github.com/pkg/errors"

--- a/cmd/ci_run.go
+++ b/cmd/ci_run.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"text/tabwriter"
 	"time"

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"strings"
 	"sync"

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"runtime/debug"
 	"strings"

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"strings"
 	"time"
 

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/spf13/cobra"

--- a/cmd/issue_browse.go
+++ b/cmd/issue_browse.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"strconv"
 
 	"github.com/rsteube/carapace"

--- a/cmd/issue_close.go
+++ b/cmd/issue_close.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/rsteube/carapace"

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"path/filepath"
 	"runtime"
 	"strconv"

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"runtime"
 	"strconv"
 	"strings"

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/pkg/errors"

--- a/cmd/issue_move.go
+++ b/cmd/issue_move.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/rsteube/carapace"

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/rsteube/carapace"

--- a/cmd/issue_reopen.go
+++ b/cmd/issue_reopen.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 

--- a/cmd/issue_subscribe.go
+++ b/cmd/issue_subscribe.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"

--- a/cmd/issue_unsubscribe.go
+++ b/cmd/issue_unsubscribe.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"

--- a/cmd/label_create.go
+++ b/cmd/label_create.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"

--- a/cmd/label_delete.go
+++ b/cmd/label_delete.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/action"

--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/pkg/errors"

--- a/cmd/milestone_create.go
+++ b/cmd/milestone_create.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"

--- a/cmd/milestone_delete.go
+++ b/cmd/milestone_delete.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/action"

--- a/cmd/milestone_list.go
+++ b/cmd/milestone_list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/rsteube/carapace"

--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/rsteube/carapace"

--- a/cmd/mr_browse.go
+++ b/cmd/mr_browse.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"net/url"
 	"path"
 	"strconv"

--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/rsteube/carapace"

--- a/cmd/mr_close.go
+++ b/cmd/mr_close.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"regexp"
 	"runtime"

--- a/cmd/mr_delete.go
+++ b/cmd/mr_delete.go
@@ -5,7 +5,6 @@ import (
 	lab "github.com/zaquestion/lab/internal/gitlab"
 
 	"fmt"
-	"log"
 )
 
 var mrDeleteCmd = &cobra.Command{

--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"runtime"
 	"strconv"
 	"strings"

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 	"strconv"

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/pkg/errors"

--- a/cmd/mr_merge.go
+++ b/cmd/mr_merge.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"

--- a/cmd/mr_rebase.go
+++ b/cmd/mr_rebase.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/action"

--- a/cmd/mr_reopen.go
+++ b/cmd/mr_reopen.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/charmbracelet/glamour"

--- a/cmd/mr_subscribe.go
+++ b/cmd/mr_subscribe.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"

--- a/cmd/mr_thumb.go
+++ b/cmd/mr_thumb.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/rsteube/carapace"

--- a/cmd/mr_unsubscribe.go
+++ b/cmd/mr_unsubscribe.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"

--- a/cmd/note_common.go
+++ b/cmd/note_common.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"runtime"
 	"strconv"
 	"strings"

--- a/cmd/project_browse.go
+++ b/cmd/project_browse.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/spf13/cobra"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/spf13/cobra"

--- a/cmd/project_list.go
+++ b/cmd/project_list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/spf13/cobra"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,6 +111,7 @@ func init() {
 	RootCmd.Flags().Bool("version", false, "Show the lab version")
 	RootCmd.PersistentFlags().Bool("no-pager", false, "Do not pipe output into a pager")
 	RootCmd.PersistentFlags().Bool("debug", false, "Enable debug logging level")
+	RootCmd.PersistentFlags().Bool("quiet", false, "Turn off any sort of logging. Only command output is printed")
 
 	// We need to set the logger level before any other piece of code is
 	// called, thus we make sure we don't lose any debug message, but for
@@ -118,9 +119,15 @@ func init() {
 	err := RootCmd.ParseFlags(os.Args[1:])
 	// Handle the err != nil case later
 	if err == nil {
-		debugLogLevel, _ := RootCmd.Flags().GetBool("debug")
-		if debugLogLevel {
+		debugLogger, _ := RootCmd.Flags().GetBool("debug")
+		quietLogger, _ := RootCmd.Flags().GetBool("quiet")
+		if debugLogger && quietLogger {
+			log.Fatal("option --debug cannot be combined with --quiet")
+		}
+		if debugLogger {
 			log.SetLogLevel(logger.LOG_DEBUG)
+		} else if quietLogger {
+			log.SetLogLevel(logger.LOG_NONE)
 		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,7 +13,11 @@ import (
 	gitconfig "github.com/tcnksm/go-gitconfig"
 	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
+	"github.com/zaquestion/lab/internal/logger"
 )
+
+// Get internal lab logger instance
+var log = logger.GetInstance()
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -177,7 +180,7 @@ func Execute(initSkipped bool) {
 	if git.InsideGitRepo() {
 		defaultRemote = guessDefaultRemote()
 		if defaultRemote == "" {
-			log.Println("No default remote found")
+			log.Infoln("No default remote found")
 		}
 
 		// Check if the user fork exists
@@ -208,7 +211,7 @@ func Execute(initSkipped bool) {
 		}
 
 		// Passthrough to git for any unrecognized commands
-		log.Println("Warning: lab's git passthrough command support will be removed in a later release.")
+		log.Warnln("lab's git passthrough command support will be removed in a later release.")
 		err = git.New(os.Args[1:]...).Run()
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
@@ -229,7 +232,7 @@ func Execute(initSkipped bool) {
 		// Pass unknown flags to git, if it also doesn't handle it, let lab
 		// handle the exit msg (help) and code.
 		if !initSkipped {
-			log.Println("Warning: lab's git passthrough command support will be removed in a later release.")
+			log.Warnln("lab's git passthrough command support will be removed in a later release.")
 			gitCmd := git.New(os.Args[1:]...)
 			gitCmd.Stderr = nil
 			gitCmd.Stdout = nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -110,6 +110,19 @@ func init() {
 	RootCmd.AddCommand(versionCmd)
 	RootCmd.Flags().Bool("version", false, "Show the lab version")
 	RootCmd.PersistentFlags().Bool("no-pager", false, "Do not pipe output into a pager")
+	RootCmd.PersistentFlags().Bool("debug", false, "Enable debug logging level")
+
+	// We need to set the logger level before any other piece of code is
+	// called, thus we make sure we don't lose any debug message, but for
+	// that we need to parse the args from command input.
+	err := RootCmd.ParseFlags(os.Args[1:])
+	// Handle the err != nil case later
+	if err == nil {
+		debugLogLevel, _ := RootCmd.Flags().GetBool("debug")
+		if debugLogLevel {
+			log.SetLogLevel(logger.LOG_DEBUG)
+		}
+	}
 }
 
 var (

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"io"
-	"log"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -46,7 +45,7 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 	// Make a copy of the testdata Git test project and chdir to it.
-	repo := copyTestRepo(log.New(os.Stderr, "", log.LstdFlags))
+	repo := copyTestRepo(log)
 	if err := os.Chdir(repo); err != nil {
 		log.Fatalf("Error chdir to testdata: %s", err)
 	}
@@ -81,12 +80,12 @@ func TestMain(m *testing.M) {
 	os.Remove(labBinaryPath)
 	testdirs, err := filepath.Glob(os.ExpandEnv("$GOPATH/src/github.com/zaquestion/lab/testdata-*"))
 	if err != nil {
-		log.Printf("Error listing glob testdata-*: %s", err)
+		log.Infof("Error listing glob testdata-*: %s", err)
 	}
 	for _, dir := range testdirs {
 		err := os.RemoveAll(dir)
 		if err != nil {
-			log.Printf("Error removing dir %s: %s", dir, err)
+			log.Infof("Error removing dir %s: %s", dir, err)
 		}
 	}
 
@@ -200,7 +199,7 @@ func getAppOutput(output []byte) []string {
 func setConfigValues(repo string, configVal string, gitVal string) error {
 	err := copy.Copy(repo+"/lab.toml", configFile())
 	if err != nil {
-		log.Println(err)
+		log.Errorln(err)
 		return err
 	}
 

--- a/cmd/snippet_browse.go
+++ b/cmd/snippet_browse.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"net/url"
 	"path"
 	"strconv"

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"runtime"
 	"strconv"

--- a/cmd/snippet_delete.go
+++ b/cmd/snippet_delete.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"

--- a/cmd/snippet_list.go
+++ b/cmd/snippet_list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/rsteube/carapace"

--- a/cmd/todo_done.go
+++ b/cmd/todo_done.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/spf13/cobra"

--- a/cmd/todo_issue.go
+++ b/cmd/todo_issue.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"strconv"
 
 	"github.com/spf13/cobra"

--- a/cmd/todo_list.go
+++ b/cmd/todo_list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 

--- a/cmd/todo_mr.go
+++ b/cmd/todo_mr.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/spf13/cobra"

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -3,7 +3,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strconv"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/hashicorp/go-retryablehttp v0.6.8 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
@@ -38,7 +38,7 @@ require (
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/tcnksm/go-gitconfig v0.1.2
-	github.com/xanzy/go-gitlab v0.43.0
+	github.com/xanzy/go-gitlab v0.49.0
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	github.com/yuin/goldmark v1.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.6.8 h1:92lWxgpa+fF3FozM4B3UZtHZMJX8T5XT+TFdCxsPyWs=
 github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
+github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -394,6 +396,8 @@ github.com/tcnksm/go-gitconfig v0.1.2/go.mod h1:/8EhP4H7oJZdIPyT+/UIsG87kTzrzM4U
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xanzy/go-gitlab v0.43.0 h1:rpOZQjxVJGW/ch+Jy4j7W4o7BB1mxkXJNVGuplZ7PUs=
 github.com/xanzy/go-gitlab v0.43.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xanzy/go-gitlab v0.49.0 h1:alk636Xc1SUyvtiuJH+5jo1BQdKI/M+TSqBE/6J+c7A=
+github.com/xanzy/go-gitlab v0.49.0/go.mod h1:Q+hQhV508bDPoBijv7YjK/Lvlb4PhVhJdKqXVQrUoAE=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
@@ -487,6 +491,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -505,6 +510,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,8 +19,12 @@ import (
 	"github.com/spf13/viper"
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/git"
+	"github.com/zaquestion/lab/internal/logger"
 	"golang.org/x/crypto/ssh/terminal"
 )
+
+// Get internal lab logger instance
+var log = logger.GetInstance()
 
 const defaultGitLabHost = "https://gitlab.com"
 
@@ -195,7 +198,7 @@ func getUser(host, token string, skipVerify bool) string {
 	lab, _ := gitlab.NewClient(token, gitlab.WithHTTPClient(httpClient), gitlab.WithBaseURL(host+"/api/v4"))
 	u, _, err := lab.Users.CurrentUser()
 	if err != nil {
-		log.Print(err)
+		log.Infoln(err)
 		UserConfigError()
 	}
 
@@ -217,7 +220,7 @@ func GetToken() string {
 		args := strings.Split(MainConfig.GetString("core.load_token"), " ")
 		_token, err := exec.Command(args[0], args[1:]...).Output()
 		if err != nil {
-			log.Print(err)
+			log.Infoln(err)
 			UserConfigError()
 		}
 		token = string(_token)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,7 +3,6 @@ package git
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,7 +15,11 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/pkg/errors"
 	gitconfig "github.com/tcnksm/go-gitconfig"
+	"github.com/zaquestion/lab/internal/logger"
 )
+
+// Get internal lab logger instance
+var log = logger.GetInstance()
 
 // New looks up the git binary and returns a cmd which outputs to stdout
 func New(args ...string) *exec.Cmd {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"log"
 	"math/rand"
 	"os"
 	"os/exec"

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -95,7 +95,7 @@ func Init(_host, _user, _token string, allowInsecure bool) {
 		},
 	}
 
-	lab, _ = gitlab.NewClient(token, gitlab.WithHTTPClient(httpClient), gitlab.WithBaseURL(host+"/api/v4"))
+	lab, _ = gitlab.NewClient(token, gitlab.WithHTTPClient(httpClient), gitlab.WithBaseURL(host+"/api/v4"), gitlab.WithCustomLeveledLogger(log))
 }
 
 func InitWithCustomCA(_host, _user, _token, caFile string) error {

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -23,7 +22,11 @@ import (
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/config"
 	"github.com/zaquestion/lab/internal/git"
+	"github.com/zaquestion/lab/internal/logger"
 )
+
+// Get internal lab logger instance
+var log = logger.GetInstance()
 
 var (
 	// ErrActionRepeated is returned when a GitLab action is executed again.  For example
@@ -284,7 +287,7 @@ func Fork(project string, opts *gitlab.ForkProjectOptions, useHTTP bool, wait bo
 	//   https://docs.gitlab.com/ee/api/project_import_export.html#import-status
 	status, _, err := lab.ProjectImportExport.ImportStatus(fork.ID, nil)
 	if err != nil {
-		log.Printf("Impossible to get fork status: %s\n", err)
+		log.Infof("Impossible to get fork status: %s\n", err)
 	} else {
 		if wait {
 			for {

--- a/internal/gitlab/gitlab_test.go
+++ b/internal/gitlab/gitlab_test.go
@@ -1,7 +1,6 @@
 package gitlab
 
 import (
-	"log"
 	"math/rand"
 	"os"
 	"path/filepath"

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,248 @@
+package logger
+
+import (
+	"errors"
+	"io"
+	"log"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Logger levels available
+const (
+	LOG_ERROR = iota
+	LOG_INFO
+	LOG_DEBUG
+)
+
+// This internal logger will have a different log.Logger for each level,
+// allowing different destination (file or fd) in different levels and
+// also different prefixes.
+type logger struct {
+	level       int
+	errorLogger *log.Logger
+	warnLogger  *log.Logger
+	infoLogger  *log.Logger
+	debugLogger *log.Logger
+}
+
+// Internal instance that is used by anyone getting it through GetInstance()
+var internalLogger *logger
+
+// A way to avoid multiple initialization of the same logger
+var once sync.Once
+
+// GetInstance returns the default lab internal logger
+func GetInstance() *logger {
+	once.Do(func() {
+		internalLogger = &logger{
+			// Set INFO as default level. The user can change it
+			level: LOG_INFO,
+			// Setting Lmsgprefix preffix make the prefix to be printed before
+			// the actual message, but after the LstdFlags (date and time)
+			errorLogger: log.New(os.Stderr, "ERROR: ", log.LstdFlags|log.Lmsgprefix),
+			warnLogger:  log.New(os.Stdout, "WARNING: ", log.LstdFlags|log.Lmsgprefix),
+			infoLogger:  log.New(os.Stdout, "", log.LstdFlags|log.Lmsgprefix),
+			debugLogger: log.New(os.Stdout, "DEBUG: ", log.LstdFlags|log.Lmsgprefix),
+		}
+	})
+	return internalLogger
+}
+
+// SetLogLevel set the level of the internal logger.
+// Allowed values are LOG_{ERROR,INFO,DEBUG}.
+func (l *logger) SetLogLevel(level int) error {
+	if !(level >= LOG_ERROR && level <= LOG_DEBUG) {
+		return errors.New("invalid log level")
+	}
+	l.level = level
+	return nil
+}
+
+// LogLevel return de current log level of the internal logger
+func (l *logger) LogLevel() int {
+	return l.level
+}
+
+// SetStdDest sets what's the desired stdout and stderr for the internal
+// log. It can be any io.Writer value.
+func (l *logger) SetStdDest(stdout io.Writer, stderr io.Writer) {
+	l.errorLogger.SetOutput(stderr)
+	l.warnLogger.SetOutput(stdout)
+	l.infoLogger.SetOutput(stdout)
+	l.debugLogger.SetOutput(stdout)
+}
+
+// printKeysAndValues prints the keys and valus, as pairs, passed to those
+// functions in the way expected by go-retryablehttp LeveledLogger interface
+func printKeysAndValues(l *log.Logger, keysAndValues ...interface{}) {
+	for i := 0; i <= len(keysAndValues)/2; i += 2 {
+		l.Printf("\t%s = %s\n", keysAndValues[i], keysAndValues[i+1])
+	}
+}
+
+// addFileLinePrefix prepend the file name and line number to the message being
+// printed.
+func addFileLinePrefix(msg string) string {
+	var file string
+
+	// Using runtime.Caller() with calldepth == 2 is enough for getting the
+	// logger function callers
+	_, filePath, line, ok := runtime.Caller(2)
+	if ok {
+		fileParts := strings.Split(filePath, "/")
+		file = fileParts[len(fileParts)-1]
+	} else {
+		// Not sure if there's a better name or line number for an unknown caller
+		file = "???"
+		line = 0
+	}
+
+	prefix := []string{file, ":", strconv.Itoa(line), ":"}
+	// When called from Error, Warn, Info or Debug(), the Print() used
+	// doesn't know about this additional prefix we're adding, so we
+	// need to add the space between it and the msg ourselves.
+	if len(strings.TrimSpace(msg)) > 0 {
+		prefix = append(prefix, " ")
+	}
+
+	prefixedMsg := append(prefix, msg)
+	return strings.Join(prefixedMsg, "")
+}
+
+// Fatal prints the values and exit the program with os.Exit()
+func (l *logger) Fatal(values ...interface{}) {
+	values = append([]interface{}{addFileLinePrefix("")}, values...)
+	l.errorLogger.Fatal(values...)
+}
+
+// Fatal prints formated strings and exit the program with os.Exit()
+func (l *logger) Fatalf(format string, values ...interface{}) {
+	values = append([]interface{}{addFileLinePrefix("")}, values...)
+	l.errorLogger.Fatalf("%s "+format, values...)
+}
+
+// Fatal prints the values in a new line and exit the program with os.Exit()
+func (l *logger) Fatalln(values ...interface{}) {
+	values = append([]interface{}{addFileLinePrefix("")}, values...)
+	l.errorLogger.Fatalln(values...)
+}
+
+// Error prints error messages (prefixed with "ERROR:").
+// These parameters match the retryablehttp.LeveledLogger, which we want to
+// satisfy for silencing their debug messages being printed in the stdout.
+// Error message are always printed, regardless the log level.
+func (l *logger) Error(msg string, keysAndValues ...interface{}) {
+	if l.level >= LOG_ERROR {
+		l.errorLogger.Print(addFileLinePrefix(msg))
+		printKeysAndValues(l.errorLogger, keysAndValues...)
+	}
+}
+
+// Errorf prints formated error message (prefixed with "ERROR:").
+// Error message are always printed, regardless the log level.
+func (l *logger) Errorf(format string, values ...interface{}) {
+	if l.level >= LOG_ERROR {
+		values = append([]interface{}{addFileLinePrefix("")}, values...)
+		l.errorLogger.Printf("%s "+format, values...)
+	}
+}
+
+// Errorln prints error values in a new line (prefixed with "ERROR:").
+// Error message are always printed, regardless the log level.
+func (l *logger) Errorln(values ...interface{}) {
+	if l.level >= LOG_ERROR {
+		values = append([]interface{}{addFileLinePrefix("")}, values...)
+		l.errorLogger.Println(values...)
+	}
+}
+
+// Warn prints warning messages (prefixed with "WARNING:").
+// These parameters match the retryablehttp.LeveledLogger, which we want to
+// satisfy for silencing their debug messages being printed in the stdout.
+// Warning messages require at least LOG_INFO level.
+func (l *logger) Warn(msg string, keysAndValues ...interface{}) {
+	if l.level >= LOG_INFO {
+		l.warnLogger.Print(addFileLinePrefix(msg))
+		printKeysAndValues(l.warnLogger, keysAndValues...)
+	}
+}
+
+// Warnf prints formated warning message (prefixed with "WARNING:").
+// Warning messages require at least LOG_INFO level.
+func (l *logger) Warnf(format string, values ...interface{}) {
+	if l.level >= LOG_INFO {
+		values = append([]interface{}{addFileLinePrefix("")}, values...)
+		l.warnLogger.Printf("%s "+format, values...)
+	}
+}
+
+// Warnln prints warning values in a new line (prefixed with "WARNING:").
+// Warning messages require at least LOG_INFO level.
+func (l *logger) Warnln(values ...interface{}) {
+	if l.level >= LOG_INFO {
+		values = append([]interface{}{addFileLinePrefix("")}, values...)
+		l.warnLogger.Println(values...)
+	}
+}
+
+// Info prints informational messages (prefixed with "INFO:").
+// These parameters match the retryablehttp.LeveledLogger, which we want to
+// satisfy for silencing their debug messages being printed in the stdout.
+// Info messages require at least LOG_INFO level.
+func (l *logger) Info(msg string, keysAndValues ...interface{}) {
+	if l.level >= LOG_INFO {
+		l.infoLogger.Print(addFileLinePrefix(msg))
+		printKeysAndValues(l.infoLogger, keysAndValues...)
+	}
+}
+
+// Infof prints formated informational message (prefixed with "INFO:").
+// Info messages require at least LOG_INFO level.
+func (l *logger) Infof(format string, values ...interface{}) {
+	if l.level >= LOG_INFO {
+		values = append([]interface{}{addFileLinePrefix("")}, values...)
+		l.infoLogger.Printf("%s "+format, values...)
+	}
+}
+
+// Infoln prints info values in a new line (prefixed with "INFO:").
+// Info messages require at least LOG_INFO level.
+func (l *logger) Infoln(values ...interface{}) {
+	if l.level >= LOG_INFO {
+		values = append([]interface{}{addFileLinePrefix("")}, values...)
+		l.infoLogger.Println(values...)
+	}
+}
+
+// Debug prints warning messages (prefixed with "DEBUG:").
+// These parameters match the retryablehttp.LeveledLogger, which we want to
+// satisfy for silencing thier debug messages being printed in the stdout.
+// Debug messages require at least LOG_DEBUG level.
+func (l *logger) Debug(msg string, keysAndValues ...interface{}) {
+	if l.level >= LOG_DEBUG {
+		l.debugLogger.Print(addFileLinePrefix(msg))
+		printKeysAndValues(l.debugLogger, keysAndValues...)
+	}
+}
+
+// Debugf prints formated debug message (prefixed with "DEBUG:").
+// Debug messages require at least LOG_DEBUG level.
+func (l *logger) Debugf(format string, values ...interface{}) {
+	if l.level >= LOG_DEBUG {
+		values = append([]interface{}{addFileLinePrefix("")}, values...)
+		l.debugLogger.Printf("%s "+format, values...)
+	}
+}
+
+// Debugln prints debug values in a new line (prefixed with "DEBUG:").
+// Debug messages require at least LOG_DEBUG level.
+func (l *logger) Debugln(values ...interface{}) {
+	if l.level >= LOG_DEBUG {
+		values = append([]interface{}{addFileLinePrefix("")}, values...)
+		l.debugLogger.Println(values...)
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -13,7 +13,8 @@ import (
 
 // Logger levels available
 const (
-	LOG_ERROR = iota
+	LOG_NONE = iota
+	LOG_ERROR
 	LOG_INFO
 	LOG_DEBUG
 )
@@ -53,9 +54,9 @@ func GetInstance() *logger {
 }
 
 // SetLogLevel set the level of the internal logger.
-// Allowed values are LOG_{ERROR,INFO,DEBUG}.
+// Allowed values are LOG_{ERROR,INFO,DEBUG,NONE}.
 func (l *logger) SetLogLevel(level int) error {
-	if !(level >= LOG_ERROR && level <= LOG_DEBUG) {
+	if !(level >= LOG_NONE && level <= LOG_DEBUG) {
 		return errors.New("invalid log level")
 	}
 	l.level = level

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,39 @@
+package logger
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetInstance(t *testing.T) {
+	firstInstance := GetInstance()
+	secondInstance := GetInstance()
+	require.Equal(t, firstInstance, secondInstance)
+}
+
+func TestLogLevel(t *testing.T) {
+	log := GetInstance()
+	// Check default log level
+	require.Equal(t, LOG_INFO, log.LogLevel())
+
+	// Set invalid log level
+	err := log.SetLogLevel(100)
+	require.Error(t, err)
+	require.EqualError(t, err, "invalid log level")
+	err = log.SetLogLevel(-1)
+	require.Error(t, err)
+	require.EqualError(t, err, "invalid log level")
+
+	// Set a different and valid log level
+	err = log.SetLogLevel(LOG_DEBUG)
+	require.NoError(t, err)
+	require.Equal(t, LOG_DEBUG, log.LogLevel())
+}
+
+func Test_addFileLinePrefix(t *testing.T) {
+	msg := addFileLinePrefix("test")
+	regex := regexp.MustCompile("testing.go:[0-9]+: test")
+	require.Regexp(t, regex, msg)
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/rsteube/carapace"
@@ -14,7 +13,6 @@ import (
 var version = "master"
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	cmd.Version = version
 	initSkipped := skipInit()
 	if !initSkipped {


### PR DESCRIPTION
This MR add an internal leveled logger to lab, allowing different levels of log messages, from NONE to DEBUG.
What influenced this additional was the fact the module go-retryablehttp was printing debug messages to the output in case of connection timeouts and/or retries to gitlab server, so some users were complaining about that. For getting rid of it, a custom Leveled Logger should be passed to that through go-gitlab.

With this addition, this MR also adds two root flags: `--debug` and `--quiet`. The first, enable debug messages to be printed, while the second prevents any sort of logging other than the default output from commands.

This PR is still draft, since it depends on the PR https://github.com/xanzy/go-gitlab/pull/1121 to be accepted and merged, since go-gitlab today don't offer a way to pass a custom logger to go-retryablehttp.