### PR TITLE
Add commit comment functionality

### DIFF
--- a/cmd/issue_note.go
+++ b/cmd/issue_note.go
@@ -28,6 +28,8 @@ func init() {
 	issueNoteCmd.Flags().Bool("quote", false, "quote note in reply")
 	issueNoteCmd.Flags().Bool("resolve", false, "[unused in issue note command]")
 	issueNoteCmd.Flags().MarkHidden("resolve")
+	issueNoteCmd.Flags().StringP("commit", "", "", "[unused in issue note command]")
+	issueNoteCmd.Flags().MarkHidden("commit")
 
 	issueCmd.AddCommand(issueNoteCmd)
 	carapace.Gen(issueNoteCmd).PositionalCompletion(

--- a/cmd/issue_show.go
+++ b/cmd/issue_show.go
@@ -66,7 +66,7 @@ var issueShowCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 
-			printDiscussions(discussions, since, "issues", int(issueNum), renderMarkdown)
+			printDiscussions(rn, discussions, since, "issues", int(issueNum), renderMarkdown)
 		}
 	},
 }

--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -65,7 +65,7 @@ var mrApproveCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 
-			createNote(rn, true, int(id), msgs, filename, linebreak)
+			createNote(rn, true, int(id), msgs, filename, linebreak, "")
 		}
 
 		fmt.Printf("Merge Request !%d approved\n", id)

--- a/cmd/mr_note.go
+++ b/cmd/mr_note.go
@@ -17,7 +17,8 @@ var mrNoteCmd = &cobra.Command{
 		lab mr note a_remote -F test_file --force-linebreak
 		lab mr note upstream -m "A helpfull comment"
 		lab mr note upstream:613278106 --quote
-		lab mr note upstream:613278107 --resolve`),
+		lab mr note upstream:613278107 --resolve
+		lab mr note upstream:613278108 --commit abcdef123456`),
 	PersistentPreRun: labPersistentPreRun,
 	Run:              noteRunFn,
 }
@@ -28,6 +29,7 @@ func init() {
 	mrNoteCmd.Flags().Bool("force-linebreak", false, "append 2 spaces to the end of each line to force markdown linebreaks")
 	mrNoteCmd.Flags().Bool("quote", false, "quote note in reply")
 	mrNoteCmd.Flags().Bool("resolve", false, "mark thread resolved")
+	mrNoteCmd.Flags().StringP("commit", "c", "", "start a thread on a commit")
 
 	mrCmd.AddCommand(mrNoteCmd)
 	carapace.Gen(mrNoteCmd).PositionalCompletion(

--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -90,7 +90,7 @@ var mrShowCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 
-			printDiscussions(discussions, since, "mr", int(mrNum), renderMarkdown)
+			printDiscussions(rn, discussions, since, "mr", int(mrNum), renderMarkdown)
 		}
 	},
 }

--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -105,26 +105,27 @@ func Test_mrShow_diffs(t *testing.T) {
 	}
 
 	require.Contains(t, out, `
+commit:5f4397445f620e1a6f22e0ce59e18cbf22f0ddff
 File:test
-  4   4  
-  5   5  
-  6   6  line 6 This is a test file with some text in it.
-  7   7  
-  8     -line 8 This is the second test line in the file.
-      8 +line 8 This is an edit of line 8.
-
+|        @@ -5,7 +5,7 @@
+|  5   5  
+|  6   6  line 6 This is a test file with some text in it.
+|  7   7  
+|  8     -line 8 This is the second test line in the file.
+|      8 +line 8 This is an edit of line 8.
 
     This is a comment on the deleted line 8.
 `)
 
 	require.Contains(t, out, `
+commit:5f4397445f620e1a6f22e0ce59e18cbf22f0ddff
 File:test
-      6 +line 6 This is a test file with some text in it.
-      7 +
-      8 +line 8 This is an edit of line 8.
-      9 +
-     10 +line 10 This is the third line in the file.
-
+|  6   6  line 6 This is a test file with some text in it.
+|  7   7  
+|  8     -line 8 This is the second test line in the file.
+|      8 +line 8 This is an edit of line 8.
+|  9   9  
+| 10  10  line 10 This is the third line in the file.
 
     This is a comment on line 10.
 `)

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -65,7 +65,7 @@ var mrUnapproveCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 
-			createNote(rn, true, int(id), msgs, filename, linebreak)
+			createNote(rn, true, int(id), msgs, filename, linebreak, "")
 		}
 
 		fmt.Printf("Merge Request !%d unapproved\n", id)

