### PR TITLE
Review with quick actions

### DIFF
--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -63,7 +63,7 @@ var mrApproveCmd = &cobra.Command{
 			}
 		}
 
-		msgs = append(msgs, "\n  /approve")
+		msgs = append(msgs, "/approve")
 		createNote(rn, true, int(id), msgs, filename, linebreak, "", !note)
 
 		fmt.Printf("Merge Request !%d approved\n", id)

--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -61,6 +61,11 @@ var mrApproveCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
+			if comment {
+				state := noteGetState(rn, true, int(id))
+				msg, _ := noteMsg(msgs, true, int(id), state, "", "")
+				msgs = append(msgs, msg)
+			}
 		}
 
 		msgs = append(msgs, "/approve")

--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -64,7 +64,7 @@ var mrApproveCmd = &cobra.Command{
 		}
 
 		msgs = append(msgs, "/approve")
-		createNote(rn, true, int(id), msgs, filename, linebreak, "", !note)
+		createNote(rn, true, int(id), msgs, filename, linebreak, "", note)
 
 		fmt.Printf("Merge Request !%d approved\n", id)
 	},

--- a/cmd/mr_approve.go
+++ b/cmd/mr_approve.go
@@ -3,12 +3,11 @@ package cmd
 import (
 	"fmt"
 	"github.com/MakeNowJust/heredoc/v2"
-	"os"
-
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/zaquestion/lab/internal/action"
 	lab "github.com/zaquestion/lab/internal/gitlab"
+	"os"
 )
 
 var mrApproveCmd = &cobra.Command{
@@ -28,9 +27,16 @@ var mrApproveCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
+		approvalConfig, err := lab.GetMRApprovalsConfiguration(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
+		}
+
+		for _, approvers := range approvalConfig.ApprovedBy {
+			if approvers.User.Username == lab.User() {
+				fmt.Printf("Merge Request !%d already approved\n", id)
+				os.Exit(1)
+			}
 		}
 
 		comment, err := cmd.Flags().GetBool("with-comment")
@@ -48,25 +54,17 @@ var mrApproveCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		if comment || len(msgs) > 0 || filename != "" {
-			linebreak, err := cmd.Flags().GetBool("force-linebreak")
+		note := comment || len(msgs) > 0 || filename != ""
+		linebreak := false
+		if note {
+			linebreak, err = cmd.Flags().GetBool("force-linebreak")
 			if err != nil {
 				log.Fatal(err)
 			}
-
-			createNote(rn, true, int(id), msgs, filename, linebreak, "")
 		}
 
-		err = lab.MRApprove(p.ID, int(id))
-		if err != nil {
-			if err == lab.ErrStatusForbidden {
-				log.Fatal(err)
-			}
-			if err == lab.ErrActionRepeated {
-				fmt.Printf("Merge Request !%d already approved\n", id)
-				os.Exit(1)
-			}
-		}
+		msgs = append(msgs, "\n  /approve")
+		createNote(rn, true, int(id), msgs, filename, linebreak, "", !note)
 
 		fmt.Printf("Merge Request !%d approved\n", id)
 	},

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -65,7 +65,7 @@ var mrUnapproveCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 
-			createNote(rn, true, int(id), msgs, filename, linebreak, "")
+			createNote(rn, true, int(id), msgs, filename, linebreak, "", false)
 		}
 
 		fmt.Printf("Merge Request !%d unapproved\n", id)

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -67,6 +67,11 @@ var mrUnapproveCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
+			if comment {
+				state := noteGetState(rn, true, int(id))
+				msg, _ := noteMsg(msgs, true, int(id), state, "", "")
+				msgs = append(msgs, msg)
+			}
 		}
 
 		msgs = append(msgs, "/unapprove")

