### PR TITLE
mr show: Change 'Reviewers' to output usernames

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -199,7 +199,7 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 	}
 
 	for _, reviewerUsers := range mr.Reviewers {
-		_tmpStringArray = append(_tmpStringArray, reviewerUsers.Name)
+		_tmpStringArray = append(_tmpStringArray, reviewerUsers.Username)
 	}
 	if len(_tmpStringArray) > 0 {
 		reviewers = strings.Join(_tmpStringArray, ", ")


### PR DESCRIPTION
The 'mr show' Reviewers lists the first and last names of reviewers and
not usernames.  The other fields (Author, Approved By, etc.) show the
usernames.

Change the 'mr show' command's Reviewers field to show usernames.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>