### PR TITLE
Move noteRunFn to a common place and fix os.Args usage

### DIFF
--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/action"
@@ -16,76 +13,6 @@ var issueNoteCmd = &cobra.Command{
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: labPersistentPreRun,
 	Run:              noteRunFn,
-}
-
-func noteRunFn(cmd *cobra.Command, args []string) {
-	isMR := false
-	if os.Args[1] == "mr" {
-		isMR = true
-	}
-
-	reply, branchArgs, err := filterCommentArg(args)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	var (
-		rn    string
-		idNum int = 0
-	)
-
-	if isMR {
-		s, mrNum, _ := parseArgsWithGitBranchMR(branchArgs)
-		if mrNum == 0 {
-			fmt.Println("Error: Cannot determine MR id.")
-			os.Exit(1)
-		}
-		idNum = int(mrNum)
-		rn = s
-	} else {
-		s, issueNum, _ := parseArgsRemoteAndID(branchArgs)
-		if issueNum == 0 {
-			fmt.Println("Error: Cannot determine issue id.")
-			os.Exit(1)
-		}
-		idNum = int(issueNum)
-		rn = s
-	}
-
-	msgs, err := cmd.Flags().GetStringArray("message")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	filename, err := cmd.Flags().GetString("file")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	linebreak, err := cmd.Flags().GetBool("force-linebreak")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if reply != 0 {
-		resolve, err := cmd.Flags().GetBool("resolve")
-		if err != nil {
-			log.Fatal(err)
-		}
-		// 'lab mr resolve' always overrides options
-		if os.Args[2] == "resolve" {
-			resolve = true
-		}
-
-		quote, err := cmd.Flags().GetBool("quote")
-		if err != nil {
-			log.Fatal(err)
-		}
-		replyNote(rn, isMR, int(idNum), reply, quote, false, filename, linebreak, resolve, msgs)
-		return
-	}
-
-	createNote(rn, isMR, int(idNum), msgs, filename, linebreak)
 }
 
 func init() {

--- a/cmd/note_common.go
+++ b/cmd/note_common.go
@@ -19,7 +19,7 @@ import (
 
 func noteRunFn(cmd *cobra.Command, args []string) {
 	isMR := false
-	if os.Args[1] == "mr" {
+	if cmd.Parent().Name() == "mr" {
 		isMR = true
 	}
 
@@ -72,7 +72,7 @@ func noteRunFn(cmd *cobra.Command, args []string) {
 			log.Fatal(err)
 		}
 		// 'lab mr resolve' always overrides options
-		if os.Args[2] == "resolve" {
+		if cmd.CalledAs() == "resolve" {
 			resolve = true
 		}
 
@@ -80,6 +80,7 @@ func noteRunFn(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
+
 		replyNote(rn, isMR, int(idNum), reply, quote, false, filename, linebreak, resolve, msgs)
 		return
 	}


### PR DESCRIPTION
This MR clean 2 things up:

1) move noteRunFn to cmd/note_common.go file since it's used by both mr_note and issue_note;
2) instead of using `os.Args`, use `cmd.Parent().Name()` and `cmd.CalledAs()` to avoid surprises with `os.Args` being mangled.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>