### PR TITLE
ci: add --passed flag for retrieving only passed pipelines 

### DIFF
--- a/cmd/ci_artifacts.go
+++ b/cmd/ci_artifacts.go
@@ -63,7 +63,12 @@ var ciArtifactsCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		rn, pipelineID, err := getPipelineFromArgs(branchArgs, forMR)
+		onlyPassed, err := cmd.Flags().GetBool("passed")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		rn, pipelineID, err = getPipelineFromArgs(branchArgs, forMR, onlyPassed)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -96,6 +101,7 @@ var ciArtifactsCmd = &cobra.Command{
 func init() {
 	ciArtifactsCmd.Flags().Bool("merge-request", false, "use merge request pipeline if enabled")
 	ciArtifactsCmd.Flags().StringP("artifact-path", "p", "", "only download specified file from archive")
+	ciArtifactsCmd.Flags().Bool("passed", false, "consider only pipeline that succeeded")
 	ciCmd.AddCommand(ciArtifactsCmd)
 	carapace.Gen(ciArtifactsCmd).PositionalCompletion(
 		action.Remotes(),

--- a/cmd/ci_status.go
+++ b/cmd/ci_status.go
@@ -50,7 +50,12 @@ var ciStatusCmd = &cobra.Command{
 			}
 		}
 
-		rn, pipelineID, err := getPipelineFromArgs(args, forMR)
+		onlyPassed, err := cmd.Flags().GetBool("passed")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		rn, pipelineID, err = getPipelineFromArgs(args, forMR, onlyPassed)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -119,6 +124,7 @@ var ciStatusCmd = &cobra.Command{
 func init() {
 	ciStatusCmd.Flags().Bool("wait", false, "continuously print the status and wait to exit until the pipeline finishes. Exit code indicates pipeline status")
 	ciStatusCmd.Flags().Bool("merge-request", false, "use merge request pipeline if enabled")
+	ciStatusCmd.Flags().Bool("passed", false, "consider only pipeline that succeeded")
 	ciCmd.AddCommand(ciStatusCmd)
 
 	carapace.Gen(ciStatusCmd).PositionalCompletion(

--- a/cmd/ci_status_test.go
+++ b/cmd/ci_status_test.go
@@ -103,3 +103,30 @@ deploy: deploy10                       - success`)
 
 	assert.Contains(t, out, "Pipeline Status: success")
 }
+
+// Test_ciStatusMRPassed tests a behavior that is not documented in GitLab's
+// API docs. So this is basically to make sure we don't get hit by a
+// future/unnotified API change.
+func Test_ciStatusMRPassed(t *testing.T) {
+	t.Parallel()
+	repo := copyTestRepo(t)
+	cmd := exec.Command(labBinaryPath, "ci", "status", "--merge-request", "968")
+	cmd.Dir = repo
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+	out := string(b)
+	assert.Contains(t, out, "Pipeline Status: canceled")
+
+	cmd = exec.Command(labBinaryPath, "ci", "status", "--passed", "--merge-request", "968")
+	cmd.Dir = repo
+	b, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+	out = string(b)
+	assert.Contains(t, out, "Pipeline Status: success")
+}

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -68,7 +68,12 @@ var ciTraceCmd = &cobra.Command{
 			}
 		}
 
-		rn, pipelineID, err := getPipelineFromArgs(branchArgs, forMR)
+		onlyPassed, err := cmd.Flags().GetBool("passed")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		rn, pipelineID, err = getPipelineFromArgs(branchArgs, forMR, onlyPassed)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -185,6 +190,7 @@ func filterJobArg(args []string) (string, []string, error) {
 
 func init() {
 	ciTraceCmd.Flags().Bool("merge-request", false, "use merge request pipeline if enabled")
+	ciTraceCmd.Flags().Bool("passed", false, "consider only pipeline that succeeded")
 	ciCmd.AddCommand(ciTraceCmd)
 	carapace.Gen(ciTraceCmd).PositionalCompletion(
 		action.Remotes(),

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -73,7 +73,12 @@ var ciViewCmd = &cobra.Command{
 			}
 		}
 
-		rn, pipelineID, err = getPipelineFromArgs(args, forMR)
+		onlyPassed, err := cmd.Flags().GetBool("passed")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		rn, pipelineID, err = getPipelineFromArgs(args, forMR, onlyPassed)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -653,6 +658,7 @@ func latestJobs(jobs []*gitlab.Job) []*gitlab.Job {
 
 func init() {
 	ciViewCmd.Flags().Bool("merge-request", false, "use merge request pipeline if enabled")
+	ciViewCmd.Flags().Bool("passed", false, "consider only pipeline that succeeded")
 	ciCmd.AddCommand(ciViewCmd)
 	carapace.Gen(ciViewCmd).PositionalCompletion(
 		action.Remotes(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,21 +116,21 @@ func init() {
 
 	// We need to set the logger level before any other piece of code is
 	// called, thus we make sure we don't lose any debug message, but for
-	// that we need to parse the args from command input.
-	err := RootCmd.ParseFlags(os.Args[1:])
-	// Handle the err != nil case later
-	if err == nil {
-		debugLogger, _ := RootCmd.Flags().GetBool("debug")
-		quietLogger, _ := RootCmd.Flags().GetBool("quiet")
-		if debugLogger && quietLogger {
-			log.Fatal("option --debug cannot be combined with --quiet")
-		}
-		if debugLogger {
-			log.SetLogLevel(logger.LogLevelDebug)
-		} else if quietLogger {
-			log.SetLogLevel(logger.LogLevelNone)
-		}
+	// that we need to parse the args from command input. Also, the return
+	// value is being ignored here because errors like "unknown flag" are
+	// going to be handled later in subcommand level.
+	_ = RootCmd.ParseFlags(os.Args[1:])
+	debugLogger, _ := RootCmd.Flags().GetBool("debug")
+	quietLogger, _ := RootCmd.Flags().GetBool("quiet")
+	if debugLogger && quietLogger {
+		log.Fatal("option --debug cannot be combined with --quiet")
 	}
+	if debugLogger {
+		log.SetLogLevel(logger.LogLevelDebug)
+	} else if quietLogger {
+		log.SetLogLevel(logger.LogLevelNone)
+	}
+
 	carapace.Gen(RootCmd)
 }
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -199,6 +199,7 @@ func parseArgsRemoteAndBranch(args []string) (string, string, error) {
 
 func getPipelineFromArgs(args []string, forMR bool, onlyPassed bool) (string, int, error) {
 	if forMR {
+		log.Debug("fetching merge request pipeline...")
 		rn, mrNum, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
 			return "", 0, err
@@ -208,6 +209,7 @@ func getPipelineFromArgs(args []string, forMR bool, onlyPassed bool) (string, in
 		if err != nil {
 			return "", 0, err
 		}
+		log.Debugf("mr id = %d", mr.IID)
 
 		// mr.Pipeline points to the latest successful pipeline run, while
 		// mr.HeadPipeline points to the latest pipeline overall, regardless
@@ -246,6 +248,7 @@ func getPipelineFromArgs(args []string, forMR bool, onlyPassed bool) (string, in
 		}
 
 		if webURLMatch {
+			log.Debugf("pipeline id = %d", pipelineID)
 			return rn, pipelineID, nil
 		}
 
@@ -253,6 +256,7 @@ func getPipelineFromArgs(args []string, forMR bool, onlyPassed bool) (string, in
 		if err != nil {
 			return "", 0, err
 		}
+		log.Debugf("project name = %s", p.PathWithNamespace)
 
 		return p.PathWithNamespace, pipelineID, nil
 	}
@@ -270,6 +274,7 @@ func getPipelineFromArgs(args []string, forMR bool, onlyPassed bool) (string, in
 	if commit.LastPipeline == nil {
 		return "", 0, errors.Errorf("No pipeline found for %s", refName)
 	}
+	log.Debugf("pipeline id = %d", commit.LastPipeline.ID)
 
 	return rn, commit.LastPipeline.ID, nil
 }


### PR DESCRIPTION
This PR adds the `--passed` flag to some of the CI commands. This flag allow the user to request lab to retrieve only information from passed pipeline runs. Also, this PR adds some debugging message to the getPipelineFromArgs() function to help future troubleshooting.

The `--passed` flag name might not be the best one (I'm not sure I even like it too :D), so please, let me know what you guys think.