### PR TITLE
cmd/mr_create: fix index out of range with --source

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -121,11 +121,14 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 
 	if sourceTarget != "" {
 		sourceParts := strings.Split(sourceTarget, ":")
+		if len(sourceParts) < 2 ||
+			strings.TrimSpace(sourceParts[0]) == "" ||
+			strings.TrimSpace(sourceParts[1]) == "" {
+			log.Fatalf("source remote must have format remote:remote_branch")
+		}
+
 		sourceRemote = sourceParts[0]
 		sourceBranch = sourceParts[1]
-		if sourceRemote == "" || sourceBranch == "" {
-			log.Fatalf("source remote must have format remote:remote_branch.\n")
-		}
 
 		_, err := git.IsRemote(sourceRemote)
 		if err != nil {


### PR DESCRIPTION
In case the user could use `lab mr create --source` with "remote" only,
without the branch part, or at least using `:` it would panic:

---- 8< ----
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/zaquestion/lab/cmd.runMRCreate(0x18f3600, 0xc00055a460, 0x0, 0x2)
        /home/bmeneg/git/lab/cmd/mr_create.go:125 +0x207e
github.com/spf13/cobra.(*Command).execute(0x18f3600, 0xc00055a440, 0x2, 0x2, 0x18f3600, 0xc00055a440)
        /home/bmeneg/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:854 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x18f8f40, 0xc00012a000, 0x5, 0x5)
        /home/bmeneg/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /home/bmeneg/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
github.com/zaquestion/lab/cmd.Execute(0xc000124100)
        /home/bmeneg/git/lab/cmd/root.go:273 +0x3c5
main.main()
        /home/bmeneg/git/lab/main.go:27 +0x74
---- >8 ----

This patch adds a condition to the number of elements after spliting the
string.

Fixes #699 

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>