### PR TITLE
Remove redundant code and fix flag option

### DIFF
--- a/cmd/ci_run.go
+++ b/cmd/ci_run.go
@@ -69,7 +69,7 @@ var ciTriggerCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		token, err := cmd.Flags().GetString("project")
+		token, err := cmd.Flags().GetString("token")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -197,10 +197,7 @@ func FindProject(project string) (*gitlab.Project, error) {
 		search = user + "/" + project
 	}
 
-	target, resp, err := lab.Projects.GetProject(search, nil)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		return nil, ErrProjectNotFound
-	}
+	target, err := GetProject(search)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This MR has three different and minor fixes:

1. Remove redundant code in `internal/gitlab/gitlab.go::FindProject()`
2. The `--project` value was being used as the value for `token` variable instead of `--token` value.

Check the individual commits for more information.