### PR TITLE
mr merge: Add successful completion message.

### DIFF
--- a/cmd/mr_merge.go
+++ b/cmd/mr_merge.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/rsteube/carapace"
@@ -39,6 +40,7 @@ succeeds`,
 		if err != nil {
 			log.Fatal(err)
 		}
+		fmt.Printf("Merge Request !%d merged\n", id)
 	},
 }
 


### PR DESCRIPTION
Other commands, like 'mr reopen' output a nice completion message.  The
'mr merge' command only returns positive status.

Add a successful completion message to 'mr merge'.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>