### PR TITLE
mr_list_test: update the last created MR

### DIFF
--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -124,7 +124,7 @@ func Test_mrFilterByTargetBranch(t *testing.T) {
 }
 
 var (
-	latestCreatedTestMR = "!740 MR to test close/reopen"
+	latestCreatedTestMR = "!968 README: dummy commit for CI tests"
 	latestUpdatedTestMR = "!329 MR for assign and review commands"
 )
 


### PR DESCRIPTION
A new MR was created in the live test repo to accomodate a new feature being
implemented for the CI subcommands (the --passed flag). This MR will be used
for testing purposes and need to be set as the latest MR for the mr_list
testing code.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>