### PR TITLE
Fix build for BSD OSes family

### DIFF
--- a/cmd/util_bsd.go
+++ b/cmd/util_bsd.go
@@ -1,6 +1,6 @@
 // This file contains Darwin (MacOS) and *BSD specific calls.
 
-// +build darwin
+// +build freebsd openbsd dragonfly darwin
 
 package cmd
 

--- a/cmd/util_bsd.go
+++ b/cmd/util_bsd.go
@@ -1,4 +1,4 @@
-// This file contains Darwin (MacOS) specific calls.
+// This file contains Darwin (MacOS) and *BSD specific calls.
 
 // +build darwin
 
@@ -8,8 +8,8 @@ package cmd
 // by Linux ARM64 not having the DUP2() anymore. With that, we need to
 // repeat the other code and func declarations that are the same.
 
-// FIXME: there MUST be some better way to do that... only dupFD2() should be
-// here.
+// FIXME: there MUST be some better way to do that... only dupFD2() should
+// be here.
 
 import "syscall"
 

--- a/cmd/util_linux.go
+++ b/cmd/util_linux.go
@@ -1,13 +1,10 @@
 // This file contains Linux specific calls.
 
-// +build !windows,!darwin
-
 package cmd
 
 // Since we're using some system calls that are platform-specific, we need
-// to make sure we have a small layer of compatibility for Unix-like and
-// Windows operating systems. For now, this file is still valid for BSDs
-// (MacOS NOT included)
+// to make sure we have a small layer of compatibility for Linux, Windows
+// and *BSD operating systems.
 
 import "syscall"
 

--- a/cmd/util_windows.go
+++ b/cmd/util_windows.go
@@ -1,7 +1,5 @@
 // This file contains Windows specific calls.
 
-// +build windows
-
 package cmd
 
 // Even though Windows has a POSIX layer, it's implemented in userspace and,


### PR DESCRIPTION
This merge request fixes #680 by re-organizing the cmd/util_* files for specific GOOS.
Darwin and *BSD (mostly FreeBSD) share some ground when it comes to kernel API, with that, a good starting point is to add both families in the same file, suffixed by _bsd.
I know it doesn't hold true for every syscall, but for what we need in `lab` it's good enough.