### PR TITLE
Fix thumb Down

### DIFF
--- a/cmd/mr_thumb.go
+++ b/cmd/mr_thumb.go
@@ -45,7 +45,7 @@ var mrThumbDownCmd = &cobra.Command{
 	Aliases: []string{},
 	Short:   "Thumbs down merge request",
 	Run: func(cmd *cobra.Command, args []string) {
-		rn, id, err := parseArgsRemoteAndID(args)
+		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
`Thumb Down` cannot determine MR id, changed the function to the same used on `Thumb Up`

Signed-off-by: Lucas Zampieri <lzampier@redhat.com>