### PR TITLE
cmd/lab_todo: fix index out of range without any args

### DIFF
--- a/cmd/todo_done.go
+++ b/cmd/todo_done.go
@@ -25,7 +25,9 @@ var todoDoneCmd = &cobra.Command{
 			fmt.Println("All Todo entries marked as Done")
 			return
 		}
-
+		if len(args) == 0 {
+			log.Fatalf("Specify todo id to be marked as done")
+		}
 		toDoNum, err := strconv.Atoi(args[0])
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Before that condition, if the user used `lab todo done`, a `runtime
error: index out of range [0] with length 0` would occur.

Signed-off-by: Lucas Zampieri <lzampier@redhat.com>