### PR TITLE
Added documentation examples on every command; Fixes

### DIFF
--- a/cmd/ci_artifacts.go
+++ b/cmd/ci_artifacts.go
@@ -22,13 +22,11 @@ var ciArtifactsCmd = &cobra.Command{
 		The branch name, when using with the --merge-request option, can be the
 		merge request number, which matches the branch name internally.	The "job"
 		portion is the given job name, which may contain whitespace characters
-		and which, for this specific case, must be quoted.
-	`),
+		and which, for this specific case, must be quoted.`),
 	Example: heredoc.Doc(`
 		lab ci artifacts upstream feature_branch
 		lab ci artifacts upstream 125 --merge-request
-		lab ci artifacts upstream 125:'my custom stage' --merge-request
-	`),
+		lab ci artifacts upstream 125:'my custom stage' --merge-request`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (

--- a/cmd/ci_lint.go
+++ b/cmd/ci_lint.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 	"io/ioutil"
 	"os"
 
@@ -13,8 +14,11 @@ import (
 
 // ciLintCmd represents the lint command
 var ciLintCmd = &cobra.Command{
-	Use:              "lint",
-	Short:            "Validate .gitlab-ci.yml against GitLab",
+	Use:   "lint",
+	Short: "Validate .gitlab-ci.yml against GitLab",
+	Example: heredoc.Doc(`
+		lab ci lint
+		lab ci lint upstream`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		path := ".gitlab-ci.yml"

--- a/cmd/ci_run.go
+++ b/cmd/ci_run.go
@@ -27,12 +27,10 @@ var ciCreateCmd = &cobra.Command{
 		Project will be inferred from branch if not provided
 
 		Note: "lab ci create" differs from "lab ci trigger" which is a
-		different API
-	`),
+		different API`),
 	Example: heredoc.Doc(`
 		lab ci create feature_branch
-		lab ci create -p engineering/integration_tests master
-	`),
+		lab ci create -p engineering/integration_tests master`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, branch, err := getCIRunOptions(cmd, args)
@@ -60,13 +58,11 @@ var ciTriggerCmd = &cobra.Command{
 
 		Project will be inferred from branch if not provided
 
-		Note: "lab ci trigger" differs from "lab ci create" which is a different API
-	`),
+		Note: "lab ci trigger" differs from "lab ci create" which is a different API`),
 	Example: heredoc.Doc(`
 		lab ci trigger feature_branch
 		lab ci trigger -p engineering/integration_tests master
-		lab ci trigger -p engineering/integration_tests -v foo=bar master
-	`),
+		lab ci trigger -p engineering/integration_tests -v foo=bar master`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, branch, err := getCIRunOptions(cmd, args)

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -22,8 +22,8 @@ var ciStatusCmd = &cobra.Command{
 	Short:   "Textual representation of a CI pipeline",
 	Example: heredoc.Doc(`
 		lab ci status
-		lab ci status --wait
-	`),
+		lab ci status upstream 608 --merge-request
+		lab ci status 600 --wait`),
 	RunE:             nil,
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -32,13 +32,11 @@ var ciTraceCmd = &cobra.Command{
 		The branch name, when using with the --merge-request option, can be the
 		merge request number, which matches the branch name internally.	The "job"
 		portion is the given job name, which may contain whitespace characters
-		and which, for this specific case, must be quoted.
-	`),
+		and which, for this specific case, must be quoted.`),
 	Example: heredoc.Doc(`
 		lab ci trace upstream feature_branch
 		lab ci trace upstream 18 --merge-request
-		lab ci trace upstream 18:'my custom stage' --merge-request
-	`),
+		lab ci trace upstream 18:'my custom stage' --merge-request`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -42,8 +42,10 @@ var ciViewCmd = &cobra.Command{
 		'r', 'p' to run/retry/play a job
 		't' to toggle trace/logs (runs in background)
 		'T' to toggle trace/logs (suspending application)
-		'c' to cancel job
-	`),
+		'c' to cancel job`),
+	Example: heredoc.Doc(`
+		lab ci view
+		lab ci view upstream --merge-request`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		a := tview.NewApplication()

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -18,13 +18,11 @@ var cloneCmd = &cobra.Command{
 	Short: "GitLab aware clone repo command",
 	Long: heredoc.Doc(`
 		Clone a repository, similarly to 'git clone', but aware of GitLab
-		specific settings.
-	`),
+		specific settings.`),
 	Example: heredoc.Doc(`
 		lab clone awesome-repo
-		lab clone company/awesome-repo
-		lab clone company/backend-team/awesome-repo
-	`),
+		lab clone company/awesome-repo --http
+		lab clone company/backend-team/awesome-repo`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		project, err := gitlab.FindProject(args[0])

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -17,17 +17,15 @@ var completionCmd = &cobra.Command{
 		Generates shell autocompletion scripts for different implementations.
 
 		These scripts can be directly sourced, though using pre-generated
-		versions is recommended to avoid shell startup delay.
-	`),
+		versions is recommended to avoid shell startup delay.`),
 	Example: heredoc.Doc(`
 		bash       : source <(lab completion)
 		elvish     : eval(lab completion|slurp)
 		fish       : lab completion | source
 		oil        : source <(lab completion)
 		powershell : lab completion | Out-String | Invoke-Expression
