### PR TITLE
Make use of heredoc.Doc() module in multiline texts

### DIFF
--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -11,7 +11,6 @@ var followBridge bool
 var ciCmd = &cobra.Command{
 	Use:   "ci",
 	Short: "Work with GitLab CI pipelines and jobs",
-	Long:  ``,
 }
 
 func init() {

--- a/cmd/ci_artifacts.go
+++ b/cmd/ci_artifacts.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/action"
@@ -12,9 +13,22 @@ import (
 )
 
 var ciArtifactsCmd = &cobra.Command{
-	Use:              "artifacts [remote [[branch:]job]]",
-	Short:            "Download artifacts of a ci job",
-	Long:             `If a job is not specified the latest job with artifacts is used`,
+	Use:   "artifacts [remote] [branch[:job]]",
+	Short: "Download artifacts of a ci job",
+	Long: heredoc.Doc(`
+		Download the CI pipeline job artifacts for the given or current branch if
+		none provided.
+
+		The branch name, when using with the --merge-request option, can be the
+		merge request number, which matches the branch name internally.	The "job"
+		portion is the given job name, which may contain whitespace characters
+		and which, for this specific case, must be quoted.
+	`),
+	Example: heredoc.Doc(`
+		lab ci artifacts upstream feature_branch
+		lab ci artifacts upstream 125 --merge-request
+		lab ci artifacts upstream 125:'my custom stage' --merge-request
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (

--- a/cmd/ci_lint.go
+++ b/cmd/ci_lint.go
@@ -15,7 +15,6 @@ import (
 var ciLintCmd = &cobra.Command{
 	Use:              "lint",
 	Short:            "Validate .gitlab-ci.yml against GitLab",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		path := ".gitlab-ci.yml"

--- a/cmd/ci_run.go
+++ b/cmd/ci_run.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -19,13 +20,19 @@ var ciCreateCmd = &cobra.Command{
 	Use:     "create [branch]",
 	Aliases: []string{"run"},
 	Short:   "Create a CI pipeline",
-	Long: `Run the CI pipeline for the given or current branch if none provided. This API uses your GitLab token to create CI pipelines
+	Long: heredoc.Doc(`
+		Run the CI pipeline for the given or current branch if none provided.
+		This API uses your GitLab token to create CI pipelines
 
-Project will be inferred from branch if not provided
+		Project will be inferred from branch if not provided
 
-Note: "lab ci create" differs from "lab ci trigger" which is a different API`,
-	Example: `lab ci create feature_branch
-lab ci create -p engineering/integration_tests master`,
+		Note: "lab ci create" differs from "lab ci trigger" which is a
+		different API
+	`),
+	Example: heredoc.Doc(`
+		lab ci create feature_branch
+		lab ci create -p engineering/integration_tests master
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, branch, err := getCIRunOptions(cmd, args)
@@ -47,14 +54,19 @@ lab ci create -p engineering/integration_tests master`,
 var ciTriggerCmd = &cobra.Command{
 	Use:   "trigger [branch]",
 	Short: "Trigger a CI pipeline",
-	Long: `Runs a trigger for a CI pipeline on the given or current branch if none provided. This API supports variables and must be called with a trigger token or from within GitLab CI.
+	Long: heredoc.Doc(`
+		Runs a trigger for a CI pipeline on the given or current branch if none provided.
+		This API supports variables and must be called with a trigger token or from within GitLab CI.
 
-Project will be inferred from branch if not provided
+		Project will be inferred from branch if not provided
 
-Note: "lab ci trigger" differs from "lab ci create" which is a different API`,
-	Example: `lab ci trigger feature_branch
-lab ci trigger -p engineering/integration_tests master
-lab ci trigger -p engineering/integration_tests -v foo=bar master`,
+		Note: "lab ci trigger" differs from "lab ci create" which is a different API
+	`),
+	Example: heredoc.Doc(`
+		lab ci trigger feature_branch
+		lab ci trigger -p engineering/integration_tests master
+		lab ci trigger -p engineering/integration_tests -v foo=bar master
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, branch, err := getCIRunOptions(cmd, args)

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -19,9 +20,10 @@ var ciStatusCmd = &cobra.Command{
 	Use:     "status [branch]",
 	Aliases: []string{"run"},
 	Short:   "Textual representation of a CI pipeline",
-	Long:    ``,
-	Example: `lab ci status
-lab ci status --wait`,
+	Example: heredoc.Doc(`
+		lab ci status
+		lab ci status --wait
+	`),
 	RunE:             nil,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -20,10 +21,24 @@ import (
 
 // ciLintCmd represents the lint command
 var ciTraceCmd = &cobra.Command{
-	Use:              "trace [remote [[branch:]job]]",
-	Aliases:          []string{"logs"},
-	Short:            "Trace the output of a ci job",
-	Long:             `If a job is not specified the latest running job or last job in the pipeline is used`,
+	Use:     "trace [remote] [branch[:job]]",
+	Aliases: []string{"logs"},
+	Short:   "Trace the output of a ci job",
+	Long: heredoc.Doc(`
+		Download the CI pipeline job artifacts for the given or current branch if
+		none provided. If a job is not specified the latest running job or last
+		job in the pipeline is used
+
+		The branch name, when using with the --merge-request option, can be the
+		merge request number, which matches the branch name internally.	The "job"
+		portion is the given job name, which may contain whitespace characters
+		and which, for this specific case, must be quoted.
+	`),
+	Example: heredoc.Doc(`
+		lab ci trace upstream feature_branch
+		lab ci trace upstream 18 --merge-request
+		lab ci trace upstream 18:'my custom stage' --merge-request
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/gdamore/tcell/v2"
 	"github.com/pkg/errors"
 	"github.com/rivo/tview"
@@ -32,16 +33,17 @@ var (
 var ciViewCmd = &cobra.Command{
 	Use:   "view [remote [branch/tag]]",
 	Short: "View, run, trace, and/or cancel CI jobs current pipeline",
-	Long: `Supports viewing, running, tracing, and canceling jobs
+	Long: heredoc.Doc(`
+		Supports viewing, running, tracing, and canceling jobs.
 
-'r', 'p' to run/retry/play a job -- Tab navigates modal and Enter to confirm
-'t' to toggle trace/logs (runs in background, so you can jump in and out)
-'T' to toggle trace/logs by suspending application (similar to lab ci trace)
-'c' to cancel job
+		The <tab> key navigates and <enter> confirms. Also supports vi style
+		(hjkl,Gg) bindings and arrow keys for navigating jobs and logs.
 
-Supports vi style (hjkl,Gg) bindings and arrow keys for navigating jobs and logs.
-
-Feedback Encouraged!: https://github.com/zaquestion/lab/issues`,
+		'r', 'p' to run/retry/play a job
+		't' to toggle trace/logs (runs in background)
+		'T' to toggle trace/logs (suspending application)
+		'c' to cancel job
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		a := tview.NewApplication()

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	retry "github.com/avast/retry-go"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/git"
@@ -14,11 +15,16 @@ import (
 // NOTE: There is special handling for "clone" in cmd/root.go
 var cloneCmd = &cobra.Command{
 	Use:   "clone",
-	Short: "GitLab repo aware clone command",
-	Long: `Clone supports these shorthands
-- repo
-- namespace/repo
-- namespace/group/repo`,
+	Short: "GitLab aware clone repo command",
+	Long: heredoc.Doc(`
+		Clone a repository, similarly to 'git clone', but aware of GitLab
+		specific settings.
+	`),
+	Example: heredoc.Doc(`
+		lab clone awesome-repo
+		lab clone company/awesome-repo
+		lab clone company/backend-team/awesome-repo
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		project, err := gitlab.FindProject(args[0])

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 )
@@ -11,17 +12,22 @@ import (
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
 	Use:   "completion [shell]",
-	Short: "Generates the shell autocompletion [bash, elvish, fish, oil, powershell, xonsh, zsh]",
-	Long: `Generates the shell autocompletion [bash, elvish, fish, oil, powershell, xonsh, zsh]
+	Short: "Generates autocompletion for different shell implementations",
+	Long: heredoc.Doc(`
+		Generates shell autocompletion scripts for different implementations.
 
-Scripts can be directly sourced (though using pre-generated versions is recommended to avoid shell startup delay):
-  bash       : source <(lab completion)
-  elvish     : eval(lab completion|slurp)
-  fish       : lab completion | source
-  oil        : source <(lab completion)
-  powershell : lab completion | Out-String | Invoke-Expression
-  xonsh      : exec($(lab completion))
-  zsh        : source <(lab completion)`,
+		These scripts can be directly sourced, though using pre-generated
+		versions is recommended to avoid shell startup delay.
+	`),
+	Example: heredoc.Doc(`
+		bash       : source <(lab completion)
+		elvish     : eval(lab completion|slurp)
+		fish       : lab completion | source
+		oil        : source <(lab completion)
+		powershell : lab completion | Out-String | Invoke-Expression
+		xonsh      : exec($(lab completion))
+		zsh        : source <(lab completion)
+	`),
 	ValidArgs: []string{"bash", "elvish", "fish", "oil", "powershell", "xonsh", "zsh"},
 	Run: func(cmd *cobra.Command, args []string) {
 		shell := ""

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
 	"github.com/tcnksm/go-gitconfig"
 	"github.com/xanzy/go-gitlab"
@@ -25,9 +26,17 @@ var (
 
 // forkCmd represents the fork command
 var forkCmd = &cobra.Command{
-	Use:              "fork [remote|upstream-to-fork]",
-	Short:            "Fork a remote repository on GitLab and add as remote",
-	Long:             ``,
+	Use:   "fork [remote|repo]",
+	Short: "Fork a remote repository on GitLab and add as remote",
+	Long: heredoc.Doc(`
+		Fork a remote repository on user's location of choice.
+		Both an already existent remote or a repository path can be specified.
+	`),
+	Example: heredoc.Doc(`
+		lab fork origin
+		lab fork upstream --remote-name origin
+		lab fork origin --name new-awasome-project
+	`),
 	Args:             cobra.MaximumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/issue_browse.go
+++ b/cmd/issue_browse.go
@@ -13,7 +13,6 @@ var issueBrowseCmd = &cobra.Command{
 	Use:              "browse [remote] <id>",
 	Aliases:          []string{"b"},
 	Short:            "View issue in a browser",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, num, err := parseArgsRemoteAndID(args)

--- a/cmd/issue_close.go
+++ b/cmd/issue_close.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/action"
@@ -13,13 +14,14 @@ import (
 var issueCloseCmd = &cobra.Command{
 	Use:              "close [remote] <id>",
 	Aliases:          []string{"delete"},
-	Short:            "Close issue by id",
-	Long:             ``,
+	Short:            "Close issue by ID",
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
-	Example: `lab issue close 1234
-lab issue close --duplicate 123 1234
-lab issue close --duplicate other-project#123 1234`,
+	Example: heredoc.Doc(`
+		lab issue close 1234
+		lab issue close --duplicate 123 1234
+		lab issue close --duplicate other-project#123 1234
+	`),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -119,9 +120,10 @@ func issueMsg(templateName string, msgs []string) (string, string, error) {
 }
 
 func issueText(templateName string) (string, error) {
-	const tmpl = `{{.InitMsg}}
-{{.CommentChar}} Write a message for this issue. The first block
-{{.CommentChar}} of text is the title and the rest is the description.`
+	tmpl := heredoc.Doc(`
+		{{.InitMsg}}
+		{{.CommentChar}} Write a message for this issue. The first block
+		{{.CommentChar}} of text is the title and the rest is the description.`)
 
 	templateFile := filepath.Join("issue_templates", templateName)
 	templateFile += ".md"

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -21,7 +21,6 @@ var issueCreateCmd = &cobra.Command{
 	Use:              "create [remote]",
 	Aliases:          []string{"new"},
 	Short:            "Open an issue on GitLab",
-	Long:             ``,
 	Args:             cobra.MaximumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -20,13 +21,13 @@ var issueEditCmd = &cobra.Command{
 	Use:     "edit [remote] <id>[:<comment_id>]",
 	Aliases: []string{"update"},
 	Short:   "Edit or update an issue",
-	Long:    ``,
-	Example: `lab issue edit <id>                                # update issue via $EDITOR
-lab issue update <id>                              # same as above
-lab issue edit <id> -m "new title"                 # update title
-lab issue edit <id> -m "new title" -m "new desc"   # update title & description
-lab issue edit <id> -l newlabel --unlabel oldlabel # relabel issue
-lab issue edit <id>:<comment_id>                   # update a comment on MR`,
+	Example: heredoc.Doc(`
+		lab issue edit <id>
+		lab issue edit <id> -m "new title"
+		lab issue edit <id> -m "new title" -m "new desc"
+		lab issue edit <id> -l new_label --unlabel old_label
+		lab issue edit <id>:<comment_id>
+	`),
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -187,10 +187,11 @@ func issueGetCurrentAssignees(issue *gitlab.Issue) []string {
 // editText returns an issue editing template that is suitable for loading
 // into an editor
 func editText(title string, body string) (string, error) {
-	const tmpl = `{{.InitMsg}}
+	tmpl := heredoc.Doc(`
+		{{.InitMsg}}
 
-{{.CommentChar}} Edit the title and/or description. The first block of text
-{{.CommentChar}} is the title and the rest is the description.`
+		{{.CommentChar}} Edit the title and/or description. The first block of text
+		{{.CommentChar}} is the title and the rest is the description.`)
 
 	msg := &struct {
 		InitMsg     string

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -32,11 +33,11 @@ var issueListCmd = &cobra.Command{
 	Use:     "list [remote] [search]",
 	Aliases: []string{"ls", "search"},
 	Short:   "List issues",
-	Long:    ``,
-	Example: `lab issue list                        # list all open issues
-lab issue list "search terms"         # search issues for "search terms"
-lab issue search "search terms"       # same as above
-lab issue list remote "search terms"  # search "remote" for issues with "search terms"`,
+	Example: heredoc.Doc(`
+		lab issue list
+		lab issue list "search terms"
+		lab issue list remote "search terms"
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		issues, err := issueList(args)

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -13,7 +13,6 @@ var issueNoteCmd = &cobra.Command{
 	Use:              "note [remote] <id>[:<comment_id>]",
 	Aliases:          []string{"comment", "reply"},
 	Short:            "Add a note or comment to an issue on GitLab",
-	Long:             ``,
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run:              NoteRunFn,

--- a/cmd/issue_reopen.go
+++ b/cmd/issue_reopen.go
@@ -12,7 +12,6 @@ import (
 var issueReopenCmd = &cobra.Command{
 	Use:              "reopen [remote] <id>",
 	Short:            "Reopen a closed issue",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -18,7 +18,6 @@ var issueShowCmd = &cobra.Command{
 	Aliases:          []string{"get"},
 	ArgAliases:       []string{"s"},
 	Short:            "Describe an issue",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/charmbracelet/glamour"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -112,24 +113,24 @@ func printIssue(issue *gitlab.Issue, project string, renderMarkdown bool) {
 		subscribed = "Yes"
 	}
 
-	fmt.Printf(`
-#%d %s
-===================================
-%s
------------------------------------
-Project: %s
-Status: %s
-Assignees: %s
-Author: %s
-Milestone: %s
-Due Date: %s
-Time Stats: %s
-Labels: %s
-Related MRs: %s
-MRs that will close this Issue: %s
-Subscribed: %s
-WebURL: %s
-`,
+	fmt.Printf(
+		heredoc.Doc(`#%d %s
+			===================================
+			%s
+			-----------------------------------
+			Project: %s
+			Status: %s
+			Assignees: %s
+			Author: %s
+			Milestone: %s
+			Due Date: %s
+			Time Stats: %s
+			Labels: %s
+			Related MRs: %s
+			MRs that will close this Issue: %s
+			Subscribed: %s
+			WebURL: %s
+		`),
 		issue.IID, issue.Title, issue.Description, project, state, strings.Join(assignees, ", "),
 		issue.Author.Username, milestone, dueDate, timestats,
 		strings.Join(issue.Labels, ", "),

--- a/cmd/issue_show_test.go
+++ b/cmd/issue_show_test.go
@@ -21,8 +21,7 @@ func Test_issueShow(t *testing.T) {
 	}
 
 	out := string(b)
-	require.Contains(t, out, `
-#1 test issue for lab list
+	require.Contains(t, out, `#1 test issue for lab list
 ===================================
 
 -----------------------------------

--- a/cmd/issue_subscribe.go
+++ b/cmd/issue_subscribe.go
@@ -12,8 +12,7 @@ import (
 var issueSubscribeCmd = &cobra.Command{
 	Use:              "subscribe [remote] <id>",
 	Aliases:          []string{},
-	Short:            "Subscribe to issue",
-	Long:             ``,
+	Short:            "Subscribe to an issue",
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)

--- a/cmd/issue_unsubscribe.go
+++ b/cmd/issue_unsubscribe.go
@@ -12,7 +12,7 @@ import (
 var issueUnsubscribeCmd = &cobra.Command{
 	Use:              "unsubscribe [remote] <id>",
 	Aliases:          []string{},
-	Short:            "Unubscribe from issue",
+	Short:            "Unubscribe from an issue",
 	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/label.go
+++ b/cmd/label.go
@@ -6,8 +6,7 @@ import (
 
 var labelCmd = &cobra.Command{
 	Use:              "label",
-	Short:            `List and search labels`,
-	Long:             ``,
+	Short:            "List and search labels",
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/label_create.go
+++ b/cmd/label_create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -12,10 +13,11 @@ var labelCreateCmd = &cobra.Command{
 	Use:     "create [remote] <name>",
 	Aliases: []string{"add"},
 	Short:   "Create a new label",
-	Long:    ``,
-	Example: `lab label create my-label
-lab label create --color cornflowerblue --description "Blue as a cornflower" blue
-lab label create --color #6495ed --description "Also blue as a cornflower" blue2`,
+	Example: heredoc.Doc(`
+		lab label create my-label
+		lab label create --color cornflowerblue --description "Blue as a cornflower" blue
+		lab label create --color #6495ed --description "Also blue as a cornflower" blue2
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/label_delete.go
+++ b/cmd/label_delete.go
@@ -11,7 +11,6 @@ var labelDeleteCmd = &cobra.Command{
 	Use:              "delete [remote] <name>",
 	Aliases:          []string{"remove"},
 	Short:            "Deletes an existing label",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -15,11 +16,11 @@ var labelListCmd = &cobra.Command{
 	Use:     "list [remote] [search]",
 	Aliases: []string{"ls", "search"},
 	Short:   "List labels",
-	Long:    ``,
-	Example: `lab label list                       # list all labels
-lab label list "search term"         # search labels for "search term"
-lab label search "search term"       # same as above
-lab label list remote "search term"  # search "remote" for labels with "search term"`,
+	Example: heredoc.Doc(`
+		lab label list
+		lab label list "search term"
+		lab label list remote "search term"
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, labelSearch, err := parseArgsRemoteAndProject(args)

--- a/cmd/milestone.go
+++ b/cmd/milestone.go
@@ -6,12 +6,10 @@ import (
 
 var milestoneCmd = &cobra.Command{
 	Use:              "milestone",
-	Short:            `List and search milestones`,
-	Long:             ``,
+	Short:            "List and search milestones",
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
-		return
 	},
 }
 

--- a/cmd/milestone_create.go
+++ b/cmd/milestone_create.go
@@ -12,7 +12,6 @@ var milestoneCreateCmd = &cobra.Command{
 	Use:              "create [remote] <name>",
 	Aliases:          []string{"add"},
 	Short:            "Create a new milestone",
-	Long:             ``,
 	Example:          "lab milestone create my-milestone",
 	PersistentPreRun: LabPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),

--- a/cmd/milestone_delete.go
+++ b/cmd/milestone_delete.go
@@ -11,7 +11,6 @@ var milestoneDeleteCmd = &cobra.Command{
 	Use:              "delete [remote] <name>",
 	Aliases:          []string{"remove"},
 	Short:            "Deletes an existing milestone",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/milestone_list.go
+++ b/cmd/milestone_list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -15,11 +16,11 @@ var milestoneListCmd = &cobra.Command{
 	Use:     "list [remote] [search]",
 	Aliases: []string{"ls", "search"},
 	Short:   "List milestones",
-	Long:    ``,
-	Example: `lab milestone list                       # list all milestones
-lab milestone list "search term"         # search milestones for "search term"
-lab milestone search "search term"       # same as above
-lab milestone list remote "search term"  # search "remote" for milestones with "search term"`,
+	Example: heredoc.Doc(`
+		lab milestone list
+		lab milestone list "search term"
+		lab milestone list remote "search term"
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, milestoneSearch, err := parseArgsRemoteAndProject(args)

--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -14,7 +14,6 @@ var mrApproveCmd = &cobra.Command{
 	Use:              "approve [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Approve merge request",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_browse.go
+++ b/cmd/mr_browse.go
@@ -15,7 +15,6 @@ var mrBrowseCmd = &cobra.Command{
 	Use:              "browse [remote] <id>",
 	Aliases:          []string{"b"},
 	Short:            "View merge request in a browser",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, num, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -28,7 +28,6 @@ var (
 var checkoutCmd = &cobra.Command{
 	Use:              "checkout [remote] <id>",
 	Short:            "Checkout an open merge request",
-	Long:             ``,
 	Args:             cobra.RangeArgs(1, 2),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/mr_close.go
+++ b/cmd/mr_close.go
@@ -12,7 +12,6 @@ import (
 var mrCloseCmd = &cobra.Command{
 	Use:              "close [remote] <id>",
 	Short:            "Close merge request",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -72,7 +73,7 @@ func init() {
 
 func verifyRemoteAndBranch(projectID int, remote string, branch string) error {
 	if _, err := lab.GetCommit(projectID, branch); err != nil {
-		return fmt.Errorf("aborting MR create, %s:%s is not a valid reference", remote, branch)
+		return fmt.Errorf("Aborting MR create, %s:%s is not a valid reference", remote, branch)
 	}
 	return nil
 }
@@ -292,20 +293,22 @@ func mrText(sourceRemote, sourceBranch, targetRemote, targetBranch string, cover
 		}
 	}
 	if numCommits == 0 {
-		return "", fmt.Errorf("aborting: The resulting Merge Request from %s to %s has 0 commits", target, source)
+		return "", fmt.Errorf("Aborting: The resulting Merge Request from %s to %s has 0 commits", target, source)
 	}
 
-	const tmpl = `{{if .InitMsg}}{{.InitMsg}}{{end}}
+	tmpl := heredoc.Doc(`
+		{{if .InitMsg}}{{.InitMsg}}{{end}}
 
-{{if .Tmpl}}{{.Tmpl}}{{end}}
-{{.CommentChar}} Requesting a merge into {{.Target}} from {{.Source}} ({{.NumCommits}} commits)
-{{.CommentChar}}
-{{.CommentChar}} Write a message for this merge request. The first block
-{{.CommentChar}} of text is the title and the rest is the description.{{if .CommitLogs}}
-{{.CommentChar}}
-{{.CommentChar}} Changes:
-{{.CommentChar}}
-{{.CommitLogs}}{{end}}`
+		{{if .Tmpl}}{{.Tmpl}}{{end}}
+		{{.CommentChar}} Requesting a merge into {{.Target}} from {{.Source}} ({{.NumCommits}} commits)
+		{{.CommentChar}}
+		{{.CommentChar}} Write a message for this merge request. The first block
+		{{.CommentChar}} of text is the title and the rest is the description.{{if .CommitLogs}}
+		{{.CommentChar}}
+		{{.CommentChar}} Changes:
+		{{.CommentChar}}
+		{{.CommitLogs}}{{end}}
+	`)
 
 	mrTmpl := lab.LoadGitLabTmpl(lab.TmplMR)
 

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -23,7 +23,7 @@ var mrCreateCmd = &cobra.Command{
 	Use:              "create [remote [remote_branch]]",
 	Aliases:          []string{"new"},
 	Short:            "Open a merge request on GitLab",
-	Long:             `Creates a merge request (default: MR created on default branch of origin)`,
+	Long:             "Creates a merge request.",
 	Args:             cobra.MaximumNArgs(2),
 	PersistentPreRun: LabPersistentPreRun,
 	Run:              runMRCreate,
@@ -72,7 +72,7 @@ func init() {
 
 func verifyRemoteAndBranch(projectID int, remote string, branch string) error {
 	if _, err := lab.GetCommit(projectID, branch); err != nil {
-		return fmt.Errorf("Aborting MR create, %s:%s is not a valid reference\n", remote, branch)
+		return fmt.Errorf("aborting MR create, %s:%s is not a valid reference", remote, branch)
 	}
 	return nil
 }
@@ -292,7 +292,7 @@ func mrText(sourceRemote, sourceBranch, targetRemote, targetBranch string, cover
 		}
 	}
 	if numCommits == 0 {
-		return "", fmt.Errorf("Aborting: The resulting Merge Request from %s to %s has 0 commits\n", target, source)
+		return "", fmt.Errorf("aborting: The resulting Merge Request from %s to %s has 0 commits", target, source)
 	}
 
 	const tmpl = `{{if .InitMsg}}{{.InitMsg}}{{end}}

--- a/cmd/mr_delete.go
+++ b/cmd/mr_delete.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 
@@ -8,10 +9,13 @@ import (
 )
 
 var mrDeleteCmd = &cobra.Command{
-	Use:              "delete [remote] <id>",
-	Aliases:          []string{"del"},
-	Short:            "Delete a merge request on GitLab",
-	Long:             `Delete a merge request (default: MR created on default branch of origin)`,
+	Use:     "delete [remote] <id>",
+	Aliases: []string{"del"},
+	Short:   "Delete a merge request on GitLab",
+	Long: heredoc.Doc(`
+		Delete a specific merge request or the one created on the default
+		of the main remote.
+	`),
 	Args:             cobra.MaximumNArgs(2),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -20,7 +20,6 @@ import (
 var mrCreateDiscussionCmd = &cobra.Command{
 	Use:              "discussion [remote] <id>",
 	Short:            "Start a discussion on an MR on GitLab",
-	Long:             ``,
 	Aliases:          []string{"block", "thread"},
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -80,8 +81,9 @@ func mrDiscussionMsg(msgs []string) (string, error) {
 }
 
 func mrDiscussionText() (string, error) {
-	const tmpl = `{{.InitMsg}}
-{{.CommentChar}} Write a message for this discussion. Commented lines are discarded.`
+	tmpl := heredoc.Doc(`
+		{{.InitMsg}}
+		{{.CommentChar}} Write a message for this discussion. Commented lines are discarded.`)
 
 	initMsg := "\n"
 	commentChar := git.CommentChar()

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -19,14 +20,13 @@ var mrEditCmd = &cobra.Command{
 	Use:     "edit [remote] <id>[:<comment_id>]",
 	Aliases: []string{"update"},
 	Short:   "Edit or update an MR",
-	Long:    ``,
-	Example: `lab MR edit <id>                                # update MR via $EDITOR
-lab MR update <id>                              # same as above
-lab MR update <branch-name>                     # same, but get MR ID from local branch
-lab MR edit <id> -m "new title"                 # update title
-lab MR edit <id> -m "new title" -m "new desc"   # update title & description
-lab MR edit <id> -l newlabel --unlabel oldlabel # relabel MR
-lab MR edit <id>:<comment_id>                   # update a comment on MR`,
+	Example: heredoc.Doc(`
+		lab mr edit <id>
+		lab mr edit <id> -m "new title"
+		lab mr edit <id> -m "new title" -m "new desc"
+		lab mr edit <id> -l new_label --unlabel old_label
+		lab mr edit <id>:<comment_id>
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		commentNum, branchArgs, err := filterCommentArg(args)

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -40,12 +41,13 @@ var listCmd = &cobra.Command{
 	Use:     "list [remote] [search]",
 	Aliases: []string{"ls", "search"},
 	Short:   "List merge requests",
-	Long:    ``,
 	Args:    cobra.MaximumNArgs(2),
-	Example: `lab mr list
-lab mr list "search terms"         # search merge requests for "search terms"
-lab mr search "search terms"       # same as above
-lab mr list remote "search terms"  # search "remote" for merge requests with "search terms"`,
+	Example: heredoc.Doc(`
+		lab mr list
+		lab mr list "search terms"
+		lab mr list --target-branch main
+		lab mr list remote --target-branch main --label my-label --all
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		mrs, err := mrList(args)

--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -124,7 +124,7 @@ func Test_mrFilterByTargetBranch(t *testing.T) {
 }
 
 var (
-	latestCreatedTestMR = "!329 MR for assign and review commands"
+	latestCreatedTestMR = "!740 MR to test close/reopen"
 	latestUpdatedTestMR = "!329 MR for assign and review commands"
 )
 

--- a/cmd/mr_merge.go
+++ b/cmd/mr_merge.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -15,10 +16,12 @@ var mergeImmediate bool
 var mrMergeCmd = &cobra.Command{
 	Use:   "merge [remote] <id>",
 	Short: "Merge an open merge request",
-	Long: `Merges an open merge request. If the pipeline in the project is
-enabled and is still running for that specific MR, by default,
-this command will sets the merge to only happen when the pipeline
-succeeds`,
+	Long: heredoc.Doc(`
+		Merges an open merge request. If the pipeline in the project is
+		enabled and is still running for that specific MR, by default,
+		this command will sets the merge to only happen when the pipeline
+		succeeds.
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -10,7 +10,6 @@ var mrNoteCmd = &cobra.Command{
 	Use:              "note [remote] <id>[:<comment_id>]",
 	Aliases:          []string{"comment", "reply", "resolve"},
 	Short:            "Add a note or comment to an MR on GitLab",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run:              NoteRunFn,
 }

--- a/cmd/mr_reopen.go
+++ b/cmd/mr_reopen.go
@@ -12,7 +12,6 @@ import (
 var mrReopenCmd = &cobra.Command{
 	Use:              "reopen [remote] <id>",
 	Short:            "Reopen a closed merge request",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_reopen_test.go
+++ b/cmd/mr_reopen_test.go
@@ -21,7 +21,7 @@ func Test_mrCloseReopen(t *testing.T) {
 		{
 			desc:     "close-open",
 			opt:      "close",
-			expected: "Merge Request !19 closed",
+			expected: "Merge Request !740 closed",
 		},
 		{
 			desc:     "close-closed",
@@ -31,7 +31,7 @@ func Test_mrCloseReopen(t *testing.T) {
 		{
 			desc:     "reopen-closed",
 			opt:      "reopen",
-			expected: "Merge Request !19 reopened",
+			expected: "Merge Request !740 reopened",
 		},
 	}
 
@@ -39,7 +39,7 @@ func Test_mrCloseReopen(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
-			cmd := exec.Command(labBinaryPath, "mr", test.opt, "19")
+			cmd := exec.Command(labBinaryPath, "mr", test.opt, "740")
 			cmd.Dir = repo
 
 			b, err := cmd.CombinedOutput()

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/charmbracelet/glamour"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -207,26 +208,27 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 		subscribed = "Yes"
 	}
 
-	fmt.Printf(`
-!%d %s
-===================================
-%s
------------------------------------
-Project: %s
-Branches: %s->%s
-Status: %s
-Assignee: %s
-Author: %s
-Approved By: %s
-Approvers: %s
-Approval Groups: %s
-Reviewers: %s
-Milestone: %s
-Labels: %s
-Issues Closed by this MR: %s
-Subscribed: %s
-WebURL: %s
-`,
+	fmt.Printf(
+		heredoc.Doc(`
+			!%d %s
+			===================================
+			%s
+			-----------------------------------
+			Project: %s
+			Branches: %s->%s
+			Status: %s
+			Assignee: %s
+			Author: %s
+			Approved By: %s
+			Approvers: %s
+			Approval Groups: %s
+			Reviewers: %s
+			Milestone: %s
+			Labels: %s
+			Issues Closed by this MR: %s
+			Subscribed: %s
+			WebURL: %s
+		`),
 		mr.IID, mr.Title, mr.Description, project, mr.SourceBranch,
 		mr.TargetBranch, state, assignee, mr.Author.Username,
 		approvedByUsers, approvers, approverGroups, reviewers, milestone, labels,

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -24,10 +24,8 @@ var mrShowCmd = &cobra.Command{
 	Aliases:          []string{"get"},
 	ArgAliases:       []string{"s"},
 	Short:            "Describe a merge request",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		rn, mrNum, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -24,8 +24,7 @@ func Test_mrShow(t *testing.T) {
 	}
 
 	out := string(b)
-	require.Contains(t, out, `
-!1 Test MR for lab list
+	require.Contains(t, out, `!1 Test MR for lab list
 ===================================
 This MR is to remain open for testing the `+"`lab mr list`"+` functionality
 -----------------------------------

--- a/cmd/mr_subscribe.go
+++ b/cmd/mr_subscribe.go
@@ -13,7 +13,6 @@ var mrSubscribeCmd = &cobra.Command{
 	Use:              "subscribe [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Subscribe to merge request",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_thumb.go
+++ b/cmd/mr_thumb.go
@@ -14,14 +14,12 @@ var mrThumbCmd = &cobra.Command{
 	Aliases:          []string{},
 	Short:            "Thumb operations on merge requests",
 	PersistentPreRun: LabPersistentPreRun,
-	Long:             ``,
 }
 
 var mrThumbUpCmd = &cobra.Command{
 	Use:              "up [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Thumb up merge request",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
@@ -46,7 +44,6 @@ var mrThumbDownCmd = &cobra.Command{
 	Use:     "down [remote] <id>",
 	Aliases: []string{},
 	Short:   "Thumbs down merge request",
-	Long:    ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -14,7 +14,6 @@ var mrUnapproveCmd = &cobra.Command{
 	Use:              "unapprove [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Unapprove merge request",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_unsubscribe.go
+++ b/cmd/mr_unsubscribe.go
@@ -13,7 +13,6 @@ var mrUnsubscribeCmd = &cobra.Command{
 	Use:              "unsubscribe [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Unubscribe from merge request",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/note_common.go
+++ b/cmd/note_common.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
@@ -103,8 +104,9 @@ func noteMsg(msgs []string, isMR bool, body string) (string, error) {
 }
 
 func noteText(body string) (string, error) {
-	const tmpl = `{{.InitMsg}}
-{{.CommentChar}} Write a message for this note. Commented lines are discarded.`
+	tmpl := heredoc.Doc(`
+		{{.InitMsg}}
+		{{.CommentChar}} Write a message for this note. Commented lines are discarded.`)
 
 	initMsg := body
 	commentChar := git.CommentChar()

--- a/cmd/note_common.go
+++ b/cmd/note_common.go
@@ -15,7 +15,6 @@ import (
 )
 
 func createNote(rn string, isMR bool, idNum int, msgs []string, filename string, linebreak bool) {
-
 	var err error
 
 	body := ""

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -10,8 +10,6 @@ var projectCmd = &cobra.Command{
 	Aliases:          []string{"repo"},
 	Short:            "Perform project level operations on GitLab",
 	PersistentPreRun: LabPersistentPreRun,
-	Long:             ``,
-	//Run: func(cmd *cobra.Command, args []string) {},
 }
 
 func init() {

--- a/cmd/project_browse.go
+++ b/cmd/project_browse.go
@@ -9,7 +9,6 @@ var projectBrowseCmd = &cobra.Command{
 	Use:              "browse [remote]",
 	Aliases:          []string{"b"},
 	Short:            "View project in a browser",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, _, err := parseArgsRemoteAndID(args)

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/git"
@@ -14,20 +15,24 @@ import (
 var projectCreateCmd = &cobra.Command{
 	Use:   "create [path]",
 	Short: "Create a new project on GitLab",
-	Long: `Create a new project on GitLab.
+	Long: heredoc.Doc(`
+		Create a new project on GitLab.
 
-path refers to the path on GitLab not including the group/namespace. If no path
-or name is provided and the current directory is a git repo, the name of the
-current working directory will be used.`,
-	Example: `# this command...                          # creates this project
-lab project create                         # user/<curr dir> named <curr dir>
-                                           # (above only works w/i git repo)
-lab project create myproject               # user/myproject named myproject
-lab project create myproject -n "new proj" # user/myproject named "new proj"
-lab project create -n "new proj"           # user/new-proj named "new proj"
+		"path" refers to the path on GitLab not including the group/namespace.
+		If no path or name is provided and the current directory is a git repo,
+		the name of the	current working directory will be used.
+	`),
+	Example: heredoc.Doc(`
+		# this command...                          # creates this project
+		lab project create                         # user/<curr dir> named <curr dir>
+		                                           # (above only works within a git repo)
+		lab project create myproject               # user/myproject named myproject
+		lab project create myproject -n "new proj" # user/myproject named "new proj"
+		lab project create -n "new proj"           # user/new-proj named "new proj"
 
-lab project create mygroup/myproject       # mygroup/myproject named myproject
-lab project create -g mygroup myproject    # mygroup/myproject named myproject`,
+		lab project create mygroup/myproject       # mygroup/myproject named myproject
+		lab project create -g mygroup myproject    # mygroup/myproject named myproject
+	`),
 	Args:             cobra.MaximumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/show_common.go
+++ b/cmd/show_common.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/araddon/dateparse"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/glamour/ansi"
@@ -232,24 +233,28 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 				// system notes are informational messages only
 				// and cannot have replies.  Do not output the
 				// note.ID
-				printit(`
-* %s %s at %s
-`,
+				printit(
+					heredoc.Doc(`
+						* %s %s at %s
+					`),
 					note.Author.Username, splitNote[0], time.Time(*note.UpdatedAt).String())
 				if len(splitNote) == 2 {
 					if renderMarkdown {
 						splitNote[1], _ = mdRenderer.Render(splitNote[1])
 					}
-					printit(`%s
-`,
+					printit(
+						heredoc.Doc(`
+							%s
+						`),
 						splitNote[1])
 				}
 				continue
 			}
 
-			printit(`
-%s-----------------------------------
-`,
+			printit(
+				heredoc.Doc(`
+					%s-----------------------------------
+				`),
 				indentHeader)
 
 			if time.Time(*note.UpdatedAt).After(comparetime) {

--- a/cmd/snippet_browse.go
+++ b/cmd/snippet_browse.go
@@ -14,7 +14,6 @@ import (
 var snippetBrowseCmd = &cobra.Command{
 	Use:              "browse [remote] <id>",
 	Short:            "View personal or project snippet in a browser",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -28,9 +29,9 @@ var (
 var snippetCreateCmd = &cobra.Command{
 	Use:   "create [remote]",
 	Short: "Create a personal or project snippet",
-	Long: `
-Source snippets from stdin, file, or in editor from scratch
-Optionally add a title & description with -m`,
+	Long: heredoc.Doc(`
+		Source snippets from stdin, file, or in editor from scratch.
+	`),
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		msgs, err := cmd.Flags().GetStringArray("message")

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -133,9 +133,10 @@ func snipCode(path string) (string, error) {
 		}
 	}
 
-	var tmpl = `
-{{.CommentChar}} In this mode you are writing a snippet from scratch
-{{.CommentChar}} The first block is the title and the rest is the contents.`
+	tmpl := heredoc.Doc(`
+		{{.CommentChar}} In this mode you are writing a snippet from scratch
+		{{.CommentChar}} The first block is the title and the rest is the contents.
+	`)
 
 	text, err := snipText(tmpl)
 	if err != nil {

--- a/cmd/snippet_delete.go
+++ b/cmd/snippet_delete.go
@@ -13,7 +13,6 @@ import (
 var snippetDeleteCmd = &cobra.Command{
 	Use:   "delete [remote] <id>",
 	Short: "Delete a project or personal snippet",
-	Long:  ``,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)

--- a/cmd/snippet_list.go
+++ b/cmd/snippet_list.go
@@ -21,7 +21,6 @@ var snippetListCmd = &cobra.Command{
 	Use:              "list [remote]",
 	Aliases:          []string{"ls"},
 	Short:            "List personal or project snippets",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		snips, err := snippetList(args)

--- a/cmd/todo.go
+++ b/cmd/todo.go
@@ -6,8 +6,7 @@ import (
 
 var todoCmd = &cobra.Command{
 	Use:              "todo",
-	Short:            `Check out the todo list for MR or issues`,
-	Long:             ``,
+	Short:            "Check out the todo list for MR or issues",
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if list, _ := cmd.Flags().GetBool("list"); list {

--- a/cmd/todo_done.go
+++ b/cmd/todo_done.go
@@ -15,7 +15,6 @@ var (
 var todoDoneCmd = &cobra.Command{
 	Use:              "done",
 	Short:            "Mark todo list entry as Done",
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if all {

--- a/cmd/todo_issue.go
+++ b/cmd/todo_issue.go
@@ -3,15 +3,17 @@ package cmd
 import (
 	"strconv"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
 )
 
 var todoIssueCmd = &cobra.Command{
-	Use:              "issue",
-	Short:            "Add a Issue to Todo list",
-	Example:          `lab todo issue 5678                #adds Issue 1234 to user's Todo list`,
+	Use:   "issue",
+	Short: "Add a Issue to Todo list",
+	Example: heredoc.Doc(`
+		lab todo issue 5678       #adds Issue 1234 to user's Todo list
+	`),
 	Hidden:           true,
-	Long:             ``,
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, err := getRemoteName("")

--- a/cmd/todo_list.go
+++ b/cmd/todo_list.go
@@ -23,8 +23,7 @@ var todoListCmd = &cobra.Command{
 	Use:              "list",
 	Aliases:          []string{"ls"},
 	Short:            "List todos",
-	Long:             ``,
-	Example:          `lab todo list                        # list open todos"`,
+	Example:          "lab todo list",
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		todos, err := todoList(args)

--- a/cmd/todo_mr.go
+++ b/cmd/todo_mr.go
@@ -11,8 +11,7 @@ import (
 var todoMRCmd = &cobra.Command{
 	Use:              "mr",
 	Short:            "Add a Merge Request to Todo list",
-	Example:          `lab todo mr 1234                      #adds MR 1234 to user's Todo list`,
-	Long:             ``,
+	Example:          "lab todo mr 1234    #adds MR 1234 to user's Todo list",
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, err := getRemoteName("")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/zaquestion/lab
 
 require (
+	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/Microsoft/go-winio v0.4.15 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alecthomas/chroma v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A=
+github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15 h1:qkLXKzb1QoVatRyd/YlXZ/Kg0m5K3SPuoD82jjSOaBc=
 github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=


### PR DESCRIPTION
We have multiple places where multiline texts are used within the actual code (help messages, text templates, etc..).
Using the usual back-quote marks allow that, but at the same time it considers all the leading whitespaces in each line, making it look really ugly.

This MR adds the use of `heredoc.Doc()` module/function to solve it, which considers valid leading whitespace only what is beyond the first line indentation level. Tests multiline texts were not changed to keep checking the `heredoc.Doc()`  behavior.

Also, this MR updates some help messages for some commands and doesn't contain any functional code changes.