### PR TITLE
list: Fix list user options

### DIFF
--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -82,14 +82,14 @@ func issueList(args []string) ([]*gitlab.Issue, error) {
 	// because of that we need to get user's ID for both assignee and
 	// author.
 	if issueAuthor != "" {
-		issueAuthorID := getUserID(issueAuthor)
+		issueAuthorID = getUserID(issueAuthor)
 		if issueAuthorID == nil {
 			log.Fatal(fmt.Errorf("%s user not found\n", issueAuthor))
 		}
 	}
 
 	if issueAssignee != "" {
-		issueAssigneeID := getUserID(issueAssignee)
+		issueAssigneeID = getUserID(issueAssignee)
 		if issueAssigneeID == nil {
 			log.Fatal(fmt.Errorf("%s user not found\n", issueAssignee))
 		}

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -82,7 +82,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 	// gitlab lib still doesn't have search by assignee and author username
 	// for merge requests, because of that we need to get the ID for both.
 	if mrAssignee != "" {
-		mrAssigneeID := getUserID(mrAssignee)
+		mrAssigneeID = getUserID(mrAssignee)
 		if mrAssigneeID == nil {
 			log.Fatal(fmt.Errorf("%s user not found\n", mrAssignee))
 		}
@@ -95,7 +95,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 	}
 
 	if mrAuthor != "" {
-		mrAuthorID := getUserID(mrAuthor)
+		mrAuthorID = getUserID(mrAuthor)
 		if mrAuthorID == nil {
 			log.Fatal(fmt.Errorf("%s user not found\n", mrAuthor))
 		}
@@ -110,7 +110,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 	}
 
 	if mrReviewer != "" {
-		mrReviewerID := getUserID(mrReviewer)
+		mrReviewerID = getUserID(mrReviewer)
 		if mrReviewerID == nil {
 			log.Fatal(fmt.Errorf("%s user not found\n", mrReviewer))
 		}


### PR DESCRIPTION
The "--assignee", "--reviewer", and "--author" options are not working
because the scope of the variables was incorrect.

Fix thhe "--assignee", "--reviewer", and "--author" list command options.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>
Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>