### PR TITLE
mr show: Fix --patch and --comments option output

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -62,6 +62,7 @@ var mrShowCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 			git.Show(remote+"/"+mr.TargetBranch, mr.SHA, mrShowPatchReverse)
+			return
 		} else {
 			pager := newPager(cmd.Flags())
 			defer pager.Close()
@@ -239,9 +240,9 @@ func printMR(mr *gitlab.MergeRequest, project string, renderMarkdown bool) {
 
 func init() {
 	mrShowCmd.Flags().BoolP("no-markdown", "M", false, "don't use markdown renderer to print the issue description")
-	mrShowCmd.Flags().BoolP("comments", "c", false, "show comments for the merge request")
+	mrShowCmd.Flags().BoolP("comments", "c", false, "show comments for the merge request (does not work with --patch)")
 	mrShowCmd.Flags().StringP("since", "s", "", "show comments since specified date (format: 2020-08-21 14:57:46.808 +0000 UTC)")
-	mrShowCmd.Flags().BoolVarP(&mrShowPatch, "patch", "p", false, "show MR patches")
+	mrShowCmd.Flags().BoolVarP(&mrShowPatch, "patch", "p", false, "show MR patches (does not work with --comments)")
 	mrShowCmd.Flags().BoolVarP(&mrShowPatchReverse, "reverse", "", false, "reverse order when showing MR patches (chronological instead of anti-chronological)")
 	mrShowCmd.Flags().BoolVarP(&mrShowNoColorDiff, "no-color-diff", "", false, "do not show color diffs in comments")
 	mrCmd.AddCommand(mrShowCmd)


### PR DESCRIPTION
Users have been setting "comments = true" for the mr show command.  This
causes weird output with the --patch output in which the git log is output,
then the comments from the MR is output.

Make a note that --patch and --comments do not work together and stop
the output after the git log is output.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>