### PR TITLE
git: fix editor command split rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/internal/git/edit_test.go
+++ b/internal/git/edit_test.go
@@ -91,8 +91,11 @@ func TestEditor(t *testing.T) {
 		require.NotEmpty(t, editor)
 	})
 	t.Run("Open Editor", func(t *testing.T) {
-		cmd := editorCMD(path, filePath)
-		err := cmd.Start()
+		cmd, err := editorCMD(path, filePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = cmd.Start()
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Editor commands with quoting, like:

vim -c 'set tw=74' -c 'set noai' -c 'set wrap'

were being splitted in the wrong way: only spaces were being considered and
each part was placed in a different slot of the command arg array:

[vim, -c, 'set, tw=74', -c, 'set, noai', -c, 'set, wrap']

With that, lab ended up calling `vim` with strings like `'set` and `tw=74'`
as separated args and, thus, vim was creating files with these names instead
of using them as real arguments for the `-c` flag.

This commit fixes it by using Google's shlex module, which respects
shell-style rules for quoting and commenting in the command line. The
previous example is now splitted as follows:

[vim, -c, 'set tw=74', -c, 'set noai', -c, 'set wrap']

So the quoted values are kept together.

Fixes: b73579a7b15e ("git: fix edit command when using extra args")
Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>