### PR TITLE
chore: (ci status) #240 bump up default wait interval

### DIFF
--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -76,7 +76,6 @@ var ciStatusCmd = &cobra.Command{
 
 			// filter out old jobs
 			jobs = latestJobs(jobs)
-
 			if len(jobs) == 0 {
 				log.Fatal("no CI jobs found in pipeline ", pipelineID, " on remote ", rn)
 				return
@@ -97,7 +96,7 @@ var ciStatusCmd = &cobra.Command{
 			fmt.Fprintln(w)
 
 			// don't spam the api TOO much
-			time.Sleep(1 * time.Second)
+			time.Sleep(10 * time.Second)
 		}
 
 		fmt.Fprintf(w, "\nPipeline Status: %s\n", jobs[0].Pipeline.Status)


### PR DESCRIPTION
Per discussion in #240, lets just bump up the interval, totally open to putting it behind a flag, but in the context of waiting for a an entire pipeline to finish, 1s is clearly a bit too aggressive.