### PR TITLE
Fix GoLint warnings across cmd/*

### DIFF
--- a/cmd/ci_artifacts.go
+++ b/cmd/ci_artifacts.go
@@ -29,7 +29,7 @@ var ciArtifactsCmd = &cobra.Command{
 		lab ci artifacts upstream 125 --merge-request
 		lab ci artifacts upstream 125:'my custom stage' --merge-request
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
 			rn      string

--- a/cmd/ci_lint.go
+++ b/cmd/ci_lint.go
@@ -15,7 +15,7 @@ import (
 var ciLintCmd = &cobra.Command{
 	Use:              "lint",
 	Short:            "Validate .gitlab-ci.yml against GitLab",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		path := ".gitlab-ci.yml"
 		if len(args) == 1 {

--- a/cmd/ci_run.go
+++ b/cmd/ci_run.go
@@ -33,7 +33,7 @@ var ciCreateCmd = &cobra.Command{
 		lab ci create feature_branch
 		lab ci create -p engineering/integration_tests master
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, branch, err := getCIRunOptions(cmd, args)
 		if err != nil {
@@ -67,7 +67,7 @@ var ciTriggerCmd = &cobra.Command{
 		lab ci trigger -p engineering/integration_tests master
 		lab ci trigger -p engineering/integration_tests -v foo=bar master
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, branch, err := getCIRunOptions(cmd, args)
 		if err != nil {

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -25,7 +25,7 @@ var ciStatusCmd = &cobra.Command{
 		lab ci status --wait
 	`),
 	RunE:             nil,
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
 			rn  string

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -49,7 +49,7 @@ var ciStatusCmd = &cobra.Command{
 
 		pid := rn
 
-		pager := NewPager(cmd.Flags())
+		pager := newPager(cmd.Flags())
 		defer pager.Close()
 
 		w := tabwriter.NewWriter(os.Stdout, 2, 4, 1, byte(' '), 0)

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -109,7 +109,12 @@ func doTrace(ctx context.Context, w io.Writer, pid interface{}, pipelineID int, 
 			}
 			fmt.Fprintf(w, "Showing logs for %s job #%d\n", job.Name, job.ID)
 		})
+
 		_, err = io.CopyN(ioutil.Discard, trace, offset)
+		if err != nil {
+			return err
+		}
+
 		lenT, err := io.Copy(w, trace)
 		if err != nil {
 			return err

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -72,7 +72,7 @@ var ciTraceCmd = &cobra.Command{
 		}
 		projectID = project.ID
 
-		pager := NewPager(cmd.Flags())
+		pager := newPager(cmd.Flags())
 		defer pager.Close()
 
 		err = doTrace(context.Background(), os.Stdout, projectID, pipelineID, jobName)

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -39,7 +39,7 @@ var ciTraceCmd = &cobra.Command{
 		lab ci trace upstream 18 --merge-request
 		lab ci trace upstream 18:'my custom stage' --merge-request
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
 			rn      string

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -44,7 +44,7 @@ var ciViewCmd = &cobra.Command{
 		'T' to toggle trace/logs (suspending application)
 		'c' to cancel job
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		a := tview.NewApplication()
 		defer recoverPanic(a)

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -25,7 +25,7 @@ var cloneCmd = &cobra.Command{
 		lab clone company/awesome-repo
 		lab clone company/backend-team/awesome-repo
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		project, err := gitlab.FindProject(args[0])
 		if err == gitlab.ErrProjectNotFound {

--- a/cmd/edit_common.go
+++ b/cmd/edit_common.go
@@ -27,7 +27,7 @@ func getUpdateUsers(currentUsers []string, users []string, remove []string) ([]i
 		userIDs = make([]int, len(users))
 		for i, a := range users {
 			if getUserID(a) == nil {
-				return nil, false, fmt.Errorf("Error: %s is not a valid username\n", a)
+				return nil, false, fmt.Errorf("%s is not a valid username", a)
 			}
 			userIDs[i] = *getUserID(a)
 		}

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -38,7 +38,7 @@ var forkCmd = &cobra.Command{
 		lab fork origin --name new-awasome-project
 	`),
 	Args:             cobra.MaximumNArgs(1),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		skipClone, _ = cmd.Flags().GetBool("skip-clone")
 		noWaitFork, _ := cmd.Flags().GetBool("no-wait")

--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -8,7 +8,7 @@ var issueCmd = &cobra.Command{
 	Use:              "issue",
 	Short:            `Describe, list, and create issues`,
 	Long:             ``,
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if list, _ := cmd.Flags().GetBool("list"); list {
 			issueListCmd.Run(cmd, args)

--- a/cmd/issue_browse.go
+++ b/cmd/issue_browse.go
@@ -13,7 +13,7 @@ var issueBrowseCmd = &cobra.Command{
 	Use:              "browse [remote] <id>",
 	Aliases:          []string{"b"},
 	Short:            "View issue in a browser",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, num, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/issue_close.go
+++ b/cmd/issue_close.go
@@ -33,16 +33,16 @@ var issueCloseCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		dupId, _ := cmd.Flags().GetString("duplicate")
-		if dupId != "" {
-			if !strings.Contains(dupId, "#") {
-				dupId = "#" + dupId
+		dupID, _ := cmd.Flags().GetString("duplicate")
+		if dupID != "" {
+			if !strings.Contains(dupID, "#") {
+				dupID = "#" + dupID
 			}
-			err = lab.IssueDuplicate(p.ID, int(id), dupId)
+			err = lab.IssueDuplicate(p.ID, int(id), dupID)
 			if err != nil {
 				log.Fatal(err)
 			}
-			fmt.Printf("Issue #%d closed as duplicate of %s\n", id, dupId)
+			fmt.Printf("Issue #%d closed as duplicate of %s\n", id, dupID)
 		} else {
 			err = lab.IssueClose(p.ID, int(id))
 			if err != nil {

--- a/cmd/issue_close.go
+++ b/cmd/issue_close.go
@@ -16,7 +16,7 @@ var issueCloseCmd = &cobra.Command{
 	Aliases:          []string{"delete"},
 	Short:            "Close issue by ID",
 	Args:             cobra.MinimumNArgs(1),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Example: heredoc.Doc(`
 		lab issue close 1234
 		lab issue close --duplicate 123 1234

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -23,7 +23,7 @@ var issueCreateCmd = &cobra.Command{
 	Aliases:          []string{"new"},
 	Short:            "Open an issue on GitLab",
 	Args:             cobra.MaximumNArgs(1),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		msgs, err := cmd.Flags().GetStringArray("message")
 		if err != nil {

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -60,7 +60,7 @@ var issueCreateCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		labels, err := MapLabels(rn, labelTerms)
+		labels, err := mapLabels(rn, labelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -170,18 +170,18 @@ func init() {
 
 	carapace.Gen(issueCreateCmd).FlagCompletion(carapace.ActionMap{
 		"label": carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 			}
+			return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 		}),
 		"milestone": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Milestones(project, action.MilestoneOpts{Active: true})
 			}
+			return action.Milestones(project, action.MilestoneOpts{Active: true})
 		}),
 	})
 

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -233,18 +233,18 @@ func init() {
 
 	carapace.Gen(issueEditCmd).FlagCompletion(carapace.ActionMap{
 		"label": carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 			}
+			return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 		}),
 		"milestone": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Milestones(project, action.MilestoneOpts{Active: true})
 			}
+			return action.Milestones(project, action.MilestoneOpts{Active: true})
 		}),
 	})
 

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -72,7 +72,7 @@ var issueEditCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		addLabels, err := MapLabels(rn, addLabelTerms)
+		addLabels, err := mapLabels(rn, addLabelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -85,7 +85,7 @@ var issueEditCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		rmLabels, err := MapLabels(rn, rmLabelTerms)
+		rmLabels, err := mapLabels(rn, rmLabelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -29,7 +29,7 @@ var issueEditCmd = &cobra.Command{
 		lab issue edit <id>:<comment_id>
 	`),
 	Args:             cobra.MinimumNArgs(1),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		rn, idString, err := parseArgsRemoteAndProject(args)

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -55,10 +55,11 @@ var issueListCmd = &cobra.Command{
 }
 
 func issueList(args []string) ([]*gitlab.Issue, error) {
-	rn, issueSearch, err := parseArgsRemoteAndProject(args)
+	rn, search, err := parseArgsRemoteAndProject(args)
 	if err != nil {
 		return nil, err
 	}
+	issueSearch = search
 
 	labels, err := MapLabels(rn, issueLabels)
 	if err != nil {

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -61,7 +61,7 @@ func issueList(args []string) ([]*gitlab.Issue, error) {
 	}
 	issueSearch = search
 
-	labels, err := MapLabels(rn, issueLabels)
+	labels, err := mapLabels(rn, issueLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -45,7 +45,7 @@ var issueListCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		pager := NewPager(cmd.Flags())
+		pager := newPager(cmd.Flags())
 		defer pager.Close()
 
 		for _, issue := range issues {

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -84,14 +84,14 @@ func issueList(args []string) ([]*gitlab.Issue, error) {
 	if issueAuthor != "" {
 		issueAuthorID = getUserID(issueAuthor)
 		if issueAuthorID == nil {
-			log.Fatal(fmt.Errorf("%s user not found\n", issueAuthor))
+			log.Fatalf("%s user not found\n", issueAuthor)
 		}
 	}
 
 	if issueAssignee != "" {
 		issueAssigneeID = getUserID(issueAssignee)
 		if issueAssigneeID == nil {
-			log.Fatal(fmt.Errorf("%s user not found\n", issueAssignee))
+			log.Fatalf("%s user not found\n", issueAssignee)
 		}
 	}
 

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -38,7 +38,7 @@ var issueListCmd = &cobra.Command{
 		lab issue list "search terms"
 		lab issue list remote "search terms"
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		issues, err := issueList(args)
 		if err != nil {

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -158,18 +158,18 @@ func init() {
 	issueCmd.AddCommand(issueListCmd)
 	carapace.Gen(issueListCmd).FlagCompletion(carapace.ActionMap{
 		"label": carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 			}
+			return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 		}),
 		"milestone": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Milestones(project, action.MilestoneOpts{Active: true})
 			}
+			return action.Milestones(project, action.MilestoneOpts{Active: true})
 		}),
 		"state": carapace.ActionValues("all", "opened", "closed"),
 	})

--- a/cmd/issue_move.go
+++ b/cmd/issue_move.go
@@ -16,7 +16,7 @@ var issueMoveCmd = &cobra.Command{
 	Long:             ``,
 	Example:          "lab issue move 5 zaquestion/test/           # FQDN must match",
 	Args:             cobra.MinimumNArgs(2),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		// get this rn
 		srcRN, err := getRemoteName(defaultRemote)

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -15,11 +15,10 @@ var issueNoteCmd = &cobra.Command{
 	Short:            "Add a note or comment to an issue on GitLab",
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: LabPersistentPreRun,
-	Run:              NoteRunFn,
+	Run:              noteRunFn,
 }
 
-func NoteRunFn(cmd *cobra.Command, args []string) {
-
+func noteRunFn(cmd *cobra.Command, args []string) {
 	isMR := false
 	if os.Args[1] == "mr" {
 		isMR = true

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -14,7 +14,7 @@ var issueNoteCmd = &cobra.Command{
 	Aliases:          []string{"comment", "reply"},
 	Short:            "Add a note or comment to an issue on GitLab",
 	Args:             cobra.MinimumNArgs(1),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run:              noteRunFn,
 }
 

--- a/cmd/issue_note_test.go
+++ b/cmd/issue_note_test.go
@@ -34,7 +34,7 @@ func Test_issueReplyNote(t *testing.T) {
 		t.Fatal(err)
 	}
 	issueIDs := strings.Split(string(a), "\n")
-	issueID := strings.Trim(issueIDs[0], "https://gitlab.com/lab-testing/test/-/issues/")
+	issueID := strings.TrimPrefix(issueIDs[0], "https://gitlab.com/lab-testing/test/-/issues/")
 
 	note := exec.Command(labBinaryPath, "issue", "note", "lab-testing", issueID, "-m", "note text")
 	note.Dir = repo

--- a/cmd/issue_reopen.go
+++ b/cmd/issue_reopen.go
@@ -12,7 +12,7 @@ import (
 var issueReopenCmd = &cobra.Command{
 	Use:              "reopen [remote] <id>",
 	Short:            "Reopen a closed issue",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -19,7 +19,7 @@ var issueShowCmd = &cobra.Command{
 	Aliases:          []string{"get"},
 	ArgAliases:       []string{"s"},
 	Short:            "Describe an issue",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		rn, issueNum, err := parseArgsRemoteAndID(args)

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -41,7 +41,7 @@ var issueShowCmd = &cobra.Command{
 			renderMarkdown = !noMarkdown
 		}
 
-		pager := NewPager(cmd.Flags())
+		pager := newPager(cmd.Flags())
 		defer pager.Close()
 
 		printIssue(issue, rn, renderMarkdown)

--- a/cmd/issue_show_test.go
+++ b/cmd/issue_show_test.go
@@ -53,9 +53,7 @@ func Test_issueShow_updated_comments(t *testing.T) {
 		t.Log(string(b))
 		t.Error(err)
 	}
+	out := stripansi.Strip(string(b))
 
-	out := string(b)
-	out = stripansi.Strip(out) // This is required because glamour adds a lot of ansi chars
-
-	require.Contains(t, string(b), `updated comment at`)
+	require.Contains(t, string(out), `updated comment at`)
 }

--- a/cmd/issue_subscribe.go
+++ b/cmd/issue_subscribe.go
@@ -13,7 +13,7 @@ var issueSubscribeCmd = &cobra.Command{
 	Use:              "subscribe [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Subscribe to an issue",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/issue_unsubscribe.go
+++ b/cmd/issue_unsubscribe.go
@@ -14,7 +14,7 @@ var issueUnsubscribeCmd = &cobra.Command{
 	Aliases:          []string{},
 	Short:            "Unubscribe from an issue",
 	Long:             ``,
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/label.go
+++ b/cmd/label.go
@@ -10,7 +10,6 @@ var labelCmd = &cobra.Command{
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
-		return
 	},
 }
 

--- a/cmd/label.go
+++ b/cmd/label.go
@@ -7,7 +7,7 @@ import (
 var labelCmd = &cobra.Command{
 	Use:              "label",
 	Short:            "List and search labels",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cmd/label_create.go
+++ b/cmd/label_create.go
@@ -18,7 +18,7 @@ var labelCreateCmd = &cobra.Command{
 		lab label create --color cornflowerblue --description "Blue as a cornflower" blue
 		lab label create --color #6495ed --description "Also blue as a cornflower" blue2
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, name, err := parseArgsRemoteAndProject(args)

--- a/cmd/label_delete.go
+++ b/cmd/label_delete.go
@@ -11,7 +11,7 @@ var labelDeleteCmd = &cobra.Command{
 	Use:              "delete [remote] <name>",
 	Aliases:          []string{"remove"},
 	Short:            "Deletes an existing label",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, name, err := parseArgsRemoteAndProject(args)

--- a/cmd/label_delete.go
+++ b/cmd/label_delete.go
@@ -19,7 +19,7 @@ var labelDeleteCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		labels, err := MapLabels(rn, []string{name})
+		labels, err := mapLabels(rn, []string{name})
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -21,7 +21,7 @@ var labelListCmd = &cobra.Command{
 		lab label list "search term"
 		lab label list remote "search term"
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, labelSearch, err := parseArgsRemoteAndProject(args)
 		if err != nil {

--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -55,7 +55,7 @@ var labelListCmd = &cobra.Command{
 	},
 }
 
-func MapLabels(rn string, labelTerms []string) ([]string, error) {
+func mapLabels(rn string, labelTerms []string) ([]string, error) {
 	// Don't bother fetching project labels if nothing is being really requested
 	if len(labelTerms) == 0 {
 		return []string{}, nil

--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -35,7 +35,7 @@ var labelListCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		pager := NewPager(cmd.Flags())
+		pager := newPager(cmd.Flags())
 		defer pager.Close()
 
 		for _, label := range labels {

--- a/cmd/merge_request.go
+++ b/cmd/merge_request.go
@@ -12,7 +12,7 @@ var mergeRequestCmd = &cobra.Command{
 	Short:            mrCreateCmd.Short,
 	Long:             mrCreateCmd.Long,
 	Args:             mrCreateCmd.Args,
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		runMRCreate(cmd, args)
 	},

--- a/cmd/milestone.go
+++ b/cmd/milestone.go
@@ -7,7 +7,7 @@ import (
 var milestoneCmd = &cobra.Command{
 	Use:              "milestone",
 	Short:            "List and search milestones",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cmd/milestone_create.go
+++ b/cmd/milestone_create.go
@@ -43,11 +43,11 @@ func init() {
 	carapace.Gen(milestoneCreateCmd).PositionalCompletion(
 		action.Remotes(),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Milestones(project, action.MilestoneOpts{Active: true})
 			}
+			return action.Milestones(project, action.MilestoneOpts{Active: true})
 		}),
 	)
 }

--- a/cmd/milestone_create.go
+++ b/cmd/milestone_create.go
@@ -13,7 +13,7 @@ var milestoneCreateCmd = &cobra.Command{
 	Aliases:          []string{"add"},
 	Short:            "Create a new milestone",
 	Example:          "lab milestone create my-milestone",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, title, err := parseArgsRemoteAndProject(args)

--- a/cmd/milestone_delete.go
+++ b/cmd/milestone_delete.go
@@ -11,7 +11,7 @@ var milestoneDeleteCmd = &cobra.Command{
 	Use:              "delete [remote] <name>",
 	Aliases:          []string{"remove"},
 	Short:            "Deletes an existing milestone",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, name, err := parseArgsRemoteAndProject(args)

--- a/cmd/milestone_delete.go
+++ b/cmd/milestone_delete.go
@@ -31,11 +31,11 @@ func init() {
 	carapace.Gen(milestoneDeleteCmd).PositionalCompletion(
 		action.Remotes(),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Milestones(project, action.MilestoneOpts{Active: true})
 			}
+			return action.Milestones(project, action.MilestoneOpts{Active: true})
 		}),
 	)
 }

--- a/cmd/milestone_list.go
+++ b/cmd/milestone_list.go
@@ -21,7 +21,7 @@ var milestoneListCmd = &cobra.Command{
 		lab milestone list "search term"
 		lab milestone list remote "search term"
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, milestoneSearch, err := parseArgsRemoteAndProject(args)
 		if err != nil {

--- a/cmd/mr.go
+++ b/cmd/mr.go
@@ -9,7 +9,7 @@ var mrCmd = &cobra.Command{
 	Use:              "mr",
 	Short:            `Describe, list, and create merge requests`,
 	Long:             ``,
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if list, _ := cmd.Flags().GetBool("list"); list {
 			listCmd.Run(cmd, args)

--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -14,7 +14,7 @@ var mrApproveCmd = &cobra.Command{
 	Use:              "approve [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Approve merge request",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_browse.go
+++ b/cmd/mr_browse.go
@@ -15,7 +15,7 @@ var mrBrowseCmd = &cobra.Command{
 	Use:              "browse [remote] <id>",
 	Aliases:          []string{"b"},
 	Short:            "View merge request in a browser",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, num, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -29,7 +29,7 @@ var checkoutCmd = &cobra.Command{
 	Use:              "checkout [remote] <id>",
 	Short:            "Checkout an open merge request",
 	Args:             cobra.RangeArgs(1, 2),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrID, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/mr_close.go
+++ b/cmd/mr_close.go
@@ -12,7 +12,7 @@ import (
 var mrCloseCmd = &cobra.Command{
 	Use:              "close [remote] <id>",
 	Short:            "Close merge request",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -26,7 +26,7 @@ var mrCreateCmd = &cobra.Command{
 	Short:            "Open a merge request on GitLab",
 	Long:             "Creates a merge request.",
 	Args:             cobra.MaximumNArgs(2),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run:              runMRCreate,
 }
 

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -50,18 +50,18 @@ func init() {
 
 	carapace.Gen(mrCreateCmd).FlagCompletion(carapace.ActionMap{
 		"label": carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 			}
+			return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 		}),
 		"milestone": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Milestones(project, action.MilestoneOpts{Active: true})
 			}
+			return action.Milestones(project, action.MilestoneOpts{Active: true})
 		}),
 	})
 

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -73,7 +73,7 @@ func init() {
 
 func verifyRemoteAndBranch(projectID int, remote string, branch string) error {
 	if _, err := lab.GetCommit(projectID, branch); err != nil {
-		return fmt.Errorf("Aborting MR create, %s:%s is not a valid reference", remote, branch)
+		return fmt.Errorf("%s:%s is not a valid reference", remote, branch)
 	}
 	return nil
 }
@@ -124,7 +124,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		sourceRemote = sourceParts[0]
 		sourceBranch = sourceParts[1]
 		if sourceRemote == "" || sourceBranch == "" {
-			log.Fatal(fmt.Errorf("Error: Source remote must have format remote:remote_branch.\n"))
+			log.Fatalf("source remote must have format remote:remote_branch.\n")
 		}
 
 		_, err := git.IsRemote(sourceRemote)
@@ -154,7 +154,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		targetRemote = args[0]
 		ok, err := git.IsRemote(targetRemote)
 		if err != nil || !ok {
-			log.Fatal(fmt.Errorf("%s is not a valid remote\n", targetRemote))
+			log.Fatalf("%s is not a valid remote\n", targetRemote)
 		}
 	}
 	targetProjectName, err := git.PathWithNameSpace(targetRemote)
@@ -232,7 +232,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	}
 
 	if title == "" {
-		log.Fatal("aborting MR due to empty MR msg")
+		log.Fatal("empty MR message")
 	}
 
 	linebreak, _ := cmd.Flags().GetBool("force-linebreak")
@@ -293,7 +293,7 @@ func mrText(sourceRemote, sourceBranch, targetRemote, targetBranch string, cover
 		}
 	}
 	if numCommits == 0 {
-		return "", fmt.Errorf("Aborting: The resulting Merge Request from %s to %s has 0 commits", target, source)
+		return "", fmt.Errorf("the resulting MR from %s to %s has 0 commits", target, source)
 	}
 
 	tmpl := heredoc.Doc(`

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -180,7 +180,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	labels, err := MapLabels(targetProjectName, labelTerms)
+	labels, err := mapLabels(targetProjectName, labelTerms)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/mr_delete.go
+++ b/cmd/mr_delete.go
@@ -17,7 +17,7 @@ var mrDeleteCmd = &cobra.Command{
 		of the main remote.
 	`),
 	Args:             cobra.MaximumNArgs(2),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		remote, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -22,7 +22,7 @@ var mrCreateDiscussionCmd = &cobra.Command{
 	Use:              "discussion [remote] <id>",
 	Short:            "Start a discussion on an MR on GitLab",
 	Aliases:          []string{"block", "thread"},
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrNum, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -358,18 +358,19 @@ func init() {
 
 	carapace.Gen(mrEditCmd).FlagCompletion(carapace.ActionMap{
 		"label": carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 			}
+			return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
+
 		}),
 		"milestone": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Milestones(project, action.MilestoneOpts{Active: true})
 			}
+			return action.Milestones(project, action.MilestoneOpts{Active: true})
 		}),
 	})
 

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -67,7 +67,7 @@ var mrEditCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		addLabels, err := MapLabels(rn, addLabelTerms)
+		addLabels, err := mapLabels(rn, addLabelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -80,7 +80,7 @@ var mrEditCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		rmLabels, err := MapLabels(rn, rmLabelTerms)
+		rmLabels, err := mapLabels(rn, rmLabelTerms)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -27,7 +27,7 @@ var mrEditCmd = &cobra.Command{
 		lab mr edit <id> -l new_label --unlabel old_label
 		lab mr edit <id>:<comment_id>
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		commentNum, branchArgs, err := filterCommentArg(args)
 		if err != nil {

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -55,7 +55,7 @@ var listCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		pager := NewPager(cmd.Flags())
+		pager := newPager(cmd.Flags())
 		defer pager.Close()
 
 		for _, mr := range mrs {

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -212,18 +212,18 @@ func init() {
 	mrCmd.AddCommand(listCmd)
 	carapace.Gen(listCmd).FlagCompletion(carapace.ActionMap{
 		"label": carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 			}
+			return action.Labels(project).Invoke(c).Filter(c.Parts).ToA()
 		}),
 		"milestone": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if project, _, err := parseArgsRemoteAndProject(c.Args); err != nil {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
 				return carapace.ActionMessage(err.Error())
-			} else {
-				return action.Milestones(project, action.MilestoneOpts{Active: true})
 			}
+			return action.Milestones(project, action.MilestoneOpts{Active: true})
 		}),
 		"state": carapace.ActionValues("all", "opened", "closed", "merged"),
 	})

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -70,7 +70,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 		return nil, err
 	}
 
-	labels, err := MapLabels(rn, mrLabels)
+	labels, err := mapLabels(rn, mrLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -48,7 +48,7 @@ var listCmd = &cobra.Command{
 		lab mr list --target-branch main
 		lab mr list remote --target-branch main --label my-label --all
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		mrs, err := mrList(args)
 		if err != nil {

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -85,7 +85,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 	if mrAssignee != "" {
 		mrAssigneeID = getUserID(mrAssignee)
 		if mrAssigneeID == nil {
-			log.Fatal(fmt.Errorf("%s user not found\n", mrAssignee))
+			log.Fatalf("%s user not found\n", mrAssignee)
 		}
 	} else if mrMine {
 		assigneeID, err := lab.UserID()
@@ -98,7 +98,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 	if mrAuthor != "" {
 		mrAuthorID = getUserID(mrAuthor)
 		if mrAuthorID == nil {
-			log.Fatal(fmt.Errorf("%s user not found\n", mrAuthor))
+			log.Fatalf("%s user not found\n", mrAuthor)
 		}
 	}
 
@@ -113,7 +113,7 @@ func mrList(args []string) ([]*gitlab.MergeRequest, error) {
 	if mrReviewer != "" {
 		mrReviewerID = getUserID(mrReviewer)
 		if mrReviewerID == nil {
-			log.Fatal(fmt.Errorf("%s user not found\n", mrReviewer))
+			log.Fatalf("%s user not found\n", mrReviewer)
 		}
 	}
 

--- a/cmd/mr_merge.go
+++ b/cmd/mr_merge.go
@@ -22,7 +22,7 @@ var mrMergeCmd = &cobra.Command{
 		this command will sets the merge to only happen when the pipeline
 		succeeds.
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -10,7 +10,7 @@ var mrNoteCmd = &cobra.Command{
 	Use:              "note [remote] <id>[:<comment_id>]",
 	Aliases:          []string{"comment", "reply", "resolve"},
 	Short:            "Add a note or comment to an MR on GitLab",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run:              noteRunFn,
 }
 

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -11,7 +11,7 @@ var mrNoteCmd = &cobra.Command{
 	Aliases:          []string{"comment", "reply", "resolve"},
 	Short:            "Add a note or comment to an MR on GitLab",
 	PersistentPreRun: LabPersistentPreRun,
-	Run:              NoteRunFn,
+	Run:              noteRunFn,
 }
 
 func init() {

--- a/cmd/mr_rebase.go
+++ b/cmd/mr_rebase.go
@@ -10,7 +10,7 @@ import (
 var mrRebaseCmd = &cobra.Command{
 	Use:              "rebase [remote] <id>",
 	Short:            "Rebase an open merge request",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_reopen.go
+++ b/cmd/mr_reopen.go
@@ -12,7 +12,7 @@ import (
 var mrReopenCmd = &cobra.Command{
 	Use:              "reopen [remote] <id>",
 	Short:            "Reopen a closed merge request",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -63,7 +63,7 @@ var mrShowCmd = &cobra.Command{
 			}
 			git.Show(remote+"/"+mr.TargetBranch, mr.SHA, mrShowPatchReverse)
 		} else {
-			pager := NewPager(cmd.Flags())
+			pager := newPager(cmd.Flags())
 			defer pager.Close()
 
 			printMR(mr, rn, renderMarkdown)

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -25,7 +25,7 @@ var mrShowCmd = &cobra.Command{
 	Aliases:          []string{"get"},
 	ArgAliases:       []string{"s"},
 	Short:            "Describe a merge request",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrNum, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_subscribe.go
+++ b/cmd/mr_subscribe.go
@@ -13,7 +13,7 @@ var mrSubscribeCmd = &cobra.Command{
 	Use:              "subscribe [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Subscribe to merge request",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -461,7 +461,7 @@ func Test_mrCmd_source(t *testing.T) {
 		b, _ = cmd.CombinedOutput()
 		out := string(b)
 		t.Log(out)
-		require.Contains(t, out, "Aborting MR create, origin:mrtestDoesNotExist is not a valid reference")
+		require.Contains(t, out, "origin:mrtestDoesNotExist is not a valid reference")
 	})
 	t.Run("create_valid", func(t *testing.T) {
 		git := exec.Command("git", "checkout", "mrtest")

--- a/cmd/mr_thumb.go
+++ b/cmd/mr_thumb.go
@@ -13,14 +13,14 @@ var mrThumbCmd = &cobra.Command{
 	Use:              "thumb",
 	Aliases:          []string{},
 	Short:            "Thumb operations on merge requests",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 }
 
 var mrThumbUpCmd = &cobra.Command{
 	Use:              "up [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Thumb up merge request",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -14,7 +14,7 @@ var mrUnapproveCmd = &cobra.Command{
 	Use:              "unapprove [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Unapprove merge request",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_unsubscribe.go
+++ b/cmd/mr_unsubscribe.go
@@ -13,7 +13,7 @@ var mrUnsubscribeCmd = &cobra.Command{
 	Use:              "unsubscribe [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Unubscribe from merge request",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -9,7 +9,7 @@ var projectCmd = &cobra.Command{
 	Use:              "project",
 	Aliases:          []string{"repo"},
 	Short:            "Perform project level operations on GitLab",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 }
 
 func init() {

--- a/cmd/project_browse.go
+++ b/cmd/project_browse.go
@@ -9,7 +9,7 @@ var projectBrowseCmd = &cobra.Command{
 	Use:              "browse [remote]",
 	Aliases:          []string{"b"},
 	Short:            "View project in a browser",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, _, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/project_browse.go
+++ b/cmd/project_browse.go
@@ -12,6 +12,9 @@ var projectBrowseCmd = &cobra.Command{
 	PersistentPreRun: LabPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, _, err := parseArgsRemoteAndID(args)
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		p, err := lab.FindProject(rn)
 		if err != nil {

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -108,9 +108,8 @@ func determineNamespacePath(args []string, name string) (string, string) {
 		ps := strings.Split(args[0], "/")
 		if len(ps) == 1 {
 			return "", ps[0]
-		} else {
-			return strings.Join(ps[:len(ps)-1], "/"), ps[len(ps)-1]
 		}
+		return strings.Join(ps[:len(ps)-1], "/"), ps[len(ps)-1]
 	}
 	if path == "" && name == "" && git.InsideGitRepo() {
 		wd, err := git.WorkingDir()

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -34,7 +34,7 @@ var projectCreateCmd = &cobra.Command{
 		lab project create -g mygroup myproject    # mygroup/myproject named myproject
 	`),
 	Args:             cobra.MaximumNArgs(1),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
 			name, _  = cmd.Flags().GetString("name")

--- a/cmd/project_list.go
+++ b/cmd/project_list.go
@@ -50,7 +50,7 @@ var projectListCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		pager := NewPager(cmd.Flags())
+		pager := newPager(cmd.Flags())
 		defer pager.Close()
 
 		for _, p := range projects {

--- a/cmd/project_list.go
+++ b/cmd/project_list.go
@@ -21,7 +21,7 @@ var projectListCmd = &cobra.Command{
 	Use:              "list [search]",
 	Aliases:          []string{"ls", "search"},
 	Short:            "List your projects",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		search, _, err := parseArgsStringAndID(args)
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -266,7 +266,7 @@ func Execute(initSkipped bool) {
 		}
 	}
 
-	// Set CommandPrefix
+	// Set commandPrefix
 	scmd, _, _ := cmd.Find(os.Args)
 	setCommandPrefix(scmd)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -418,8 +418,8 @@ func Test_flag_config_FT(t *testing.T) {
 func Test_versionCmd(t *testing.T) {
 
 	t.Run("version", func(t *testing.T) {
-		lab_cmd := exec.Command(labBinaryPath, "version")
-		out, err := lab_cmd.CombinedOutput()
+		labCmd := exec.Command(labBinaryPath, "version")
+		out, err := labCmd.CombinedOutput()
 		if err != nil {
 			t.Log(string(out))
 			t.Fatal(err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -249,13 +249,11 @@ func Test_config_gitConfig_FF(t *testing.T) {
 		t.Log(string(b))
 		t.Error(err)
 	}
-
-	out := string(b)
-	out = stripansi.Strip(out)
+	out := stripansi.Strip(string(b))
 
 	os.Remove(configFile())
 	// both configs set to false, comments should not be output
-	require.NotContains(t, string(b), `commented at`)
+	require.NotContains(t, string(out), `commented at`)
 }
 
 func Test_config_gitConfig_FT(t *testing.T) {
@@ -275,14 +273,12 @@ func Test_config_gitConfig_FT(t *testing.T) {
 		t.Log(string(b))
 		t.Error(err)
 	}
-
-	out := string(b)
-	out = stripansi.Strip(out)
+	out := stripansi.Strip(string(b))
 
 	os.Remove(configFile())
 	// .config set to false and .git set to true, comments should be
 	// output
-	require.Contains(t, string(b), `commented at`)
+	require.Contains(t, string(out), `commented at`)
 }
 
 func Test_config_gitConfig_TF(t *testing.T) {
@@ -302,14 +298,12 @@ func Test_config_gitConfig_TF(t *testing.T) {
 		t.Log(string(b))
 		t.Error(err)
 	}
-
-	out := string(b)
-	out = stripansi.Strip(out)
+	out := stripansi.Strip(string(b))
 
 	os.Remove(configFile())
 	// .config set to true and .git set to false, comments should not be
 	// output
-	require.NotContains(t, string(b), `commented at`)
+	require.NotContains(t, string(out), `commented at`)
 }
 
 func Test_config_gitConfig_TT(t *testing.T) {
@@ -329,13 +323,11 @@ func Test_config_gitConfig_TT(t *testing.T) {
 		t.Log(string(b))
 		t.Error(err)
 	}
-
-	out := string(b)
-	out = stripansi.Strip(out)
+	out := stripansi.Strip(string(b))
 
 	os.Remove(configFile())
 	// both configs set to true, comments should be output
-	require.Contains(t, string(b), `commented at`)
+	require.Contains(t, string(out), `commented at`)
 }
 
 // Some flag and config tests do not have to be run.
@@ -365,13 +357,11 @@ func Test_flag_config_TT(t *testing.T) {
 		t.Log(string(b))
 		t.Error(err)
 	}
-
-	out := string(b)
-	out = stripansi.Strip(out)
+	out := stripansi.Strip(string(b))
 
 	os.Remove(configFile())
 	// both configs set to true, comments should be output
-	require.Contains(t, string(b), `commented at`)
+	require.Contains(t, string(out), `commented at`)
 }
 
 // flag set, config false == comments
@@ -392,13 +382,11 @@ func Test_flag_config_TF(t *testing.T) {
 		t.Log(string(b))
 		t.Error(err)
 	}
-
-	out := string(b)
-	out = stripansi.Strip(out)
+	out := stripansi.Strip(string(b))
 
 	os.Remove(configFile())
 	// both configs set to true, comments should be output
-	require.Contains(t, string(b), `commented at`)
+	require.Contains(t, string(out), `commented at`)
 }
 
 // flag (explicitly) unset, config true == no comments
@@ -419,13 +407,11 @@ func Test_flag_config_FT(t *testing.T) {
 		t.Log(string(b))
 		t.Error(err)
 	}
-
-	out := string(b)
-	out = stripansi.Strip(out)
+	out := stripansi.Strip(string(b))
 
 	os.Remove(configFile())
 	// configs overridden on the command line, comments should not be output
-	require.NotContains(t, string(b), `commented at`)
+	require.NotContains(t, string(out), `commented at`)
 }
 
 // Make sure the version command don't break things in the future

--- a/cmd/show_common.go
+++ b/cmd/show_common.go
@@ -281,7 +281,7 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 		}
 	}
 
-	if sinceIsSet == false {
+	if !sinceIsSet {
 		config.WriteConfigEntry(CommandPrefix+issueEntry, newAccessTime, "", "")
 	}
 }

--- a/cmd/show_common.go
+++ b/cmd/show_common.go
@@ -184,7 +184,7 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 	)
 	comparetime, err = dateparse.ParseLocal(since)
 	if err != nil || comparetime.IsZero() {
-		comparetime = getMainConfig().GetTime(CommandPrefix + issueEntry)
+		comparetime = getMainConfig().GetTime(commandPrefix + issueEntry)
 		if comparetime.IsZero() {
 			comparetime = time.Now().UTC()
 		}
@@ -282,6 +282,6 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 	}
 
 	if !sinceIsSet {
-		config.WriteConfigEntry(CommandPrefix+issueEntry, newAccessTime, "", "")
+		config.WriteConfigEntry(commandPrefix+issueEntry, newAccessTime, "", "")
 	}
 }

--- a/cmd/snippet.go
+++ b/cmd/snippet.go
@@ -12,7 +12,7 @@ var snippetCmd = &cobra.Command{
 	Aliases:          []string{"snip"},
 	Short:            snippetCreateCmd.Short,
 	Long:             snippetCreateCmd.Long,
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if list, _ := cmd.Flags().GetBool("list"); list {
 			snippetListCmd.Run(cmd, args)

--- a/cmd/snippet_browse.go
+++ b/cmd/snippet_browse.go
@@ -14,7 +14,7 @@ import (
 var snippetBrowseCmd = &cobra.Command{
 	Use:              "browse [remote] <id>",
 	Short:            "View personal or project snippet in a browser",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -32,7 +32,7 @@ var snippetCreateCmd = &cobra.Command{
 	Long: heredoc.Doc(`
 		Source snippets from stdin, file, or in editor from scratch.
 	`),
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		msgs, err := cmd.Flags().GetStringArray("message")
 		if err != nil {

--- a/cmd/snippet_list.go
+++ b/cmd/snippet_list.go
@@ -27,7 +27,7 @@ var snippetListCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		pager := NewPager(cmd.Flags())
+		pager := newPager(cmd.Flags())
 		defer pager.Close()
 		for _, snip := range snips {
 			fmt.Printf("#%d %s\n", snip.ID, snip.Title)

--- a/cmd/snippet_list.go
+++ b/cmd/snippet_list.go
@@ -21,7 +21,7 @@ var snippetListCmd = &cobra.Command{
 	Use:              "list [remote]",
 	Aliases:          []string{"ls"},
 	Short:            "List personal or project snippets",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		snips, err := snippetList(args)
 		if err != nil {

--- a/cmd/todo.go
+++ b/cmd/todo.go
@@ -7,7 +7,7 @@ import (
 var todoCmd = &cobra.Command{
 	Use:              "todo",
 	Short:            "Check out the todo list for MR or issues",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if list, _ := cmd.Flags().GetBool("list"); list {
 			todoListCmd.Run(cmd, args)

--- a/cmd/todo_done.go
+++ b/cmd/todo_done.go
@@ -15,7 +15,7 @@ var (
 var todoDoneCmd = &cobra.Command{
 	Use:              "done",
 	Short:            "Mark todo list entry as Done",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if all {
 			err := lab.TodoMarkAllDone()

--- a/cmd/todo_issue.go
+++ b/cmd/todo_issue.go
@@ -14,7 +14,7 @@ var todoIssueCmd = &cobra.Command{
 		lab todo issue 5678       #adds Issue 1234 to user's Todo list
 	`),
 	Hidden:           true,
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, err := getRemoteName("")
 		if err != nil {

--- a/cmd/todo_list.go
+++ b/cmd/todo_list.go
@@ -24,7 +24,7 @@ var todoListCmd = &cobra.Command{
 	Aliases:          []string{"ls"},
 	Short:            "List todos",
 	Example:          "lab todo list",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		todos, err := todoList(args)
 		if err != nil {

--- a/cmd/todo_list.go
+++ b/cmd/todo_list.go
@@ -31,7 +31,7 @@ var todoListCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		pager := NewPager(cmd.Flags())
+		pager := newPager(cmd.Flags())
 		defer pager.Close()
 
 		red := color.New(color.FgRed).SprintFunc()

--- a/cmd/todo_mr.go
+++ b/cmd/todo_mr.go
@@ -12,7 +12,7 @@ var todoMRCmd = &cobra.Command{
 	Use:              "mr",
 	Short:            "Add a Merge Request to Todo list",
 	Example:          "lab todo mr 1234    #adds MR 1234 to user's Todo list",
-	PersistentPreRun: LabPersistentPreRun,
+	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, err := getRemoteName("")
 		if err != nil {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -81,7 +81,7 @@ func getBranchMR(rn, branch string) int {
 	var num int = 0
 
 	mrBranch, err := git.UpstreamBranch(branch)
-	if mrBranch == "" {
+	if err != nil {
 		// Fall back to local branch
 		mrBranch = branch
 	}
@@ -316,6 +316,10 @@ func parseArgsWithGitBranchMR(args []string) (string, int64, error) {
 		err    error
 	)
 	s, i, err := parseArgsRemoteAndID(args)
+	if err != nil {
+		return "", 0, err
+	}
+
 	if i == 0 {
 		s, branch, err = parseArgsRemoteAndString(args)
 		if err != nil {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	CommandPrefix string
+	commandPrefix string
 	// http vs ssh protocol control flag
 	useHTTP bool
 )
@@ -39,13 +39,13 @@ func flagConfig(fs *flag.FlagSet) {
 
 		switch f.Value.Type() {
 		case "bool":
-			configValue = getMainConfig().GetBool(CommandPrefix + f.Name)
+			configValue = getMainConfig().GetBool(commandPrefix + f.Name)
 			configString = strconv.FormatBool(configValue.(bool))
 		case "string":
-			configValue = getMainConfig().GetString(CommandPrefix + f.Name)
+			configValue = getMainConfig().GetString(commandPrefix + f.Name)
 			configString = configValue.(string)
 		case "stringSlice":
-			configValue = getMainConfig().GetStringSlice(CommandPrefix + f.Name)
+			configValue = getMainConfig().GetStringSlice(commandPrefix + f.Name)
 			configString = strings.Join(configValue.([]string), " ")
 		case "int":
 			log.Fatal("ERROR: found int flag, use string instead: ", f.Value.Type(), f)
@@ -382,18 +382,18 @@ func filterCommentArg(args []string) (int, []string, error) {
 // would return 'issue_list.'
 func setCommandPrefix(scmd *cobra.Command) {
 	for _, command := range RootCmd.Commands() {
-		if CommandPrefix != "" {
+		if commandPrefix != "" {
 			break
 		}
 		commandName := strings.Split(command.Use, " ")[0]
 		if scmd == command {
-			CommandPrefix = commandName + "."
+			commandPrefix = commandName + "."
 			break
 		}
 		for _, subcommand := range command.Commands() {
 			subCommandName := commandName + "_" + strings.Split(subcommand.Use, " ")[0]
 			if scmd == subcommand {
-				CommandPrefix = subCommandName + "."
+				commandPrefix = subCommandName + "."
 				break
 			}
 		}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -345,6 +345,8 @@ func parseArgsWithGitBranchMR(args []string) (string, int64, error) {
 	return s, i, nil
 }
 
+// filterCommentArg separate the case where a command can have both the
+// remote and "<mrID>:<commentID>" at the same time.
 func filterCommentArg(args []string) (int, []string, error) {
 	branchArgs := []string{}
 	idString := ""
@@ -359,16 +361,18 @@ func filterCommentArg(args []string) (int, []string, error) {
 		} else {
 			idString = args[0]
 		}
-	} else if len(args) > 1 {
+	} else if len(args) == 2 {
 		branchArgs = append(branchArgs, args[0])
 		idString = args[1]
+	} else {
+		return 0, branchArgs, fmt.Errorf("unsupported number of arguments")
 	}
 
 	if strings.Contains(idString, ":") {
 		ps := strings.Split(idString, ":")
 		branchArgs = append(branchArgs, ps[0])
 		idString = ps[1]
-	} else {
+	} else if idString != "" {
 		branchArgs = append(branchArgs, idString)
 		idString = ""
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,4 +1,5 @@
 // This file contains common functions that are shared in the lab package
+
 package cmd
 
 import (

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -463,7 +463,7 @@ func (p *pager) Close() {
 	}
 }
 
-func LabPersistentPreRun(cmd *cobra.Command, args []string) {
+func labPersistentPreRun(cmd *cobra.Command, args []string) {
 	flagConfig(cmd.Flags())
 }
 


### PR DESCRIPTION
This MR fixes all `golint ./cmd/*`  warnings.
The issues range from exported members that shouldn't be to unused variables.

There still have golint issues under `internal/*` folder, but these are going to be solved in a separate MR.