### PR TITLE
edit: fix labels update for issue and MR

### DIFF
--- a/cmd/edit_common.go
+++ b/cmd/edit_common.go
@@ -9,16 +9,6 @@ import (
 	"github.com/zaquestion/lab/internal/git"
 )
 
-// editGetLabels returns a string slice of labels based on the current
-// labels and flags from the command line, and a bool indicating whether
-// the labels have changed
-func editGetLabels(idLabels []string, labels []string, unlabels []string) ([]string, bool, error) {
-	// add the new labels to the current labels, then remove the "unlabels"
-	labels = difference(union(idLabels, labels), unlabels)
-
-	return labels, !same(idLabels, labels), nil
-}
-
 // GetUpdateUsers returns an int slice of user IDs based on the
 // current users and flags from the command line, and a bool
 // indicating whether the users have changed

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -65,29 +65,31 @@ lab issue edit <id>:<comment_id>                   # update a comment on MR`,
 			return
 		}
 
+		var labelsChanged bool
 		// get the labels to add
-		labelTerms, err := cmd.Flags().GetStringSlice("label")
+		addLabelTerms, err := cmd.Flags().GetStringSlice("label")
 		if err != nil {
 			log.Fatal(err)
 		}
-		labels, err := MapLabels(rn, labelTerms)
+		addLabels, err := MapLabels(rn, addLabelTerms)
 		if err != nil {
 			log.Fatal(err)
+		}
+		if len(addLabels) > 0 {
+			labelsChanged = true
 		}
 
 		// get the labels to remove
-		unlabelTerms, err := cmd.Flags().GetStringSlice("unlabel")
+		rmLabelTerms, err := cmd.Flags().GetStringSlice("unlabel")
 		if err != nil {
 			log.Fatal(err)
 		}
-		unlabels, err := MapLabels(rn, unlabelTerms)
+		rmLabels, err := MapLabels(rn, rmLabelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		labels, labelsChanged, err := editGetLabels(issue.Labels, labels, unlabels)
-		if err != nil {
-			log.Fatal(err)
+		if len(rmLabels) > 0 {
+			labelsChanged = true
 		}
 
 		// get the assignees to add
@@ -152,7 +154,9 @@ lab issue edit <id>:<comment_id>                   # update a comment on MR`,
 		}
 
 		if labelsChanged {
-			opts.Labels = labels
+			// empty arrays are just ignored
+			opts.AddLabels = addLabels
+			opts.RemoveLabels = rmLabels
 		}
 
 		if assigneesChanged {

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -61,29 +61,31 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 			return
 		}
 
+		var labelsChanged bool
 		// get the labels to add
-		labelTerms, err := cmd.Flags().GetStringSlice("label")
+		addLabelTerms, err := cmd.Flags().GetStringSlice("label")
 		if err != nil {
 			log.Fatal(err)
 		}
-		labels, err := MapLabels(rn, labelTerms)
+		addLabels, err := MapLabels(rn, addLabelTerms)
 		if err != nil {
 			log.Fatal(err)
+		}
+		if len(addLabels) > 0 {
+			labelsChanged = true
 		}
 
 		// get the labels to remove
-		unlabelTerms, err := cmd.Flags().GetStringSlice("unlabel")
+		rmLabelTerms, err := cmd.Flags().GetStringSlice("unlabel")
 		if err != nil {
 			log.Fatal(err)
 		}
-		unlabels, err := MapLabels(rn, unlabelTerms)
+		rmLabels, err := MapLabels(rn, rmLabelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		labels, labelsChanged, err := editGetLabels(mr.Labels, labels, unlabels)
-		if err != nil {
-			log.Fatal(err)
+		if len(rmLabels) > 0 {
+			labelsChanged = true
 		}
 
 		// get the assignees to add
@@ -243,7 +245,9 @@ lab MR edit <id>:<comment_id>                   # update a comment on MR`,
 		}
 
 		if labelsChanged {
-			opts.Labels = labels
+			// empty arrays are just ignored
+			opts.AddLabels = addLabels
+			opts.RemoveLabels = rmLabels
 		}
 
 		if assigneesChanged {


### PR DESCRIPTION
Since the label/unlabel code was written the go-gitlab module was
updated and received got the ability to add and remove labels explicitly
instead of the specifying all labels through a single struct member.

With that, we can use these new members in the UpdateLabel struct to
get the job done and solve the issue where it's not possible to unlabel
an issue or MR with a single label, since the array would be ignore for
being "empty".

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>

Fixes #684 