### PR TITLE
Remove WIP terminology support

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -242,12 +242,17 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 
 	draft, _ := cmd.Flags().GetBool("draft")
 	if draft {
-		isWIP := hasPrefix(title, "wip:")
+		// GitLab 14.0 will remove WIP support in favor of Draft
+		isWIP := hasPrefix(title, "wip:") ||
+			hasPrefix(title, "[wip]")
+		if isWIP {
+			log.Fatal("the use of \"WIP\" terminology is deprecated, use \"Draft\" instead")
+		}
+
 		isDraft := hasPrefix(title, "draft:") ||
 			hasPrefix(title, "[draft]") ||
 			hasPrefix(title, "(draft)")
-
-		if !isWIP && !isDraft {
+		if !isDraft {
 			title = "Draft: " + title
 		}
 	}

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -228,7 +228,11 @@ var mrEditCmd = &cobra.Command{
 		}
 
 		if draft {
-			if !isWIP && !isDraft {
+			if isWIP {
+				log.Fatal("the use of \"WIP\" terminology is deprecated, use \"Draft\" instead")
+			}
+
+			if !isDraft {
 				title = "Draft: " + title
 			}
 		}

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -205,14 +205,19 @@ var mrEditCmd = &cobra.Command{
 			log.Fatal("aborting: empty mr title")
 		}
 
-		isWIP := strings.EqualFold(title[0:4], "wip:")
-		isDraft := strings.EqualFold(title[0:6], "draft:") ||
-			strings.EqualFold(title[0:7], "[draft]") ||
-			strings.EqualFold(title[0:7], "(draft)")
+		isWIP := hasPrefix(title, "wip:") ||
+			hasPrefix(title, "[wip]")
+		isDraft := hasPrefix(title, "draft:") ||
+			hasPrefix(title, "[draft]") ||
+			hasPrefix(title, "(draft)")
 
 		if ready {
 			if isWIP {
-				title = strings.TrimPrefix(title, title[0:4])
+				if title[0] == '[' {
+					title = strings.TrimPrefix(title, title[0:5])
+				} else {
+					title = strings.TrimPrefix(title, title[0:4])
+				}
 			} else if isDraft {
 				if title[0] == '(' || title[0] == '[' {
 					title = strings.TrimPrefix(title, title[0:7])


### PR DESCRIPTION
GitLab is planning to fully remove the WIP word from their Draft status [1]
in their 14.0 version, which is about to be released. With that, we should
also error out when the user uses it for their merge requests prefixes.

```
Adding WIP: to the start of the merge request’s title still marks a merge
request as a draft.  This feature is scheduled for removal in GitLab 14.0.
Use Draft: instead.
```

[1] https://gitlab.com/gitlab-org/gitlab/-/issues/228685
[2] https://docs.gitlab.com/ee/user/project/merge_requests/drafts.html