### PR TITLE
Fix commit log and diffstat when creating MR

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -292,7 +292,7 @@ func mrText(sourceRemote, sourceBranch, targetRemote, targetBranch string, cover
 	numCommits := git.NumberCommits(target, source)
 	if numCommits == 1 {
 		var err error
-		commitMsg, err = git.LastCommitMessage()
+		commitMsg, err = git.LastCommitMessage(source)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/mr_create_test.go
+++ b/cmd/mr_create_test.go
@@ -17,7 +17,7 @@ func Test_mrText(t *testing.T) {
 	require.Contains(t, text, `
 
 I am the default merge request template for lab
-# Requesting a merge into origin:master from origin:mrtest (12 commits)
+# Requesting a merge into origin:master from origin:mrtest (1 commits)
 #
 # Write a message for this merge request. The first block
 # of text is the title and the rest is the description.
@@ -37,7 +37,7 @@ func Test_mrText_CoverLetter(t *testing.T) {
 	require.Contains(t, coverLetter, `
 
 I am the default merge request template for lab
-# Requesting a merge into origin:master from origin:mrtest (12 commits)
+# Requesting a merge into origin:master from origin:mrtest (1 commits)
 #
 # Write a message for this merge request. The first block
 # of text is the title and the rest is the description.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -108,8 +108,8 @@ func PagerCommand() (string, []string) {
 }
 
 // LastCommitMessage returns the last commits message as one line
-func LastCommitMessage() (string, error) {
-	cmd := New("show", "-s", "--format=%s%n%+b", "HEAD")
+func LastCommitMessage(sha string) (string, error) {
+	cmd := New("show", "-s", "--format=%s%n%+b", sha)
 	cmd.Stdout = nil
 	msg, err := cmd.Output()
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -132,7 +132,7 @@ func Log(sha1, sha2 string) (string, error) {
 		return "", errors.Errorf("Can't load git log %s..%s", sha1, sha2)
 	}
 
-	diffCmd := New("diff", "--stat", sha1)
+	diffCmd := New("diff", "--stat", fmt.Sprintf("%s...", sha1))
 	diffCmd.Stdout = nil
 	diffOutput, err := diffCmd.Output()
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -132,7 +132,7 @@ func Log(sha1, sha2 string) (string, error) {
 		return "", errors.Errorf("Can't load git log %s..%s", sha1, sha2)
 	}
 
-	diffCmd := New("diff", "--stat", fmt.Sprintf("%s...", sha1))
+	diffCmd := New("diff", "--stat", fmt.Sprintf("%s...%s", sha1, sha2))
 	diffCmd.Stdout = nil
 	diffOutput, err := diffCmd.Output()
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -125,7 +125,7 @@ func Log(sha1, sha2 string) (string, error) {
 		"--no-color",
 		"--format=%h (%aN)%n%w(78,3,3)%s%n",
 		"--cherry",
-		fmt.Sprintf("%s...%s", sha1, sha2))
+		fmt.Sprintf("%s..%s", sha1, sha2))
 	cmd.Stdout = nil
 	outputs, err := cmd.Output()
 	if err != nil {
@@ -370,7 +370,7 @@ func GetUnifiedDiff(BaseSHA string, HeadSHA string, oldPath string, newPath stri
 
 // NumberCommits returns the number of commits between two commit refs
 func NumberCommits(sha1, sha2 string) int {
-	cmd := New("log", "--oneline", fmt.Sprintf("%s...%s", sha1, sha2))
+	cmd := New("log", "--oneline", fmt.Sprintf("%s..%s", sha1, sha2))
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	CmdOut, err := cmd.Output()

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -63,7 +63,7 @@ func TestCommentChar(t *testing.T) {
 }
 
 func TestLastCommitMessage(t *testing.T) {
-	lcm, err := LastCommitMessage()
+	lcm, err := LastCommitMessage("HEAD")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
When the user creates an MR he's prompted with some basic information about what's going to be the MR content:
* commit list
* number of commits
* commit diff statistics

All these information were being created using a "union" approach of `git`: when the information being considered is the union of two different sets (branches) instead of the difference from one set to another (i.e. what's different from branch `<source>` to `<target>`).

The consequence of the union approach appears when the user wants to create an MR using a source branch that is behind of the target branch wrt commits: if the target is 4 commits ahead of the source branch, and the user doesn't rebase before opening the MR, the commits information (all three of them) will present the source branch's commits + 4 from target branch, which is, obviously wrong when compared to what the UI presents during MR creation.

All the information and related commands was took from Git's manpage.

EDIT:

The commit description was also being retrieved from HEAD instead of the specific source remote and branch. Additional commits were added to handle that as well.