### PR TITLE
mr_create: Add -f option to open editor

### DIFF
--- a/cmd/mr_create_test.go
+++ b/cmd/mr_create_test.go
@@ -9,7 +9,7 @@ import (
 // MR Create is tested in cmd/mr_test.go
 
 func Test_mrText(t *testing.T) {
-	text, err := mrText("origin", "mrtest", "origin", "master", false)
+	text, err := mrText("origin", "mrtest", "origin", "master", false, false)
 	if err != nil {
 		t.Log(text)
 		t.Fatal(err)
@@ -29,7 +29,7 @@ I am the default merge request template for lab
 }
 
 func Test_mrText_CoverLetter(t *testing.T) {
-	coverLetter, err := mrText("origin", "mrtest", "origin", "master", true)
+	coverLetter, err := mrText("origin", "mrtest", "origin", "master", true, false)
 	if err != nil {
 		t.Log(coverLetter)
 		t.Fatal(err)


### PR DESCRIPTION
A request was made to add an option to open the editor when a file was
specified for the title and description.  Opening the editor would allow
project owners and maintainers to deploy MR templates that could be edited
by the MR submitter.

Add a --file-open_editor/-f option that opens the editor with the file
contents.

Closes #739

Suggested-by: David Arcari <darcari@redhat.com>
Signed-off-by: Prarit Bhargava <prarit@redhat.com>