### PR TITLE
issue list: Add --sort and --order list options

### DIFF
--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -25,6 +25,8 @@ var (
 	issueAssigneeID *int
 	issueAuthor     string
 	issueAuthorID   *int
+	issueOrder      string
+	issueSortedBy   string
 )
 
 var issueListCmd = &cobra.Command{
@@ -93,6 +95,10 @@ func issueList(args []string) ([]*gitlab.Issue, error) {
 		}
 	}
 
+	orderBy := gitlab.String(issueOrder)
+
+	sort := gitlab.String(issueSortedBy)
+
 	opts := gitlab.ListProjectIssuesOptions{
 		ListOptions: gitlab.ListOptions{
 			PerPage: num,
@@ -100,7 +106,8 @@ func issueList(args []string) ([]*gitlab.Issue, error) {
 		Labels:     labels,
 		Milestone:  &issueMilestone,
 		State:      &issueState,
-		OrderBy:    gitlab.String("updated_at"),
+		OrderBy:    orderBy,
+		Sort:       sort,
 		AuthorID:   issueAuthorID,
 		AssigneeID: issueAssigneeID,
 	}
@@ -144,6 +151,8 @@ func init() {
 	issueListCmd.Flags().BoolVarP(
 		&issueExactMatch, "exact-match", "x", false,
 		"match on the exact (case-insensitive) search terms")
+	issueListCmd.Flags().StringVar(&issueOrder, "order", "updated_at", "display order (updated_at/created_at)")
+	issueListCmd.Flags().StringVar(&issueSortedBy, "sort", "desc", "sort order (desc/asc)")
 
 	issueCmd.AddCommand(issueListCmd)
 	carapace.Gen(issueListCmd).FlagCompletion(carapace.ActionMap{

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -30,8 +30,8 @@ var (
 	mrExactMatch   bool
 	mrAssignee     string
 	mrAssigneeID   *int
-	order          string
-	sortedBy       string
+	mrOrder        string
+	mrSortedBy     string
 	mrReviewer     string
 	mrReviewerID   *int
 )
@@ -116,9 +116,9 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 		}
 	}
 
-	orderBy := gitlab.String(order)
+	orderBy := gitlab.String(mrOrder)
 
-	sort := gitlab.String(sortedBy)
+	sort := gitlab.String(mrSortedBy)
 
 	// if none of the flags are set, return every single MR
 	mrCheckConflicts := (mrConflicts || mrNoConflicts)
@@ -197,8 +197,8 @@ func init() {
 	listCmd.Flags().StringVar(&mrAuthor, "author", "", "list only MRs authored by $username")
 	listCmd.Flags().StringVar(
 		&mrAssignee, "assignee", "", "list only MRs assigned to $username")
-	listCmd.Flags().StringVar(&order, "order", "updated_at", "display order (updated_at/created_at)")
-	listCmd.Flags().StringVar(&sortedBy, "sort", "desc", "sort order (desc/asc)")
+	listCmd.Flags().StringVar(&mrOrder, "order", "updated_at", "display order (updated_at/created_at)")
+	listCmd.Flags().StringVar(&mrSortedBy, "sort", "desc", "sort order (desc/asc)")
 	listCmd.Flags().BoolVarP(&mrDraft, "draft", "", false, "list MRs marked as draft")
 	listCmd.Flags().BoolVarP(&mrReady, "ready", "", false, "list MRs not marked as draft")
 	listCmd.Flags().SortFlags = false


### PR DESCRIPTION
'issue list' sorts issues in descending order and doesn't provide
an option to list them in ascending order that they wree updated.

Add a --sort option to display the issuess by descending (desc) or
ascending (asc) order. Add a --order option display the issues they were
created in or updated at.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>