### PR TITLE
labels: don't fetch labels in case of empty request

### DIFF
--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -56,6 +56,11 @@ lab label list remote "search term"  # search "remote" for labels with "search t
 }
 
 func MapLabels(rn string, labelTerms []string) ([]string, error) {
+	// Don't bother fetching project labels if nothing is being really requested
+	if len(labelTerms) == 0 {
+		return []string{}, nil
+	}
+
 	labels, err := lab.LabelList(rn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Check if any label is being really requested before fetching project's
information. This patch improves `list` and `edit` queries by a lot, depending
on the number of labels present in the project.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>