### PR TITLE
todo: Add --pretty output

### DIFF
--- a/cmd/todo_list.go
+++ b/cmd/todo_list.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
 	lab "github.com/zaquestion/lab/internal/gitlab"
@@ -15,6 +16,7 @@ var (
 	todoType   string
 	todoNumRet string
 	targetType string
+	todoPretty bool
 )
 
 var todoListCmd = &cobra.Command{
@@ -33,8 +35,80 @@ var todoListCmd = &cobra.Command{
 		pager := NewPager(cmd.Flags())
 		defer pager.Close()
 
+		red := color.New(color.FgRed).SprintFunc()
+		green := color.New(color.FgGreen).SprintFunc()
+		cyan := color.New(color.FgCyan).SprintFunc()
+
 		for _, todo := range todos {
-			fmt.Printf("%d %s\n", todo.ID, todo.TargetURL)
+			if !todoPretty || todo.TargetType == "DesignManagement::Design" || todo.TargetType == "AlertManagement::Alert" {
+				fmt.Printf("%d %s\n", todo.ID, todo.TargetURL)
+				continue
+			}
+
+			delim := "merge_requests/"
+			if todo.TargetType == "Issue" {
+				delim = "issues/"
+			}
+
+			s := strings.Split(todo.TargetURL, delim)
+			s = strings.Split(s[1], "#")
+			id, err := strconv.Atoi(s[0])
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			var state string
+			if todo.TargetType == "MergeRequest" {
+				mr, err := lab.MRGet(todo.Project.ID, id)
+				if err != nil {
+					log.Fatal(err)
+				}
+				state = mr.State
+			} else {
+				issue, err := lab.IssueGet(todo.Project.ID, id)
+				if err != nil {
+					log.Fatal(err)
+				}
+				state = issue.State
+			}
+
+			switch state {
+			case "opened":
+				state = green("open  ")
+			case "merged":
+				state = cyan("merged")
+			default:
+				state = red(state)
+			}
+
+			fmt.Printf("%s %d %s ", state, todo.ID, todo.TargetURL)
+
+			name := todo.Author.Name
+			if lab.User() == todo.Author.Username {
+				name = "you"
+			}
+			switch todo.ActionName {
+			case "approval_required":
+				fmt.Printf("(approval requested by %s)\n", name)
+			case "assigned":
+				fmt.Printf("(assigned to you by %s)\n", name)
+			case "build_failed":
+				fmt.Printf("(build failed)\n")
+			case "directly_addressed":
+				fmt.Printf("(%s directly addressed you)\n", name)
+			case "marked":
+				fmt.Printf("(Todo Entry added by you)\n")
+			case "mentioned":
+				fmt.Printf("(%s mentioned you)\n", name)
+			case "merge_train_removed":
+				fmt.Printf("(Merge Train was removed)\n")
+			case "review_requested":
+				fmt.Printf("(review requested by %s)\n", name)
+			case "unmergeable":
+				fmt.Printf("(Cannot be merged)\n")
+			default:
+				fmt.Printf("Unknown action %s\n", todo.ActionName)
+			}
 		}
 	},
 }
@@ -65,6 +139,7 @@ func todoList(args []string) ([]*gitlab.Todo, error) {
 }
 
 func init() {
+	todoListCmd.Flags().BoolVarP(&todoPretty, "pretty", "p", false, "provide more infomation in output")
 	todoListCmd.Flags().StringVarP(
 		&todoType, "type", "t", "all",
 		"filter todos by type (all/mr/issue)")

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -384,13 +384,8 @@ func MRCreateNote(project string, mrNum int, opts *gitlab.CreateMergeRequestNote
 }
 
 // MRGet retrieves the merge request from GitLab project
-func MRGet(project string, mrNum int) (*gitlab.MergeRequest, error) {
-	p, err := FindProject(project)
-	if err != nil {
-		return nil, err
-	}
-
-	mr, _, err := lab.MergeRequests.GetMergeRequest(p.ID, mrNum, nil)
+func MRGet(project interface{}, mrNum int) (*gitlab.MergeRequest, error) {
+	mr, _, err := lab.MergeRequests.GetMergeRequest(project, mrNum, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -639,13 +634,8 @@ func IssueCreateNote(project string, issueNum int, opts *gitlab.CreateIssueNoteO
 }
 
 // IssueGet retrieves the issue information from a GitLab project
-func IssueGet(project string, issueNum int) (*gitlab.Issue, error) {
-	p, err := FindProject(project)
-	if err != nil {
-		return nil, err
-	}
-
-	issue, _, err := lab.Issues.GetIssue(p.ID, issueNum)
+func IssueGet(project interface{}, issueNum int) (*gitlab.Issue, error) {
+	issue, _, err := lab.Issues.GetIssue(project, issueNum)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The 'todo list' output currently only shows the Todo ID, and a link to the
Todo item.  The WebUI outputs additional information such as the state of
the Merge Requests and Issues, how the Todo entry was added to the Todo
list, etc.

Add an option, --pretty, to output the additional information.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>