-		xonsh      : exec($(lab completion))
-		zsh        : source <(lab completion)
-	`),
+		xonsh      : exec($(lab completion xonsh))
+		zsh        : source <(lab completion zsh)`),
 	ValidArgs: []string{"bash", "elvish", "fish", "oil", "powershell", "xonsh", "zsh"},
 	Run: func(cmd *cobra.Command, args []string) {
 		shell := ""

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -30,13 +30,15 @@ var forkCmd = &cobra.Command{
 	Short: "Fork a remote repository on GitLab and add as remote",
 	Long: heredoc.Doc(`
 		Fork a remote repository on user's location of choice.
-		Both an already existent remote or a repository path can be specified.
-	`),
+		Both an already existent remote or a repository path can be specified.`),
 	Example: heredoc.Doc(`
 		lab fork origin
 		lab fork upstream --remote-name origin
-		lab fork origin --name new-awasome-project
-	`),
+		lab fork origin --name new-awesome-project
+		lab fork origin -g TheCoolestGroup -n InitialProject
+		lab fork origin -p 'the_dot_git_path'
+		lab fork origin -n 'new_fork' -r 'new_fork_remote'
+		lab fork origin -s`),
 	Args:             cobra.MaximumNArgs(1),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/issue_browse.go
+++ b/cmd/issue_browse.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"strconv"
 
 	"github.com/rsteube/carapace"
@@ -10,9 +11,12 @@ import (
 )
 
 var issueBrowseCmd = &cobra.Command{
-	Use:              "browse [remote] <id>",
-	Aliases:          []string{"b"},
-	Short:            "View issue in a browser",
+	Use:     "browse [remote] <id>",
+	Aliases: []string{"b"},
+	Short:   "View issue in a browser",
+	Example: heredoc.Doc(`
+		lab issue browse
+		lab issue browse upstream 22`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, num, err := parseArgsRemoteAndID(args)

--- a/cmd/issue_close.go
+++ b/cmd/issue_close.go
@@ -19,9 +19,8 @@ var issueCloseCmd = &cobra.Command{
 	PersistentPreRun: labPersistentPreRun,
 	Example: heredoc.Doc(`
 		lab issue close 1234
-		lab issue close --duplicate 123 1234
-		lab issue close --duplicate other-project#123 1234
-	`),
+		lab issue close origin --duplicate 123 1234
+		lab issue close --duplicate other-project#123 1234`),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/issue_create.go
+++ b/cmd/issue_create.go
@@ -19,10 +19,17 @@ import (
 )
 
 var issueCreateCmd = &cobra.Command{
-	Use:              "create [remote]",
-	Aliases:          []string{"new"},
-	Short:            "Open an issue on GitLab",
-	Args:             cobra.MaximumNArgs(1),
+	Use:     "create [remote]",
+	Aliases: []string{"new"},
+	Short:   "Open an issue on GitLab",
+	Args:    cobra.MaximumNArgs(1),
+	Example: heredoc.Doc(`
+		lab issue create
+		lab issue create origin -a johndoe -a janedoe
+		lab issue create origin -l bug
+		lab issue create upstream -m "new issue related to the --help arg"
+		lab issue create upstream --milestone "July"
+		lab issue create upstream --template "API-BUG"`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		msgs, err := cmd.Flags().GetStringArray("message")

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -22,12 +22,14 @@ var issueEditCmd = &cobra.Command{
 	Aliases: []string{"update"},
 	Short:   "Edit or update an issue",
 	Example: heredoc.Doc(`
-		lab issue edit <id>
-		lab issue edit <id> -m "new title"
-		lab issue edit <id> -m "new title" -m "new desc"
-		lab issue edit <id> -l new_label --unlabel old_label
-		lab issue edit <id>:<comment_id>
-	`),
+		lab issue edit 14
+		lab issue edit 14:2065489
+		lab issue edit 14 -a johndoe --unassign jackdoe
+		lab issue edit 14 -m "new title"
+		lab issue edit 14 -m "new title" -m "new desc"
+		lab issue edit 14 -l new_label --unlabel old_label
+		lab issue edit --milestone "NewYear"
+		lab issue edit --force-linebreak`),
 	Args:             cobra.MinimumNArgs(1),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/issue_list.go
+++ b/cmd/issue_list.go
@@ -36,8 +36,17 @@ var issueListCmd = &cobra.Command{
 	Example: heredoc.Doc(`
 		lab issue list
 		lab issue list "search terms"
-		lab issue list remote "search terms"
-	`),
+		lab issue list origin "search terms"
+		lab issue list origin --all
+		lab issue list origin --assignee johndoe
+		lab issue list upstream --author janedoe
+		lab issue list upstream -x "An Issue with Abc"
+		lab issue list upstream -l "new_bug"
+		lab issue list upstream --milestone "week 22"
+		lab issue list remote -n "10"
+		lab issue list remote --order "created_at"
+		lab issue list remote --sort "asc"
+		lab issue list remote --state "closed"`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		issues, err := issueList(args)

--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -1,16 +1,22 @@
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/action"
 )
 
 var issueNoteCmd = &cobra.Command{
-	Use:              "note [remote] <id>[:<comment_id>]",
-	Aliases:          []string{"comment", "reply"},
-	Short:            "Add a note or comment to an issue on GitLab",
-	Args:             cobra.MinimumNArgs(1),
+	Use:     "note [remote] <id>[:<comment_id>]",
+	Aliases: []string{"comment", "reply"},
+	Short:   "Add a note or comment to an issue on GitLab",
+	Args:    cobra.MinimumNArgs(1),
+	Example: heredoc.Doc(`
+		lab issue note 1
+		lab issue note 2 -F test_file --force-linebreak
+		lab issue note origin 2 -m "a message" -m "another one"
+		lab issue note upstream 1:613278106 --quote`),
 	PersistentPreRun: labPersistentPreRun,
 	Run:              noteRunFn,
 }
@@ -19,8 +25,9 @@ func init() {
 	issueNoteCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	issueNoteCmd.Flags().StringP("file", "F", "", "use the given file as the message")
 	issueNoteCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
-	issueNoteCmd.Flags().Bool("quote", false, "quote note in reply (used with --reply only)")
+	issueNoteCmd.Flags().Bool("quote", false, "quote note in reply")
 	issueNoteCmd.Flags().Bool("resolve", false, "[unused in issue note command]")
+	issueNoteCmd.Flags().MarkHidden("resolve")
 
 	issueCmd.AddCommand(issueNoteCmd)
 	carapace.Gen(issueNoteCmd).PositionalCompletion(

--- a/cmd/issue_reopen.go
+++ b/cmd/issue_reopen.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -10,8 +11,11 @@ import (
 )
 
 var issueReopenCmd = &cobra.Command{
-	Use:              "reopen [remote] <id>",
-	Short:            "Reopen a closed issue",
+	Use:   "reopen [remote] <id>",
+	Short: "Reopen a closed issue",
+	Example: heredoc.Doc(`
+		lab issue reopen 1
+		lab issue reopen upstream 2`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -15,16 +15,24 @@ import (
 )
 
 var issueShowCmd = &cobra.Command{
-	Use:              "show [remote] <id>",
-	Aliases:          []string{"get"},
-	ArgAliases:       []string{"s"},
-	Short:            "Describe an issue",
+	Use:        "show [remote] <id>",
+	Aliases:    []string{"get"},
+	ArgAliases: []string{"s"},
+	Short:      "Describe an issue",
+	Example: heredoc.Doc(`
+		lab issue show 1
+		lab issue show origin 1 -c
+		lab issue show upstream 1 -M
+		lab issue show upstream 1 --since "1970-01-01 00:00:00.000 +0000 UTC"`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		rn, issueNum, err := parseArgsRemoteAndID(args)
 		if err != nil {
 			log.Fatal(err)
+		}
+		if issueNum == 0 {
+			log.Fatalf("Specify <id> of issue to be show")
 		}
 
 		issue, err := lab.IssueGet(rn, int(issueNum))

--- a/cmd/issue_subscribe.go
+++ b/cmd/issue_subscribe.go
@@ -13,6 +13,7 @@ var issueSubscribeCmd = &cobra.Command{
 	Use:              "subscribe [remote] <id>",
 	Aliases:          []string{},
 	Short:            "Subscribe to an issue",
+	Example:          "lab issue subscribe origin 10",
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)

--- a/cmd/issue_unsubscribe.go
+++ b/cmd/issue_unsubscribe.go
@@ -14,6 +14,7 @@ var issueUnsubscribeCmd = &cobra.Command{
 	Aliases:          []string{},
 	Short:            "Unubscribe from an issue",
 	Long:             ``,
+	Example:          "lab issue unsubscribe origin 10",
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)

--- a/cmd/label_create.go
+++ b/cmd/label_create.go
@@ -16,8 +16,7 @@ var labelCreateCmd = &cobra.Command{
 	Example: heredoc.Doc(`
 		lab label create my-label
 		lab label create --color cornflowerblue --description "Blue as a cornflower" blue
-		lab label create --color #6495ed --description "Also blue as a cornflower" blue2
-	`),
+		lab label create --color #6495ed --description "Also blue as a cornflower" blue2`),
 	PersistentPreRun: labPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/label_delete.go
+++ b/cmd/label_delete.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/action"
@@ -8,9 +9,12 @@ import (
 )
 
 var labelDeleteCmd = &cobra.Command{
-	Use:              "delete [remote] <name>",
-	Aliases:          []string{"remove"},
-	Short:            "Deletes an existing label",
+	Use:     "delete [remote] <name>",
+	Aliases: []string{"remove"},
+	Short:   "Deletes an existing label",
+	Example: heredoc.Doc(`
+		lab label delete my-label
+		lab label delete origin my-label`),
 	PersistentPreRun: labPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -19,8 +19,7 @@ var labelListCmd = &cobra.Command{
 	Example: heredoc.Doc(`
 		lab label list
 		lab label list "search term"
-		lab label list remote "search term"
-	`),
+		lab label list remote "search term"`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, labelSearch, err := parseArgsRemoteAndProject(args)

--- a/cmd/milestone_create.go
+++ b/cmd/milestone_create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -9,10 +10,12 @@ import (
 )
 
 var milestoneCreateCmd = &cobra.Command{
-	Use:              "create [remote] <name>",
-	Aliases:          []string{"add"},
-	Short:            "Create a new milestone",
-	Example:          "lab milestone create my-milestone",
+	Use:     "create [remote] <name>",
+	Aliases: []string{"add"},
+	Short:   "Create a new milestone",
+	Example: heredoc.Doc(`
+		lab milestone create my-milestone
+		lab milestone create upstream 'my title' --description 'Some Description'`),
 	PersistentPreRun: labPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/milestone_delete.go
+++ b/cmd/milestone_delete.go
@@ -11,6 +11,7 @@ var milestoneDeleteCmd = &cobra.Command{
 	Use:              "delete [remote] <name>",
 	Aliases:          []string{"remove"},
 	Short:            "Deletes an existing milestone",
+	Example:          "lab label delete origin 'some milestone'",
 	PersistentPreRun: labPersistentPreRun,
 	Args:             cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/milestone_list.go
+++ b/cmd/milestone_list.go
@@ -20,7 +20,7 @@ var milestoneListCmd = &cobra.Command{
 		lab milestone list
 		lab milestone list "search term"
 		lab milestone list remote "search term"
-	`),
+		lab milestone list upstream -s 'closed'`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, milestoneSearch, err := parseArgsRemoteAndProject(args)

--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 	"os"
 
 	"github.com/rsteube/carapace"
@@ -11,9 +12,15 @@ import (
 )
 
 var mrApproveCmd = &cobra.Command{
-	Use:              "approve [remote] <id>",
-	Aliases:          []string{},
-	Short:            "Approve merge request",
+	Use:     "approve [remote] <id>",
+	Aliases: []string{},
+	Short:   "Approve merge request",
+	Example: heredoc.Doc(`
+		lab mr approve origin
+		lab mr approve upstream -F test_file
+		lab mr approve upstream -m "A helpfull comment"
+		lab mr approve upstream --with-comment
+		lab mr approve upstream -m "A helpfull\nComment" --force-linebreak`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_browse.go
+++ b/cmd/mr_browse.go
@@ -15,6 +15,7 @@ var mrBrowseCmd = &cobra.Command{
 	Use:              "browse [remote] <id>",
 	Aliases:          []string{"b"},
 	Short:            "View merge request in a browser",
+	Example:          "lab mr browse origin",
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, num, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 	"os"
 
 	"github.com/rsteube/carapace"
@@ -26,9 +27,15 @@ var (
 
 // listCmd represents the list command
 var checkoutCmd = &cobra.Command{
-	Use:              "checkout [remote] <id>",
-	Short:            "Checkout an open merge request",
-	Args:             cobra.RangeArgs(1, 2),
+	Use:   "checkout [remote] <id>",
+	Short: "Checkout an open merge request",
+	Args:  cobra.RangeArgs(1, 2),
+	Example: heredoc.Doc(`
+		lab mr checkout origin 10
+		lab mr checkout upstream -b a_branch_name
+		lab mr checkout a_remote -f
+		lab mr checkout upstream --https
+		lab mr checkout upstream -t`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrID, err := parseArgsRemoteAndID(args)
@@ -95,7 +102,6 @@ var checkoutCmd = &cobra.Command{
 		if err := git.New("fetch", targetRemote, fetchRefSpec).Run(); err != nil {
 			log.Fatal(err)
 		}
-
 		if mrCheckoutCfg.track {
 			// Create configured branch with tracking from fetchToRef
 			// git branch --flags <branchname> [<start-point>]

--- a/cmd/mr_close.go
+++ b/cmd/mr_close.go
@@ -12,6 +12,7 @@ import (
 var mrCloseCmd = &cobra.Command{
 	Use:              "close [remote] <id>",
 	Short:            "Close merge request",
+	Example:          "lab mr close origin 10",
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -21,11 +21,26 @@ import (
 
 // mrCmd represents the mr command
 var mrCreateCmd = &cobra.Command{
-	Use:              "create [remote [remote_branch]]",
-	Aliases:          []string{"new"},
-	Short:            "Open a merge request on GitLab",
-	Long:             "Creates a merge request.",
-	Args:             cobra.MaximumNArgs(2),
+	Use:     "create [remote [remote_branch]]",
+	Aliases: []string{"new"},
+	Short:   "Creates a merge request.",
+	Args:    cobra.MaximumNArgs(2),
+	Example: heredoc.Doc(`
+		lab mr create origin
+		lab mr create origin branch --allow-collaboration
+		lab mr create a_remote -a johndoe -a janedoe
+		lab mr create my_remote -c
+		lab mr create my_remote --draft
+		lab mr create my_remote -F a_file.txt
+		lab mr create my_remote -F a_file.txt --force-linebreak
+		lab mr create my_remote -l bug -l confirmed
+		lab mr create my_remote -m "A title message"
+		lab mr create my_remote -m "A MR title" -m "A MR description"
+		lab mr create my_remote --milestone "Fall"
+		lab mr create my_remote -d
+		lab mr create my_remote -r johndoe -r janedoe
+		lab mr create my_remote --source upstream:main origin main
+		lab mr create my_remote -s`),
 	PersistentPreRun: labPersistentPreRun,
 	Run:              runMRCreate,
 }
@@ -41,7 +56,7 @@ func init() {
 	mrCreateCmd.Flags().String("milestone", "", "set milestone by milestone title or ID")
 	mrCreateCmd.Flags().StringP("file", "F", "", "use the given file as the Description")
 	mrCreateCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
-	mrCreateCmd.Flags().BoolP("cover-letter", "c", false, "do not comment changelog and diffstat")
+	mrCreateCmd.Flags().BoolP("cover-letter", "c", false, "comment changelog and diffstat")
 	mrCreateCmd.Flags().Bool("draft", false, "mark the merge request as draft")
 	mrCreateCmd.Flags().String("source", "", "specify a remote source target in the form of remote:remote_branch")
 	mergeRequestCmd.Flags().AddFlagSet(mrCreateCmd.Flags())
@@ -283,8 +298,9 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		// generate during Test_mrCreate. In the meantime API failures
 		// will exit 0
 		fmt.Fprintln(os.Stderr, err)
+	} else {
+		fmt.Println(mrURL + "/diffs")
 	}
-	fmt.Println(mrURL + "/diffs")
 }
 
 func mrText(sourceRemote, sourceBranch, targetRemote, targetBranch string, coverLetterFormat bool) (string, error) {

--- a/cmd/mr_delete.go
+++ b/cmd/mr_delete.go
@@ -14,9 +14,9 @@ var mrDeleteCmd = &cobra.Command{
 	Short:   "Delete a merge request on GitLab",
 	Long: heredoc.Doc(`
 		Delete a specific merge request or the one created on the default
-		of the main remote.
-	`),
+		of the main remote.`),
 	Args:             cobra.MaximumNArgs(2),
+	Example:          "lab mr delete upstream 22",
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		remote, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -19,9 +19,13 @@ import (
 )
 
 var mrCreateDiscussionCmd = &cobra.Command{
-	Use:              "discussion [remote] <id>",
-	Short:            "Start a discussion on an MR on GitLab",
-	Aliases:          []string{"block", "thread"},
+	Use:     "discussion [remote] <id>",
+	Short:   "Start a discussion on an MR on GitLab",
+	Aliases: []string{"block", "thread"},
+	Example: heredoc.Doc(`
+		lab mr discussion origin
+		lab mr discussion my_remote -m "discussion comment"
+		lab mr discussion upstream -F test_file.txt`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrNum, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -21,12 +21,20 @@ var mrEditCmd = &cobra.Command{
 	Aliases: []string{"update"},
 	Short:   "Edit or update an MR",
 	Example: heredoc.Doc(`
-		lab mr edit <id>
-		lab mr edit <id> -m "new title"
-		lab mr edit <id> -m "new title" -m "new desc"
-		lab mr edit <id> -l new_label --unlabel old_label
-		lab mr edit <id>:<comment_id>
-	`),
+		lab mr edit 2
+		lab mr edit 3 remote -m "new title"
+		lab mr edit 5 upstream -m "new title" -m "new desc"
+		lab mr edit 7 -l new_label --unlabel old_label
+		lab mr edit 11 upstream -a johndoe -a janedoe
+		lab mr edit 17 upstream --unassign johndoe
+		lab mr edit 13 upstream --milestone "summer"
+		lab mr edit 19 origin --target-brnch other_brnch
+		lab mr edit 23 upstream -F test_file
+		lab mr edit 29 upstream -F test_file --force-linebreak
+		lab mr edit 31 upstream --draft
+		lab mr edit 37 upstream --ready
+		lab mr edit 41 upstream -r johndoe -r janedoe
+		lab mr edit 43 upstream --unreview johndoe`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		commentNum, branchArgs, err := filterCommentArg(args)
@@ -354,7 +362,7 @@ func init() {
 	mrEditCmd.Flags().StringSliceP("assign", "a", []string{}, "add an assignee by username")
 	mrEditCmd.Flags().StringSliceP("unassign", "", []string{}, "remove an assignee by username")
 	mrEditCmd.Flags().String("milestone", "", "set milestone")
-	mrEditCmd.Flags().StringP("target-branch", "t", "", "set target branch")
+	mrEditCmd.Flags().StringP("target-branch", "t", "", "edit MR target branch")
 	mrEditCmd.Flags().StringP("file", "F", "", "use the given file as the description")
 	mrEditCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	mrEditCmd.Flags().Bool("draft", false, "mark the merge request as draft")

--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -46,8 +46,20 @@ var listCmd = &cobra.Command{
 		lab mr list
 		lab mr list "search terms"
 		lab mr list --target-branch main
-		lab mr list remote --target-branch main --label my-label --all
-	`),
+		lab mr list remote --target-branch main --label my-label
+		lab mr list -l bug
+		lab mr list -l close'
+		lab mr list upstream -n 5
+		lab mr list origin -a
+		lab mr list --author johndoe
+		lab mr list --assignee janedoe
+		lab mr list --order created_at
+		lab mr list --sort asc
+		lab mr list --draft
+		lab mr list --ready
+		lab mr list --no-conflicts
+		lab mr list -x 'test MR'
+		lab mr list -r johndoe`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		mrs, err := mrList(args)

--- a/cmd/mr_merge.go
+++ b/cmd/mr_merge.go
@@ -20,8 +20,10 @@ var mrMergeCmd = &cobra.Command{
 		Merges an open merge request. If the pipeline in the project is
 		enabled and is still running for that specific MR, by default,
 		this command will sets the merge to only happen when the pipeline
-		succeeds.
-	`),
+		succeeds.`),
+	Example: heredoc.Doc(`
+		lab mr merge origin 10
+		lab mr merge upstream 11 -i`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -1,15 +1,23 @@
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/action"
 )
 
 var mrNoteCmd = &cobra.Command{
-	Use:              "note [remote] <id>[:<comment_id>]",
-	Aliases:          []string{"comment", "reply", "resolve"},
-	Short:            "Add a note or comment to an MR on GitLab",
+	Use:     "note [remote] <id>[:<comment_id>]",
+	Aliases: []string{"comment", "reply", "resolve"},
+	Short:   "Add a note or comment to an MR on GitLab",
+	Example: heredoc.Doc(`
+		lab mr note origin
+		lab mr note upstream -F test_file
+		lab mr note a_remote -F test_file --force-linebreak
+		lab mr note upstream -m "A helpfull comment"
+		lab mr note upstream:613278106 --quote
+		lab mr note upstream:613278107 --resolve`),
 	PersistentPreRun: labPersistentPreRun,
 	Run:              noteRunFn,
 }
@@ -18,8 +26,8 @@ func init() {
 	mrNoteCmd.Flags().StringArrayP("message", "m", []string{}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	mrNoteCmd.Flags().StringP("file", "F", "", "use the given file as the message")
 	mrNoteCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
-	mrNoteCmd.Flags().Bool("quote", false, "quote note in reply (used with --reply only)")
-	mrNoteCmd.Flags().Bool("resolve", false, "mark thread resolved (used with --reply only)")
+	mrNoteCmd.Flags().Bool("quote", false, "quote note in reply")
+	mrNoteCmd.Flags().Bool("resolve", false, "mark thread resolved")
 
 	mrCmd.AddCommand(mrNoteCmd)
 	carapace.Gen(mrNoteCmd).PositionalCompletion(

--- a/cmd/mr_rebase.go
+++ b/cmd/mr_rebase.go
@@ -10,6 +10,7 @@ import (
 var mrRebaseCmd = &cobra.Command{
 	Use:              "rebase [remote] <id>",
 	Short:            "Rebase an open merge request",
+	Example:          "lab mr rebase upstream 20",
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_reopen.go
+++ b/cmd/mr_reopen.go
@@ -12,6 +12,7 @@ import (
 var mrReopenCmd = &cobra.Command{
 	Use:              "reopen [remote] <id>",
 	Short:            "Reopen a closed merge request",
+	Example:          "lab mr reopen upstream 20",
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -21,10 +21,18 @@ var (
 )
 
 var mrShowCmd = &cobra.Command{
-	Use:              "show [remote] <id>",
-	Aliases:          []string{"get"},
-	ArgAliases:       []string{"s"},
-	Short:            "Describe a merge request",
+	Use:        "show [remote] <id>",
+	Aliases:    []string{"get"},
+	ArgAliases: []string{"s"},
+	Short:      "Describe a merge request",
+	Example: heredoc.Doc(`
+		lab mr show
+		lab mr show origin -c
+		lab mr show --no-color-diff
+		lab mr show -M
+		lab mr show -p
+		lab mr show --reverse
+		lab mr show --since "1970-01-01 00:00:00.000 +0000 UTC"`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrNum, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_subscribe.go
+++ b/cmd/mr_subscribe.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -10,9 +11,12 @@ import (
 )
 
 var mrSubscribeCmd = &cobra.Command{
-	Use:              "subscribe [remote] <id>",
-	Aliases:          []string{},
-	Short:            "Subscribe to merge request",
+	Use:     "subscribe [remote] <id>",
+	Aliases: []string{},
+	Short:   "Subscribe to merge request",
+	Example: heredoc.Doc(`
+		lab mr subscribe 11
+		lab mr subscribe origin 12`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_thumb.go
+++ b/cmd/mr_thumb.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -17,9 +18,12 @@ var mrThumbCmd = &cobra.Command{
 }
 
 var mrThumbUpCmd = &cobra.Command{
-	Use:              "up [remote] <id>",
-	Aliases:          []string{},
-	Short:            "Thumb up merge request",
+	Use:     "up [remote] <id>",
+	Aliases: []string{},
+	Short:   "Thumb up merge request",
+	Example: heredoc.Doc(`
+		lab mr thumb up origin
+		lab mr thumb up origin 10`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
@@ -44,6 +48,9 @@ var mrThumbDownCmd = &cobra.Command{
 	Use:     "down [remote] <id>",
 	Aliases: []string{},
 	Short:   "Thumbs down merge request",
+	Example: heredoc.Doc(`
+		lab mr thumb down origin
+		lab mr thumb down origin 10`),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 	"os"
 
 	"github.com/rsteube/carapace"
@@ -11,9 +12,15 @@ import (
 )
 
 var mrUnapproveCmd = &cobra.Command{
-	Use:              "unapprove [remote] <id>",
-	Aliases:          []string{},
-	Short:            "Unapprove merge request",
+	Use:     "unapprove [remote] <id>",
+	Aliases: []string{},
+	Short:   "Unapprove merge request",
+	Example: heredoc.Doc(`
+		lab mr unapprove origin
+		lab mr unapprove upstream -F test_file
+		lab mr unapprove upstream -m "A helpfull comment"
+		lab mr unapprove upstream --with-comment
+		lab mr unapprove upstream -m "A helpfull\nComment" --force-linebreak`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/mr_unsubscribe.go
+++ b/cmd/mr_unsubscribe.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -10,9 +11,12 @@ import (
 )
 
 var mrUnsubscribeCmd = &cobra.Command{
-	Use:              "unsubscribe [remote] <id>",
-	Aliases:          []string{},
-	Short:            "Unubscribe from merge request",
+	Use:     "unsubscribe [remote] <id>",
+	Aliases: []string{},
+	Short:   "Unubscribe from merge request",
+	Example: heredoc.Doc(`
+		lab mr unsubscribe 11
+		lab mr unsubscribe origin 12`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsWithGitBranchMR(args)

--- a/cmd/project_browse.go
+++ b/cmd/project_browse.go
@@ -9,6 +9,7 @@ var projectBrowseCmd = &cobra.Command{
 	Use:              "browse [remote]",
 	Aliases:          []string{"b"},
 	Short:            "View project in a browser",
+	Example:          "lab mr browse origin",
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, _, err := parseArgsRemoteAndID(args)

--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -20,19 +20,16 @@ var projectCreateCmd = &cobra.Command{
 
 		"path" refers to the path on GitLab not including the group/namespace.
 		If no path or name is provided and the current directory is a git repo,
-		the name of the	current working directory will be used.
-	`),
+		the name of the	current working directory will be used.`),
 	Example: heredoc.Doc(`
-		# this command...                          # creates this project
-		lab project create                         # user/<curr dir> named <curr dir>
-		                                           # (above only works within a git repo)
-		lab project create myproject               # user/myproject named myproject
-		lab project create myproject -n "new proj" # user/myproject named "new proj"
-		lab project create -n "new proj"           # user/new-proj named "new proj"
-
-		lab project create mygroup/myproject       # mygroup/myproject named myproject
-		lab project create -g mygroup myproject    # mygroup/myproject named myproject
-	`),
+		lab project create myproject
+		lab project create myproject -n "new proj"
+		lab project create -g mygroup myproject
+		lab project create mygroup/myproject -n "new proj"
+		lab project create myproject --http
+		lab project create myproject --internal
+		lab project create myproject --private
+		lab project create myproject --public`),
 	Args:             cobra.MaximumNArgs(1),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/project_list.go
+++ b/cmd/project_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -18,9 +19,15 @@ var projectListConfig struct {
 }
 
 var projectListCmd = &cobra.Command{
-	Use:              "list [search]",
-	Aliases:          []string{"ls", "search"},
-	Short:            "List your projects",
+	Use:     "list [search]",
+	Aliases: []string{"ls", "search"},
+	Short:   "List your projects",
+	Example: heredoc.Doc(`
+		lab project list -a
+		lab project list -m
+		lab project list --member
+		lab project list --starred
+		lab project list -n 10`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		search, _, err := parseArgsStringAndID(args)

--- a/cmd/snippet_browse.go
+++ b/cmd/snippet_browse.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 	"net/url"
 	"path"
@@ -12,8 +13,11 @@ import (
 )
 
 var snippetBrowseCmd = &cobra.Command{
-	Use:              "browse [remote] <id>",
-	Short:            "View personal or project snippet in a browser",
+	Use:   "browse [remote] <id>",
+	Short: "View personal or project snippet in a browser",
+	Example: heredoc.Doc(`
+		lab snippet browse
+		lab snippet browse upstream`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -30,8 +30,14 @@ var snippetCreateCmd = &cobra.Command{
 	Use:   "create [remote]",
 	Short: "Create a personal or project snippet",
 	Long: heredoc.Doc(`
-		Source snippets from stdin, file, or in editor from scratch.
-	`),
+		Source snippets from stdin, file, or in editor from scratch.`),
+	Example: heredoc.Doc(`
+		lab snippet create
+		lab snippet create snippet_file.txt
+		lab snippet create -n "potato.go for GoLang"
+		lab snippet create -m "Snippet example" -M "Description message"
+		lab snippet create upstream --private
+		lab snippet create origin --public`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		msgs, err := cmd.Flags().GetStringArray("message")
@@ -170,7 +176,7 @@ func snipText(tmpl string) (string, error) {
 func init() {
 	snippetCreateCmd.Flags().BoolVarP(&private, "private", "p", false, "make snippet private; visible only to project members (default: internal)")
 	snippetCreateCmd.Flags().BoolVar(&public, "public", false, "make snippet public; can be accessed without any authentication (default: internal)")
-	snippetCreateCmd.Flags().StringVarP(&name, "name", "n", "", "(optional) name snippet to add code highlighting, e.g. potato.go for GoLang")
+	snippetCreateCmd.Flags().StringVarP(&name, "name", "n", "", "name snippet to add code highlighting")
 	snippetCreateCmd.Flags().StringArrayP("message", "m", []string{"-"}, "use the given <msg>; multiple -m are concatenated as separate paragraphs")
 	snippetCmd.Flags().AddFlagSet(snippetCreateCmd.Flags())
 

--- a/cmd/snippet_delete.go
+++ b/cmd/snippet_delete.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
@@ -13,7 +14,10 @@ import (
 var snippetDeleteCmd = &cobra.Command{
 	Use:   "delete [remote] <id>",
 	Short: "Delete a project or personal snippet",
-	Args:  cobra.MinimumNArgs(1),
+	Example: heredoc.Doc(`
+		lab snippet delete origin 2147103
+		lab snippet delete -g 2147104`),
+	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, id, err := parseArgsRemoteAndID(args)
 		if err != nil {

--- a/cmd/snippet_list.go
+++ b/cmd/snippet_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 	"strconv"
 
 	"github.com/rsteube/carapace"
@@ -18,9 +19,16 @@ var snippetListConfig struct {
 
 // snippetListCmd represents the snippetList command
 var snippetListCmd = &cobra.Command{
-	Use:              "list [remote]",
-	Aliases:          []string{"ls"},
-	Short:            "List personal or project snippets",
+	Use:     "list [remote]",
+	Aliases: []string{"ls"},
+	Short:   "List personal or project snippets",
+	Example: heredoc.Doc(`
+		lab snippet list
+		lab snippet list -a
+		lab snippet list -n 10
+		lab snippet list -m "Snippet example" -M "Description message"
+		lab snippet list upstream --private
+		lab snippet list origin --public`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		snips, err := snippetList(args)

--- a/cmd/todo_done.go
+++ b/cmd/todo_done.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -13,8 +14,14 @@ var (
 )
 
 var todoDoneCmd = &cobra.Command{
-	Use:              "done",
-	Short:            "Mark todo list entry as Done",
+	Use:   "done",
+	Short: "Mark todo list entry as Done",
+	Example: heredoc.Doc(`
+		lab todo done
+		lab todo done -a
+		lab todo done -n 10
+		lab todo done -p
+		lab todo done -t mr`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		if all {

--- a/cmd/todo_issue.go
+++ b/cmd/todo_issue.go
@@ -13,8 +13,7 @@ var todoIssueCmd = &cobra.Command{
 	Use:   "issue",
 	Short: "Add a Issue to Todo list",
 	Example: heredoc.Doc(`
-		lab todo issue 5678       #adds Issue 1234 to user's Todo list
-	`),
+		lab todo issue 5678`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, err := getRemoteName("")

--- a/cmd/todo_list.go
+++ b/cmd/todo_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
 	"strconv"
 	"strings"
 
@@ -20,10 +21,15 @@ var (
 )
 
 var todoListCmd = &cobra.Command{
-	Use:              "list",
-	Aliases:          []string{"ls"},
-	Short:            "List todos",
-	Example:          "lab todo list",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List todos",
+	Example: heredoc.Doc(`
+		lab todo list
+		lab todo list -a
+		lab todo list -n 10
+		lab todo list -p
+		lab todo list -t mr`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		todos, err := todoList(args)


### PR DESCRIPTION
Added example to every command;
Remove new-line after heredoc to avoid blank lines;
Fixed mr_create to show link only on creation success;
Added safeguard on issue_show if user does not specified issue number;
Removed --reply mention on examples in issue_note and mr_note, since it was a implementation
residue;

Signed-off-by: Lucas Zampieri <lzampier@redhat.com>