### PR TITLE
cmd/mr_show: golint: if block ends with a return statement

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -63,12 +63,12 @@ var mrShowCmd = &cobra.Command{
 			}
 			git.Show(remote+"/"+mr.TargetBranch, mr.SHA, mrShowPatchReverse)
 			return
-		} else {
-			pager := newPager(cmd.Flags())
-			defer pager.Close()
-
-			printMR(mr, rn, renderMarkdown)
 		}
+
+		pager := newPager(cmd.Flags())
+		defer pager.Close()
+
+		printMR(mr, rn, renderMarkdown)
 
 		showComments, _ := cmd.Flags().GetBool("comments")
 		if showComments {


### PR DESCRIPTION
Remove the else clause considering the if ends with return.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>