--- a/cmd/show_common.go
+++ b/cmd/show_common.go
@@ -17,17 +17,19 @@ import (
 	"github.com/muesli/termenv"
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/config"
-	"github.com/zaquestion/lab/internal/git"
+	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
+func inRange(val int, min int, max int) bool {
+	return val >= min && val <= max
+}
+
 // maxPadding returns the max value of two string numbers
-func maxPadding(xstr string, ystr string) int {
-	x, _ := strconv.Atoi(xstr)
-	y, _ := strconv.Atoi(ystr)
+func maxPadding(x int, y int) int {
 	if x > y {
-		return len(xstr)
+		return len(strconv.Itoa(x))
 	}
-	return len(ystr)
+	return len(strconv.Itoa(y))
 }
 
 // printDiffLine does a color print of a diff lines.  Red lines are removals
@@ -36,88 +38,120 @@ func printDiffLine(strColor string, maxChars int, sOld string, sNew string, ltex
 
 	switch strColor {
 	case "":
-		fmt.Printf("%*s %*s %s\n", maxChars, sOld, maxChars, sNew, ltext)
+		fmt.Printf("|%*s %*s %s\n", maxChars, sOld, maxChars, sNew, ltext)
 	case "green":
-		color.Green("%*s %*s %s\n", maxChars, sOld, maxChars, sNew, ltext)
+		color.Green("|%*s %*s %s\n", maxChars, sOld, maxChars, sNew, ltext)
 	case "red":
-		color.Red("%*s %*s %s\n", maxChars, sOld, maxChars, sNew, ltext)
+		color.Red("|%*s %*s %s\n", maxChars, sOld, maxChars, sNew, ltext)
 	}
 }
 
 // displayDiff displays the diff referenced in a discussion
-func displayDiff(diff string, chunkNum int, newLine int, oldLine int) {
+func displayDiff(diff string, newLine int, oldLine int) {
 	var (
-		diffChunkNum int = -1
 		oldLineNum   int = 0
 		newLineNum   int = 0
 		maxChars     int
+		output       bool = false
 	)
 
 	scanner := bufio.NewScanner(strings.NewReader(diff))
 	for scanner.Scan() {
 		if regexp.MustCompile(`^@@`).MatchString(scanner.Text()) {
-			diffChunkNum++
 			s := strings.Split(scanner.Text(), " ")
 			dOld := strings.Split(s[1], ",")
 			dNew := strings.Split(s[2], ",")
 
+			// get the new line number of the first line of the diff
+			newDiffStart, err := strconv.Atoi(strings.Replace(dNew[0], "+", "", -1))
+			if err != nil {
+				log.Fatal(err)
+			}
+			newDiffRange, err := strconv.Atoi(dNew[1])
+			if err != nil {
+				log.Fatal(err)
+			}
+			newDiffEnd := newDiffStart + newDiffRange
+			newLineNum = newDiffStart - 1
+
+			// get the old line number of the first line of the diff
+			oldDiffStart, err := strconv.Atoi(strings.Replace(dOld[0], "-", "", -1))
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			oldDiffEnd := newDiffRange
+			oldLineNum = oldDiffStart - 1
+			if len(dOld) > 1 {
+				oldDiffRange, err := strconv.Atoi(dOld[1])
+				if err != nil {
+					log.Fatal(err)
+				}
+				oldDiffEnd = oldDiffStart + oldDiffRange
+			}
+
+			if (oldLine != 0) && inRange(oldLine, oldDiffStart, oldDiffEnd) {
+				output = true
+			} else if (newLine != 0) && inRange(newLine, newDiffStart, newDiffEnd) {
+				output = true
+			} else {
+				output = false
+			}
+
+			// padding to align diff output (depends on the line numbers' length)
 			// The patch can have, for example, either
 			// @@ -1 +1 @@
 			// or
 			// @@ -1272,6 +1272,8 @@
 			// so (len - 1) makes sense in both cases.
-			maxChars = maxPadding(dOld[len(dOld)-1], dNew[len(dNew)-1]) + 1
-			if diffChunkNum == chunkNum {
-				continue
-			}
-			if diffChunkNum > chunkNum {
-				break
-			}
+			maxChars = maxPadding(oldDiffEnd, newDiffEnd) + 1
 		}
 
-		if diffChunkNum == chunkNum {
-			var (
-				sOld string
-				sNew string
-			)
-			strColor := ""
-			ltext := scanner.Text()
-			ltag := string(ltext[0])
-			switch ltag {
-			case " ":
-				strColor = ""
-				oldLineNum++
-				newLineNum++
-				sOld = strconv.Itoa(oldLineNum)
-				sNew = strconv.Itoa(newLineNum)
-			case "-":
-				strColor = "red"
-				oldLineNum++
-				sOld = strconv.Itoa(oldLineNum)
-				sNew = " "
-			case "+":
-				strColor = "green"
-				newLineNum++
-				sOld = " "
-				sNew = strconv.Itoa(newLineNum)
-			}
+		if !output {
+			continue
+		}
 
-			// output line
-			if mrShowNoColorDiff {
-				strColor = ""
-			}
-			if newLine != 0 {
-				if newLineNum <= newLine && newLineNum >= (newLine-4) {
-					printDiffLine(strColor, maxChars, sOld, sNew, ltext)
-				}
-			} else if oldLineNum <= oldLine && oldLineNum >= (oldLine-4) {
+		var (
+			sOld string
+			sNew string
+		)
+		strColor := ""
+		ltext := scanner.Text()
+		ltag := string(ltext[0])
+		switch ltag {
+		case " ":
+			strColor = ""
+			oldLineNum++
+			newLineNum++
+			sOld = strconv.Itoa(oldLineNum)
+			sNew = strconv.Itoa(newLineNum)
+		case "-":
+			strColor = "red"
+			oldLineNum++
+			sOld = strconv.Itoa(oldLineNum)
+			sNew = " "
+		case "+":
+			strColor = "green"
+			newLineNum++
+			sOld = " "
+			sNew = strconv.Itoa(newLineNum)
+		}
+
+		// output line
+		if mrShowNoColorDiff {
+			strColor = ""
+		}
+		if newLine != 0 {
+			if newLineNum <= newLine && newLineNum >= (newLine-4) {
 				printDiffLine(strColor, maxChars, sOld, sNew, ltext)
 			}
+		} else if oldLineNum <= oldLine && oldLineNum >= (oldLine-4) {
+			printDiffLine(strColor, maxChars, sOld, sNew, ltext)
 		}
 	}
 }
 
-func displayCommitDiscussion(idNum int, note *gitlab.Note) {
+func displayCommitDiscussion(project string, idNum int, note *gitlab.Note) {
 
 	// Previously, the GitLab API only supports showing comments on the
 	// entire changeset and not per-commit.  IOW, all diffs were shown
@@ -132,29 +166,35 @@ func displayCommitDiscussion(idNum int, note *gitlab.Note) {
 	// I am leaving this comment here in case it ever changes again.
 
 	// Get a unified diff for the entire file
-	diff, err := git.GetUnifiedDiff(note.Position.BaseSHA, note.Position.HeadSHA, note.Position.OldPath, note.Position.NewPath)
+	ds, err := lab.GetCommitDiff(project, note.CommitID)
 	if err != nil {
-		fmt.Printf("    Could not get unified diff: Execute 'lab mr checkout %d; git checkout master' and try again.\n", idNum)
+		fmt.Printf("    Could not get diff for commit %d.\n", note.CommitID)
 		return
 	}
 
-	if diff == "" {
-		fmt.Println("    Could not find 'git diff' command.")
-		return
+	if len(ds) == 0 {
+		log.Fatal("    No diff found for %s.", note.CommitID)
 	}
 
 	// In general, only have to display the NewPath, however there
 	// are some unusual cases where the OldPath may be displayed
 	if note.Position.NewPath == note.Position.OldPath {
-		fmt.Println("commit:" + note.Position.HeadSHA)
+		fmt.Println("commit:" + note.CommitID)
 		fmt.Println("File:" + note.Position.NewPath)
 	} else {
-		fmt.Println("commit:" + note.Position.HeadSHA)
+		fmt.Println("commit:" + note.CommitID)
 		fmt.Println("Files[old:" + note.Position.OldPath + " new:" + note.Position.NewPath + "]")
 	}
 
-	displayDiff(diff, 0, note.Position.NewLine, note.Position.OldLine)
-	fmt.Println("")
+	for _, d := range ds {
+		if note.Position.NewPath == d.NewPath && note.Position.OldPath == d.OldPath {
+			if note.Position.LineRange == nil {
+				displayDiff(d.Diff, note.Position.NewLine, note.Position.OldLine)
+			} else {
+				displayDiff(d.Diff, note.Position.LineRange.StartRange.NewLine, note.Position.LineRange.StartRange.OldLine)
+			}
+		}
+	}
 	fmt.Println("")
 }
 
@@ -181,7 +221,7 @@ func getTermRenderer(style glamour.TermRendererOption) (*glamour.TermRenderer, e
 	return r, err
 }
 
-func printDiscussions(discussions []*gitlab.Discussion, since string, idstr string, idNum int, renderMarkdown bool) {
+func printDiscussions(project string, discussions []*gitlab.Discussion, since string, idstr string, idNum int, renderMarkdown bool) {
 	newAccessTime := time.Now().UTC()
 
 	issueEntry := fmt.Sprintf("%s%d", idstr, idNum)
@@ -281,7 +321,7 @@ func printDiscussions(discussions []*gitlab.Discussion, since string, idstr stri
 `,
 				indentHeader, note.ID, note.Author.Username, commented, time.Time(*note.UpdatedAt).String())
 			if note.Position != nil && i == 0 {
-				displayCommitDiscussion(idNum, note)
+				displayCommitDiscussion(project, idNum, note)
 			}
 			printit(`%s%s
 `,

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -340,20 +340,6 @@ func GetLocalRemotesFromFile() (string, error) {
 	return string(remotes), nil
 }
 
-// GetUnifiedDiff return the full/unified patch diff, with max context length
-func GetUnifiedDiff(BaseSHA string, HeadSHA string, oldPath string, newPath string) (string, error) {
-	// I hate magic numbers as much as the next person but I cannot
-	// figure out a better way to get a unified diff for an entire file.
-	cmd := New("diff", "-U99999999", "--no-renames", BaseSHA, HeadSHA, "--", oldPath, "--", newPath)
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	diff, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return string(diff), nil
-}
-
 // NumberCommits returns the number of commits between two commit refs
 func NumberCommits(sha1, sha2 string) int {
 	cmd := New("log", "--oneline", fmt.Sprintf("%s..%s", sha1, sha2))

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1784,3 +1784,35 @@ func TodoIssueCreate(project string, issueNum int) (int, error) {
 	}
 	return todo.ID, nil
 }
+
+func GetCommitDiff(project string, sha string) ([]*gitlab.Diff, error) {
+	p, err := FindProject(project)
+	if err != nil {
+		return nil, err
+	}
+
+	var diffs []*gitlab.Diff
+	opt := &gitlab.GetCommitDiffOptions{
+		PerPage: maxItemsPerPage,
+	}
+
+	for {
+		ds, resp, err := lab.Commits.GetCommitDiff(p.ID, sha, opt)
+		if err != nil {
+			fmt.Println(err)
+			return nil, err
+		}
+
+		diffs = append(diffs, ds...)
+
+		// if we've seen all the pages, then we can break here
+		if resp.CurrentPage >= resp.TotalPages {
+			break
+		}
+
+		// otherwise, update the page number to get the next page.
+		opt.Page = resp.NextPage
+	}
+
+	return diffs, nil
+}


### PR DESCRIPTION
    The GitLab WebUI allows users to comment directly on commits.  These comments
    appear both in the comment view and the MR view.  This functionality can be
    implemented via the lab.Commits.PostCommitComment() function, however, the
    function only supports comments on "new" lines of code.  After discussions
    with GitLab they have suggested using lab.Discussions.CreateCommitDiscussion()
    as a workaround [1].  This solution has a minor issue in that it will not work
    with commits that have multiple parents
    
    Implement the ability for users to comment directly on commits.
    
    [1] https://gitlab.com/gitlab-org/gitlab/-/issues/335337#note_643291819
