### PR TITLE
cmd/show_common.go: Fix commenting on new file diffs

### DIFF
--- a/cmd/show_common.go
+++ b/cmd/show_common.go
@@ -67,9 +67,12 @@ func displayDiff(diff string, newLine int, oldLine int, outputAll bool) string {
 			if err != nil {
 				log.Fatal(err)
 			}
-			newDiffRange, err := strconv.Atoi(dNew[1])
-			if err != nil {
-				log.Fatal(err)
+			newDiffRange := 1
+			if len(dNew) == 2 {
+				newDiffRange, err = strconv.Atoi(dNew[1])
+				if err != nil {
+					log.Fatal(err)
+				}
 			}
 			newDiffEnd := newDiffStart + newDiffRange
 			newLineNum = newDiffStart - 1


### PR DESCRIPTION
When executing 'lab mr block 1369 --commit 7ed5bdfc1e' I hit this panic
this morning:

	panic: runtime error: index out of range [1] with length 1

	goroutine 1 [running]:
	github.com/zaquestion/lab/cmd.displayDiff(0xc0005f9ac0, 0x1f, 0x0, 0x0, 0x1, 0xc00017e1c0, 0x6c)
		/home/prarit/git-kernel/github/lab/cmd/show_common.go:73 +0xf45
	github.com/zaquestion/lab/cmd.getCommitBody(0xc00012230f, 0x16, 0x7fffb9bdc8c6, 0x28, 0x1179236, 0x4)
		/home/prarit/git-kernel/github/lab/cmd/note_common.go:135 +0x1f3
	github.com/zaquestion/lab/cmd.glob..func37(0x19f8c60, 0xc00052e7b0, 0x1, 0x3)
	/home/prarit/git-kernel/github/lab/cmd/mr_discussion.go:66 +0x7be

Part of the diff for 7ed5bdfc1e added a new file with one line, and
contained:

      @@ -0,0 +1 @@

The lab diff code assumes that there are always two sets of coordinates, for
example
	@@ -A,B +C,D @@

and that assumption is wrong.  It is obviously possible that D (the range
of the added code) is not defined.

Fix the panic by setting a minimum default patch range of 1.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>