### PR TITLE
lab: Fix startup error

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -277,7 +277,7 @@ func LoadMainConfig() (string, string, string, string, bool) {
 	}
 
 	MainConfig = viper.New()
-	MainConfig.SetConfigName("lab")
+	MainConfig.SetConfigName("lab.toml")
 	MainConfig.SetConfigType("toml")
 	// The local path (aka 'dot slash') does not allow for any
 	// overrides from the work tree lab.toml


### PR DESCRIPTION
For a very long time we've had an error that can be reproduced by
executing

git clone https://github.com/zaquestion/lab
cd lab
make
./lab

This results in "Error: User authentication failed.  This is likely due to
a misconfigured Personal Access Token.  Verify the token or token_load
config settings before attempting to authenticate." being output to the
screen even though a valid config exists in ~/.config/lab/lab.toml.

This occurs because after the make a lab executable is created in the
local directory and it is treated as a config file.  lab attempts to
interpret this binary as a config file and the above error is reported.

Fix the startup error by explicitly looking for lab.toml instead of just
lab.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>