--- a/cmd/mr_unapprove.go
+++ b/cmd/mr_unapprove.go
@@ -23,11 +23,6 @@ var mrUnapproveCmd = &cobra.Command{
 		lab mr unapprove upstream -m "A helpfull\nComment" --force-linebreak`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		var (
-			linebreak = false
-			canUnapprove = false
-		)
-
 		rn, id, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			log.Fatal(err)
@@ -38,6 +33,7 @@ var mrUnapproveCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		canUnapprove := false
 		for _, approvers := range approvalConfig.ApprovedBy {
 			if approvers.User.Username == lab.User() {
 				canUnapprove = true
@@ -65,6 +61,7 @@ var mrUnapproveCmd = &cobra.Command{
 		}
 
 		note := comment || len(msgs) > 0 || filename != ""
+		linebreak := false
 		if note {
 			linebreak, err = cmd.Flags().GetBool("force-linebreak")
 			if err != nil {
@@ -73,7 +70,7 @@ var mrUnapproveCmd = &cobra.Command{
 		}
 
 		msgs = append(msgs, "/unapprove")
-		createNote(rn, true, int(id), msgs, filename, linebreak, "", !note)
+		createNote(rn, true, int(id), msgs, filename, linebreak, "", note)
 
 		fmt.Printf("Merge Request !%d unapproved\n", id)
 	},

--- a/cmd/note_common.go
+++ b/cmd/note_common.go
@@ -91,7 +91,7 @@ func noteRunFn(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	createNote(rn, isMR, int(idNum), msgs, filename, linebreak, commit)
+	createNote(rn, isMR, int(idNum), msgs, filename, linebreak, commit, false)
 }
 
 func createCommitNote(rn string, mrID int, sha string, newFile string, oldFile string, oldline int, newline int, comment string, block bool) {
@@ -231,7 +231,7 @@ func noteGetState(rn string, isMR bool, idNum int) (state string) {
 	return state
 }
 
-func createNote(rn string, isMR bool, idNum int, msgs []string, filename string, linebreak bool, commit string) {
+func createNote(rn string, isMR bool, idNum int, msgs []string, filename string, linebreak bool, commit string, quickaction bool) {
 	var err error
 
 	body := ""
@@ -283,7 +283,9 @@ func createNote(rn string, isMR bool, idNum int, msgs []string, filename string,
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(noteURL)
+	if !quickaction {
+		fmt.Println(noteURL)
+	}
 }
 
 func noteMsg(msgs []string, isMR bool, idNum int, state string, commit string, body string) (string, error) {

--- a/cmd/note_common.go
+++ b/cmd/note_common.go
@@ -242,7 +242,7 @@ func createNote(rn string, isMR bool, idNum int, msgs []string, filename string,
 			log.Fatal(err)
 		}
 		body = string(content)
-		if hasNote {
+		if hasNote && len(msgs) > 0 {
 			body += msgs[0]
 		}
 	} else {

--- a/cmd/note_common.go
+++ b/cmd/note_common.go
@@ -91,7 +91,7 @@ func noteRunFn(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	createNote(rn, isMR, int(idNum), msgs, filename, linebreak, commit, false)
+	createNote(rn, isMR, int(idNum), msgs, filename, linebreak, commit, true)
 }
 
 func createCommitNote(rn string, mrID int, sha string, newFile string, oldFile string, oldline int, newline int, comment string, block bool) {
@@ -231,7 +231,8 @@ func noteGetState(rn string, isMR bool, idNum int) (state string) {
 	return state
 }
 
-func createNote(rn string, isMR bool, idNum int, msgs []string, filename string, linebreak bool, commit string, quickaction bool) {
+func createNote(rn string, isMR bool, idNum int, msgs []string, filename string, linebreak bool, commit string, hasNote bool) {
+	// hasNote is used by action that take advantage of Gitlab 'quick-action' notes, which do not create a noteURL
 	var err error
 
 	body := ""
@@ -241,6 +242,9 @@ func createNote(rn string, isMR bool, idNum int, msgs []string, filename string,
 			log.Fatal(err)
 		}
 		body = string(content)
+		if hasNote {
+			body += msgs[0]
+		}
 	} else {
 		state := noteGetState(rn, isMR, idNum)
 
@@ -283,7 +287,7 @@ func createNote(rn string, isMR bool, idNum int, msgs []string, filename string,
 	if err != nil {
 		log.Fatal(err)
 	}
-	if !quickaction {
+	if hasNote {
 		fmt.Println(noteURL)
 	}
 }


### PR DESCRIPTION
This is the second part of the change to unify the calls made when approving/commenting on an MR.

The new code removes the usage of the `merge_request/approve` API and instead uses the `/approve` and `/unapprove` notes API quick actions.
Fixes: #708