### PR TITLE
todo list: Implement --all

### DIFF
--- a/cmd/todo_list.go
+++ b/cmd/todo_list.go
@@ -16,6 +16,7 @@ var (
 	todoNumRet string
 	targetType string
 	todoPretty bool
+	todoAll    bool
 )
 
 var todoListCmd = &cobra.Command{
@@ -101,7 +102,7 @@ var todoListCmd = &cobra.Command{
 
 func todoList(args []string) ([]*gitlab.Todo, error) {
 	num, err := strconv.Atoi(todoNumRet)
-	if err != nil {
+	if todoAll || (err != nil) {
 		num = -1
 	}
 
@@ -132,6 +133,7 @@ func init() {
 	todoListCmd.Flags().StringVarP(
 		&todoNumRet, "number", "n", "10",
 		"number of todos to return")
+	todoListCmd.Flags().BoolVarP(&todoAll, "all", "a", false, "list all Todos")
 
 	todoCmd.AddCommand(todoListCmd)
 }


### PR DESCRIPTION
Similar to the 'mr list --all' option, implement a 'todo list --all' to
show all items on the todo list.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>