### PR TITLE
Remove and rename some functions and arguments

### DIFF
--- a/cmd/ci_run.go
+++ b/cmd/ci_run.go
@@ -112,7 +112,7 @@ func getCIRunOptions(cmd *cobra.Command, args []string) (interface{}, string, er
 	}
 
 	remote := determineSourceRemote(branch)
-	rn, err := git.PathWithNameSpace(remote)
+	rn, err := git.PathWithNamespace(remote)
 	if err != nil {
 		return nil, "", err
 	}

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -75,7 +75,7 @@ var forkCmd = &cobra.Command{
 			remote = "origin"
 		}
 
-		project, err := git.PathWithNameSpace(remote)
+		project, err := git.PathWithNamespace(remote)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -55,7 +55,7 @@ var issueCreateCmd = &cobra.Command{
 				remote = args[0]
 			}
 		}
-		rn, err := git.PathWithNameSpace(remote)
+		rn, err := git.PathWithNamespace(remote)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -71,9 +71,9 @@ func init() {
 	)
 }
 
-func verifyRemoteAndBranch(projectID int, remote string, branch string) error {
+func verifyRemoteBranch(projectID int, branch string) error {
 	if _, err := lab.GetCommit(projectID, branch); err != nil {
-		return fmt.Errorf("%s:%s is not a valid reference", remote, branch)
+		return fmt.Errorf("%s is not a valid reference", branch)
 	}
 	return nil
 }
@@ -143,10 +143,10 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	// verify the source branch and remote
-	err = verifyRemoteAndBranch(sourceProject.ID, sourceRemote, sourceBranch)
+	// verify the source branch in remote project
+	err = verifyRemoteBranch(sourceProject.ID, sourceBranch)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%s:%s\n", sourceRemote, err)
 	}
 
 	targetRemote := defaultRemote
@@ -169,10 +169,10 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	targetBranch := targetProject.DefaultBranch
 	if len(args) > 1 && targetBranch != args[1] {
 		targetBranch = args[1]
-		// verify the target branch and remote
-		err = verifyRemoteAndBranch(targetProject.ID, targetRemote, targetBranch)
+		// verify the target branch in remote project
+		err = verifyRemoteBranch(targetProject.ID, targetBranch)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf("%s:%s\n", targetRemote, err)
 		}
 	}
 

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -133,7 +133,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	sourceProjectName, err := git.PathWithNameSpace(sourceRemote)
+	sourceProjectName, err := git.PathWithNamespace(sourceRemote)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 			log.Fatalf("%s is not a valid remote\n", targetRemote)
 		}
 	}
-	targetProjectName, err := git.PathWithNameSpace(targetRemote)
+	targetProjectName, err := git.PathWithNamespace(targetRemote)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -74,7 +74,7 @@ var snippetCreateCmd = &cobra.Command{
 		}
 		// See if we're in a git repo or if global is set to determine
 		// if this should be a personal snippet
-		rn, _ := git.PathWithNameSpace(remote)
+		rn, _ := git.PathWithNamespace(remote)
 		if global || rn == "" {
 			opts := gitlab.CreateSnippetOptions{
 				Title:       gitlab.String(title),

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -137,7 +137,7 @@ func parseArgsRemoteAndID(args []string) (string, int64, error) {
 	if remote == "" {
 		remote = defaultRemote
 	}
-	rn, err := git.PathWithNameSpace(remote)
+	rn, err := git.PathWithNamespace(remote)
 	if err != nil {
 		return "", 0, err
 	}
@@ -257,7 +257,7 @@ func getRemoteName(remote string) (string, error) {
 		return "", errors.Errorf("%s is not a valid remote", remote)
 	}
 
-	remote, err = git.PathWithNameSpace(remote)
+	remote, err = git.PathWithNamespace(remote)
 	if err != nil {
 		return "", err
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -153,20 +153,6 @@ func CurrentBranch() (string, error) {
 	return strings.TrimSpace(string(branch)), nil
 }
 
-// CurrentUpstreamBranch returns the upstream of the currently checked out branch
-func CurrentUpstreamBranch() (string, error) {
-	localBranch, err := CurrentBranch()
-	if err != nil {
-		return "", err
-	}
-
-	branch, err := UpstreamBranch(localBranch)
-	if err != nil {
-		return "", err
-	}
-	return branch, nil
-}
-
 // UpstreamBranch returns the upstream of the specified branch
 func UpstreamBranch(branch string) (string, error) {
 	upstreamBranch, err := gitconfig.Local("branch." + branch + ".merge")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -162,10 +162,10 @@ func UpstreamBranch(branch string) (string, error) {
 	return strings.TrimPrefix(upstreamBranch, "refs/heads/"), nil
 }
 
-// PathWithNameSpace returns the owner/repository for the current repo
+// PathWithNamespace returns the owner/repository for the current repo
 // Such as zaquestion/lab
 // Respects GitLab subgroups (https://docs.gitlab.com/ce/user/group/subgroups/)
-func PathWithNameSpace(remote string) (string, error) {
+func PathWithNamespace(remote string) (string, error) {
 	remoteURL, err := gitconfig.Local("remote." + remote + ".pushurl")
 	if err != nil || remoteURL == "" {
 		remoteURL, err = gitconfig.Local("remote." + remote + ".url")
@@ -198,7 +198,7 @@ func PathWithNameSpace(remote string) (string, error) {
 
 // RepoName returns the name of the repository, such as "lab"
 func RepoName() (string, error) {
-	o, err := PathWithNameSpace("origin")
+	o, err := PathWithNamespace("origin")
 	if err != nil {
 		return "", err
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -95,7 +95,7 @@ func TestCurrentBranch(t *testing.T) {
 	require.Equal(t, expectedBranch, branch)
 }
 
-func TestPathWithNameSpace(t *testing.T) {
+func TestPathWithNamespace(t *testing.T) {
 	tests := []struct {
 		desc        string
 		remote      string
@@ -198,7 +198,7 @@ func TestPathWithNameSpace(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			path, err := PathWithNameSpace(test.remote)
+			path, err := PathWithNamespace(test.remote)
 			if test.expectedErr != "" {
 				assert.EqualError(t, err, test.expectedErr)
 			} else {


### PR DESCRIPTION
This MR doesn't introduce any code behavior change, it only remove some unused code (function and arguments) and rename the function `git.PathWithNameSpace` to `git.PathWithNamespace`.