### PR TITLE
Moved file function to break before approval

### DIFF
--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -48,6 +48,15 @@ var mrApproveCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		if comment || len(msgs) > 0 || filename != "" {
+			linebreak, err := cmd.Flags().GetBool("force-linebreak")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			createNote(rn, true, int(id), msgs, filename, linebreak, "")
+		}
+
 		err = lab.MRApprove(p.ID, int(id))
 		if err != nil {
 			if err == lab.ErrStatusForbidden {
@@ -57,15 +66,6 @@ var mrApproveCmd = &cobra.Command{
 				fmt.Printf("Merge Request !%d already approved\n", id)
 				os.Exit(1)
 			}
-		}
-
-		if comment || len(msgs) > 0 || filename != "" {
-			linebreak, err := cmd.Flags().GetBool("force-linebreak")
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			createNote(rn, true, int(id), msgs, filename, linebreak, "")
 		}
 
 		fmt.Printf("Merge Request !%d approved\n", id)


### PR DESCRIPTION
This fixes the issue of approval being sent on file error.
Unfortunately, it does not prevent the file comment to be sent on approval error, but since approval errors are less common, I think this would be better than how it is.

I will work in GitLab to comment and approve in one API call.

Signed-off-by: Lucas Zampieri <lzampier@redhat.com>