### PR TITLE
Issue732

### DIFF
--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -49,16 +49,7 @@ var mrCreateDiscussionCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		mr, err := lab.MRGet(rn, int(mrNum))
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		state := map[string]string{
-			"opened": "OPEN",
-			"closed": "CLOSED",
-			"merged": "MERGED",
-		}[mr.State]
+		state := noteGetState(rn, true, int(mrNum))
 
 		body := ""
 		if filename != "" {

--- a/cmd/mr_discussion.go
+++ b/cmd/mr_discussion.go
@@ -57,14 +57,14 @@ var mrCreateDiscussionCmd = &cobra.Command{
 			}
 			body = string(content)
 		} else if commit == "" {
-			body, err = mrDiscussionMsg(msgs)
+			body, err = mrDiscussionMsg(msgs, "\n")
 			if err != nil {
 				_, f, l, _ := runtime.Caller(0)
 				log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
 			}
 		} else {
 			body = getCommitBody(rn, commit)
-			body, err = noteMsg(nil, true, body)
+			body, err = mrDiscussionMsg(nil, body)
 			if err != nil {
 				_, f, l, _ := runtime.Caller(0)
 				log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
@@ -87,24 +87,24 @@ var mrCreateDiscussionCmd = &cobra.Command{
 	},
 }
 
-func mrDiscussionMsg(msgs []string) (string, error) {
+func mrDiscussionMsg(msgs []string, body string) (string, error) {
 	if len(msgs) > 0 {
 		return strings.Join(msgs[0:], "\n\n"), nil
 	}
 
-	text, err := mrDiscussionText()
+	text, err := mrDiscussionText(body)
 	if err != nil {
 		return "", err
 	}
 	return git.EditFile("MR_DISCUSSION", text)
 }
 
-func mrDiscussionText() (string, error) {
+func mrDiscussionText(body string) (string, error) {
 	tmpl := heredoc.Doc(`
 		{{.InitMsg}}
 		{{.CommentChar}} Write a message for this discussion. Commented lines are discarded.`)
 
-	initMsg := "\n"
+	initMsg := body
 	commentChar := git.CommentChar()
 
 	t, err := template.New("tmpl").Parse(tmpl)

--- a/cmd/mr_discussion_test.go
+++ b/cmd/mr_discussion_test.go
@@ -67,7 +67,7 @@ func Test_mrDiscussionMsg(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			test := test
 			t.Parallel()
-			body, err := mrDiscussionMsg(test.Msgs)
+			body, err := mrDiscussionMsg(1, "OPEN", "", test.Msgs, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -78,12 +78,13 @@ func Test_mrDiscussionMsg(t *testing.T) {
 
 func Test_mrDiscussionText(t *testing.T) {
 	t.Parallel()
-	text, err := mrDiscussionText()
+	tmpl := mrDiscussionGetTemplate("")
+	text, err := noteText(1701, "OPEN", "", "\n", tmpl)
 	if err != nil {
 		t.Fatal(err)
 	}
 	require.Equal(t, `
 
-# Write a message for this discussion. Commented lines are discarded.`, text)
-
+# This thread is being started on OPEN Merge Request 1701.
+# Comment lines beginning with '#' are discarded.`, text)
 }

--- a/cmd/mr_note_test.go
+++ b/cmd/mr_note_test.go
@@ -143,23 +143,11 @@ func Test_mrNoteMsg(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			test := test
 			t.Parallel()
-			body, err := noteMsg(test.Msgs, true, "\n")
+			body, err := noteMsg(test.Msgs, true, 1, "OPEN", "", "\n")
 			if err != nil {
 				t.Fatal(err)
 			}
 			assert.Equal(t, test.ExpectedBody, body)
 		})
 	}
-}
-
-func Test_mrNoteText(t *testing.T) {
-	t.Parallel()
-	text, err := noteText("\n")
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.Equal(t, `
-
-# Write a message for this note. Commented lines are discarded.`, text)
-
 }

--- a/cmd/note_common.go
+++ b/cmd/note_common.go
@@ -291,7 +291,8 @@ func noteMsg(msgs []string, isMR bool, idNum int, state string, commit string, b
 		return strings.Join(msgs[0:], "\n\n"), nil
 	}
 
-	text, err := noteText(isMR, idNum, state, commit ,body)
+	tmpl := noteGetTemplate(isMR, commit)
+	text, err := noteText(idNum, state, commit, body, tmpl)
 	if err != nil {
 		return "", err
 	}
@@ -322,10 +323,15 @@ func noteGetTemplate(isMR bool, commit string) string {
 		{{.CommentChar}} Comment lines beginning with '{{.CommentChar}}' are discarded.`)
 }
 
-func noteText(isMR bool, idNum int, state string, commit string, body string) (string, error) {
-	tmpl := noteGetTemplate(isMR, commit)
+func noteText(idNum int, state string, commit string, body string, tmpl string) (string, error) {
 	initMsg := body
 	commentChar := git.CommentChar()
+
+	if commit != "" {
+		if len(commit) > 11 {
+			commit = commit[:12]
+		}
+	}
 
 	t, err := template.New("tmpl").Parse(tmpl)
 	if err != nil {

--- a/cmd/note_common_test.go
+++ b/cmd/note_common_test.go
@@ -31,7 +31,7 @@ func Test_noteMsg(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			test := test
 			t.Parallel()
-			body, err := noteMsg(test.Msgs, false, "\n")
+			body, err := noteMsg(test.Msgs, false, 1, "OPEN", "", "\n")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -42,12 +42,13 @@ func Test_noteMsg(t *testing.T) {
 
 func Test_noteText(t *testing.T) {
 	t.Parallel()
-	text, err := noteText("\n")
+	tmpl := noteGetTemplate(true, "")
+	text, err := noteText(1701, "OPEN", "", "\n", tmpl)
 	if err != nil {
 		t.Fatal(err)
 	}
 	require.Equal(t, `
 
-# Write a message for this note. Commented lines are discarded.`, text)
-
+# This comment is being applied to OPEN Merge Request 1701.
+# Comment lines beginning with '#' are discarded.`, text)
 }


### PR DESCRIPTION
When you start a comment with 'mr note' lab adds, for example:

```
# This comment is being applied to OPEN Merge Request 1166 commit ee6d5ceeadc8f6d8e71a565bb50fcff5e98992fa.
# Do not delete patch tracking lines that begin with '|'.
# Write a message for this note. Commented lines are discarded.
```

And when you start a discussion with 'mr discussion' lab adds, for example:

```
# Write a message for this note. Commented lines are discarded.
```

Make the messaging consistent and unify the code.

Closes 732

Signed-off-by: Prarit Bhargava <prarit@redhat.com>