### PR TITLE
cmd/util: fix handle of unknown number of arguments

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -357,8 +357,6 @@ func filterCommentArg(args []string) (int, []string, error) {
 	} else if len(args) == 2 {
 		branchArgs = append(branchArgs, args[0])
 		idString = args[1]
-	} else {
-		return 0, branchArgs, fmt.Errorf("unsupported number of arguments")
 	}
 
 	if strings.Contains(idString, ":") {


### PR DESCRIPTION
Instead of returning an error in case of an unknown number of args, let
it return the nil values and let the caller handle it as it please. For
"mr_note", "issue_note" and "mr_edit" the error was interrumpting the
cmd line argument parser.

Fixes: ecd57aaf4afa ("cmd/util: avoid an empty string to be parsed")
Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>