### PR TITLE
Fix MR create documentation

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -39,7 +39,7 @@ var mrCreateCmd = &cobra.Command{
 		lab mr create my_remote --milestone "Fall"
 		lab mr create my_remote -d
 		lab mr create my_remote -r johndoe -r janedoe
-		lab mr create my_remote --source upstream:main origin main
+		lab mr create --source upstream:main origin main
 		lab mr create my_remote -s`),
 	PersistentPreRun: labPersistentPreRun,
 	Run:              runMRCreate,


### PR DESCRIPTION
MR create shows two references to remote with the --souce option when
there should be just one.

Signed-off-by: Lucas Zampieri <lzampier@redhat.com>