### PR TITLE
lab mr create: Check file exists (-F/-f options)

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -240,6 +240,10 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	var title, body string
 
 	if filename != "" {
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			log.Fatalf("file %s cannot be found", filename)
+		}
+
 		if len(msgs) > 0 || coverLetterFormat {
 			log.Fatal("option -F cannot be combined with -m/-c")
 		}


### PR DESCRIPTION
Currently, when the file specified with the -F or -f options does not
exist, lab outputs a very generic error that is not helpful to users

[prarit@prarit kernel-test]$ ~/git-kernel/github/lab/lab mr create
2021/09/22 07:14:40 ERROR: mr_create.go:289: empty MR message

Check to see if the file exists and report a better error if the file is
not present.  For example,

[prarit@prarit kernel-test]$ ~/git-kernel/github/lab/lab mr create -F /tmp/non-existent.file
2021/09/22 07:15:02 ERROR: mr_create.go:244: file /tmp/non-existent.file cannot be found

Fixes #742

Signed-off-by: Prarit Bhargava <prarit@redhat.com>