### PR TITLE
Removed --with-comment dependency; Fixed approve bug

### DIFF
--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -30,23 +30,15 @@ var mrApproveCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		if comment {
-			msgs, err := cmd.Flags().GetStringArray("message")
-			if err != nil {
-				log.Fatal(err)
-			}
 
-			filename, err := cmd.Flags().GetString("file")
-			if err != nil {
-				log.Fatal(err)
-			}
+		msgs, err := cmd.Flags().GetStringArray("message")
+		if err != nil {
+			log.Fatal(err)
+		}
 
-			linebreak, err := cmd.Flags().GetBool("force-linebreak")
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			createNote(rn, true, int(id), msgs, filename, linebreak)
+		filename, err := cmd.Flags().GetString("file")
+		if err != nil {
+			log.Fatal(err)
 		}
 
 		err = lab.MRApprove(p.ID, int(id))
@@ -59,15 +51,25 @@ var mrApproveCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}
+
+		if comment || len(msgs) > 0 || filename != "" {
+			linebreak, err := cmd.Flags().GetBool("force-linebreak")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			createNote(rn, true, int(id), msgs, filename, linebreak)
+		}
+
 		fmt.Printf("Merge Request !%d approved\n", id)
 	},
 }
 
 func init() {
 	mrApproveCmd.Flags().Bool("with-comment", false, "Add a comment with the approval")
-	mrApproveCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs (used with --with-comment only)")
-	mrApproveCmd.Flags().StringP("file", "F", "", "use the given file as the message (used with --with-comment only)")
-	mrApproveCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks (used with --with-comment only)")
+	mrApproveCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	mrApproveCmd.Flags().StringP("file", "F", "", "use the given file as the message")
+	mrApproveCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	mrCmd.AddCommand(mrApproveCmd)
 	carapace.Gen(mrApproveCmd).PositionalCompletion(
 		action.Remotes(),

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -30,23 +30,15 @@ var mrUnapproveCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		if comment {
-			msgs, err := cmd.Flags().GetStringArray("message")
-			if err != nil {
-				log.Fatal(err)
-			}
 
-			filename, err := cmd.Flags().GetString("file")
-			if err != nil {
-				log.Fatal(err)
-			}
+		msgs, err := cmd.Flags().GetStringArray("message")
+		if err != nil {
+			log.Fatal(err)
+		}
 
-			linebreak, err := cmd.Flags().GetBool("force-linebreak")
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			createNote(rn, true, int(id), msgs, filename, linebreak)
+		filename, err := cmd.Flags().GetString("file")
+		if err != nil {
+			log.Fatal(err)
 		}
 
 		err = lab.MRUnapprove(p.ID, int(id))
@@ -59,15 +51,25 @@ var mrUnapproveCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}
+
+		if comment || len(msgs) > 0 || filename != "" {
+			linebreak, err := cmd.Flags().GetBool("force-linebreak")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			createNote(rn, true, int(id), msgs, filename, linebreak)
+		}
+
 		fmt.Printf("Merge Request !%d unapproved\n", id)
 	},
 }
 
 func init() {
 	mrUnapproveCmd.Flags().Bool("with-comment", false, "Add a comment with the approval")
-	mrUnapproveCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs (used with --with-comment only)")
-	mrUnapproveCmd.Flags().StringP("file", "F", "", "use the given file as the message (used with --with-comment only)")
-	mrUnapproveCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks (used with --with-comment only)")
+	mrUnapproveCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
+	mrUnapproveCmd.Flags().StringP("file", "F", "", "use the given file as the message")
+	mrUnapproveCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	mrCmd.AddCommand(mrUnapproveCmd)
 	carapace.Gen(mrUnapproveCmd).PositionalCompletion(
 		action.Remotes(),


### PR DESCRIPTION
Fixed a bug where a comment would be added to an MR on approve or
unapprove, even if the MR was already reviewed by the user.

Changed -m and -f behavior so they don't depend on --with-comment to be
used.

Signed-off-by: Lucas Zampieri <lzampier@redhat.com>