### PR TITLE
mr discussion: allow to comment on specific lines in a diff

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -153,6 +153,17 @@ func CurrentBranch() (string, error) {
 	return strings.TrimSpace(string(branch)), nil
 }
 
+// RevParse returns the output of "git rev-parse".
+func RevParse(args ...string) (string, error) {
+	cmd := New(append([]string{"rev-parse"}, args...)...)
+	cmd.Stdout = nil
+	d, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(d)), nil
+}
+
 // UpstreamBranch returns the upstream of the specified branch
 func UpstreamBranch(branch string) (string, error) {
 	upstreamBranch, err := gitconfig.Local("branch." + branch + ".merge")


### PR DESCRIPTION
(the first two commits are independent updates but I included them here to avoid conflicts)

---

GitLab supports to comment on lines (or even ranges of lines) within a
commit diff.  This is standard practise when using the web interface,
and it's arguably friendlier to the MR author.

Add a bunch of --position-* parameters to "lab mr discussion" to implement this [1].
(This interface is awkward, because almost all of them are needed.
Maybe we could fit all of this in one parameter somehow? Then there'd
be less room for user errors.)

Given a commit diff like

	--- a/README.md
	+++ b/README.md
	@@ -3,2 +3,5 @@
	 line 3
	 line 4
	+line 5
	+line 6
	+line 7

this allows to run a command like this to comment on "line 6".

	lab mr discussion origin branch --commit=commit-id --position-file=README.md --position-line-type=+ --position-line-number=6 --position-line-number-old=5

The parameters should be fairly self-explanatory, except maybe the
line numbers. They are the equivalent to the two columns of line
numbers that GitLab/GitHub display to the left of a diff.
We should document in the command line help how they are computed,
but I wasn't sure where to add it.

This feature is designed to work well with [Tig](https://github.com/jonas/tig/),
because Tig readily exposes the correct line number parameters.
Adding this to your ~/.tigrc

	bind diff C !lab mr discussion %(remote) %(branch) --commit=%(commit) --position-file=%(file) --position-line-type=%(text) --position-line-number=%(lineno) --position-line-number-old=%(lineno_old)

will allow you press C on a line inside a diff hunk to comment on that line.
This can be really convenient with Tig. I took the liberty to mention
Tig in the documentation; not sure if this is appropriate.
(Please note that the --position-file-old which I added to the
examples currently requires an unreleased version of Tig, see Tig
commit 5a23214c (Expose %(file_old), the filename before a rename or
deletion, 2021-10-04).)

One annoyance with this binding is that every "lab mr discussion"
touches the network, so can be noticably slow. That's easy to fix
though.

Background:
I have been using a similar workflow with Tig, see
https://github.com/krobelus/gitlab-offline-review
I'd love to eventually switch to lab (or something alike)

I only heard about it in the recent Linux Plumber's Conference.
Also I discovered today that there is yet another similar project
[glab](https://github.com/profclems/glab). however, they don't
have a "mr discussions" command, so I stuck to lab.

(Additionally, there is
[bichon](https://gitlab.com/bichon-project/bichon) but that looks
less flexible than a command line tool).
