### PR TITLE
cmd: remove any FindProject() redundant call

### DIFF
--- a/cmd/ci_artifacts.go
+++ b/cmd/ci_artifacts.go
@@ -68,13 +68,7 @@ var ciArtifactsCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		project, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-		projectID := project.ID
-
-		r, outpath, err := lab.CIArtifacts(projectID, pipelineID, jobName, path, followBridge, bridgeName)
+		r, outpath, err := lab.CIArtifacts(rn, pipelineID, jobName, path, followBridge, bridgeName)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ci_run.go
+++ b/cmd/ci_run.go
@@ -41,11 +41,7 @@ var ciCreateCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		project, err := lab.GetProject(pid)
-		if err != nil {
-			log.Fatal(err)
-		}
-		fmt.Printf("%s/pipelines/%d\n", project.WebURL, pipeline.ID)
+		fmt.Println(pipeline.WebURL)
 	},
 }
 
@@ -89,41 +85,38 @@ var ciTriggerCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		project, err := lab.GetProject(pid)
-		if err != nil {
-			log.Fatal(err)
-		}
-		fmt.Printf("%s/pipelines/%d\n", project.WebURL, pipeline.ID)
+		fmt.Println(pipeline.WebURL)
 	},
 }
 
-func getCIRunOptions(cmd *cobra.Command, args []string) (interface{}, string, error) {
+func getCIRunOptions(cmd *cobra.Command, args []string) (string, string, error) {
 	branch, err := git.CurrentBranch()
 	if err != nil {
-		return nil, "", err
+		return "", "", err
 	}
-	var pid interface{}
 	if len(args) > 0 {
 		branch = args[0]
 	}
 
+	var pid string
+
 	remote := determineSourceRemote(branch)
 	rn, err := git.PathWithNamespace(remote)
 	if err != nil {
-		return nil, "", err
+		return "", "", err
 	}
 	pid = rn
 
 	project, err := cmd.Flags().GetString("project")
 	if err != nil {
-		return nil, "", err
+		return "", "", err
 	}
 	if project != "" {
-		p, err := lab.FindProject(project)
+		_, err := lab.FindProject(project)
 		if err != nil {
-			return nil, "", err
+			return "", "", err
 		}
-		pid = p.ID
+		pid = project
 	}
 	return pid, branch, nil
 }

--- a/cmd/ci_run_test.go
+++ b/cmd/ci_run_test.go
@@ -19,7 +19,7 @@ func Test_ciRun(t *testing.T) {
 		t.Log(string(b))
 		t.Fatal(err)
 	}
-	require.Regexp(t, `^https://gitlab.com/lab-testing/test/pipelines/\d+`, string(b))
+	require.Regexp(t, `^https://gitlab.com/lab-testing/test/-/pipelines/\d+`, string(b))
 }
 
 func Test_parseCIVariables(t *testing.T) {
@@ -77,7 +77,7 @@ func Test_getCIRunOptions(t *testing.T) {
 		desc            string
 		cmdFunc         func()
 		args            []string
-		expectedProject interface{}
+		expectedProject string
 		expectedBranch  string
 		expectedErr     string
 	}{
@@ -111,7 +111,7 @@ func Test_getCIRunOptions(t *testing.T) {
 				ciTriggerCmd.Flags().Set("project", "zaquestion/test")
 			},
 			[]string{},
-			4181224, // https://gitlab.com/zaquestion/test project ID
+			"zaquestion/test", // https://gitlab.com/zaquestion/test project name
 			"master",
 			"",
 		},
@@ -121,7 +121,7 @@ func Test_getCIRunOptions(t *testing.T) {
 				ciTriggerCmd.Flags().Set("project", "barfasdfasdf")
 			},
 			[]string{},
-			nil, // https://gitlab.com/zaquestion/test project ID
+			"", // https://gitlab.com/zaquestion/test project name
 			"",
 			"GitLab project not found, verify you have access to the requested resource",
 		},

--- a/cmd/ci_trace.go
+++ b/cmd/ci_trace.go
@@ -73,23 +73,17 @@ var ciTraceCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		project, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-		projectID = project.ID
-
 		pager := newPager(cmd.Flags())
 		defer pager.Close()
 
-		err = doTrace(context.Background(), os.Stdout, projectID, pipelineID, jobName)
+		err = doTrace(context.Background(), os.Stdout, rn, pipelineID, jobName)
 		if err != nil {
 			log.Fatal(err)
 		}
 	},
 }
 
-func doTrace(ctx context.Context, w io.Writer, pid interface{}, pipelineID int, name string) error {
+func doTrace(ctx context.Context, w io.Writer, projID string, pipelineID int, name string) error {
 	var (
 		once   sync.Once
 		offset int64
@@ -98,7 +92,7 @@ func doTrace(ctx context.Context, w io.Writer, pid interface{}, pipelineID int, 
 		if ctx.Err() == context.Canceled {
 			break
 		}
-		trace, job, err := lab.CITrace(pid, pipelineID, name, followBridge, bridgeName)
+		trace, job, err := lab.CITrace(projID, pipelineID, name, followBridge, bridgeName)
 		if err != nil || job == nil || trace == nil {
 			return errors.Wrap(err, "failed to find job")
 		}

--- a/cmd/ci_view.go
+++ b/cmd/ci_view.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	projectID  int
+	projectID  string
 	pipelineID int
 )
 
@@ -78,11 +78,7 @@ var ciViewCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		project, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-		projectID = project.ID
+		projectID = rn
 		root := tview.NewPages()
 		root.SetBorderPadding(1, 1, 2, 2)
 

--- a/cmd/issue_close.go
+++ b/cmd/issue_close.go
@@ -27,23 +27,18 @@ var issueCloseCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		dupID, _ := cmd.Flags().GetString("duplicate")
 		if dupID != "" {
 			if !strings.Contains(dupID, "#") {
 				dupID = "#" + dupID
 			}
-			err = lab.IssueDuplicate(p.ID, int(id), dupID)
+			err = lab.IssueDuplicate(rn, int(id), dupID)
 			if err != nil {
 				log.Fatal(err)
 			}
 			fmt.Printf("Issue #%d closed as duplicate of %s\n", id, dupID)
 		} else {
-			err = lab.IssueClose(p.ID, int(id))
+			err = lab.IssueClose(rn, int(id))
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/issue_reopen.go
+++ b/cmd/issue_reopen.go
@@ -23,12 +23,7 @@ var issueReopenCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = lab.IssueReopen(p.ID, int(id))
+		err = lab.IssueReopen(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_subscribe.go
+++ b/cmd/issue_subscribe.go
@@ -21,12 +21,7 @@ var issueSubscribeCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = lab.IssueSubscribe(p.ID, int(id))
+		err = lab.IssueSubscribe(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/issue_unsubscribe.go
+++ b/cmd/issue_unsubscribe.go
@@ -22,12 +22,7 @@ var issueUnsubscribeCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = lab.IssueUnsubscribe(p.ID, int(id))
+		err = lab.IssueUnsubscribe(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_close.go
+++ b/cmd/mr_close.go
@@ -20,12 +20,7 @@ var mrCloseCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = lab.MRClose(p.ID, int(id))
+		err = lab.MRClose(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -88,8 +88,8 @@ func init() {
 	)
 }
 
-func verifyRemoteBranch(projectID int, branch string) error {
-	if _, err := lab.GetCommit(projectID, branch); err != nil {
+func verifyRemoteBranch(projID string, branch string) error {
+	if _, err := lab.GetCommit(projID, branch); err != nil {
 		return fmt.Errorf("%s is not a valid reference", branch)
 	}
 	return nil
@@ -174,13 +174,8 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	sourceProject, err := lab.FindProject(sourceProjectName)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// verify the source branch in remote project
-	err = verifyRemoteBranch(sourceProject.ID, sourceBranch)
+	err = verifyRemoteBranch(sourceProjectName, sourceBranch)
 	if err != nil {
 		log.Fatalf("%s:%s\n", sourceRemote, err)
 	}
@@ -206,7 +201,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	if len(args) > 1 && targetBranch != args[1] {
 		targetBranch = args[1]
 		// verify the target branch in remote project
-		err = verifyRemoteBranch(targetProject.ID, targetBranch)
+		err = verifyRemoteBranch(targetProjectName, targetBranch)
 		if err != nil {
 			log.Fatalf("%s:%s\n", targetRemote, err)
 		}

--- a/cmd/mr_merge.go
+++ b/cmd/mr_merge.go
@@ -31,16 +31,11 @@ var mrMergeCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		opts := gitlab.AcceptMergeRequestOptions{
 			MergeWhenPipelineSucceeds: gitlab.Bool(!mergeImmediate),
 		}
 
-		err = lab.MRMerge(p.ID, int(id), &opts)
+		err = lab.MRMerge(rn, int(id), &opts)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_rebase.go
+++ b/cmd/mr_rebase.go
@@ -18,12 +18,7 @@ var mrRebaseCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = lab.MRRebase(p.ID, int(id))
+		err = lab.MRRebase(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_reopen.go
+++ b/cmd/mr_reopen.go
@@ -20,12 +20,7 @@ var mrReopenCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = lab.MRReopen(p.ID, int(id))
+		err = lab.MRReopen(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_subscribe.go
+++ b/cmd/mr_subscribe.go
@@ -24,12 +24,7 @@ var mrSubscribeCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = lab.MRSubscribe(p.ID, int(id))
+		err = lab.MRSubscribe(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_thumb.go
+++ b/cmd/mr_thumb.go
@@ -31,12 +31,7 @@ var mrThumbUpCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = lab.MRThumbUp(p.ID, int(id))
+		err = lab.MRThumbUp(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -57,12 +52,7 @@ var mrThumbDownCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = lab.MRThumbDown(p.ID, int(id))
+		err = lab.MRThumbDown(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_unsubscribe.go
+++ b/cmd/mr_unsubscribe.go
@@ -24,12 +24,7 @@ var mrUnsubscribeCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		p, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = lab.MRUnsubscribe(p.ID, int(id))
+		err = lab.MRUnsubscribe(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/snippet_create.go
+++ b/cmd/snippet_create.go
@@ -97,10 +97,6 @@ var snippetCreateCmd = &cobra.Command{
 			return
 		}
 
-		project, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
 		opts := gitlab.CreateProjectSnippetOptions{
 			Title:       gitlab.String(title),
 			Description: gitlab.String(body),
@@ -108,7 +104,7 @@ var snippetCreateCmd = &cobra.Command{
 			FileName:    gitlab.String(name),
 			Visibility:  &visibility,
 		}
-		snip, err := lab.ProjectSnippetCreate(project.ID, &opts)
+		snip, err := lab.ProjectSnippetCreate(rn, &opts)
 		if err != nil || snip == nil {
 			log.Fatal(errors.Wrap(err, "failed to create snippet"))
 		}

--- a/cmd/snippet_delete.go
+++ b/cmd/snippet_delete.go
@@ -32,11 +32,7 @@ var snippetDeleteCmd = &cobra.Command{
 			return
 		}
 
-		project, err := lab.FindProject(rn)
-		if err != nil {
-			log.Fatal(err)
-		}
-		err = lab.ProjectSnippetDelete(project.ID, int(id))
+		err = lab.ProjectSnippetDelete(rn, int(id))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/snippet_list.go
+++ b/cmd/snippet_list.go
@@ -65,12 +65,8 @@ func snippetList(args []string) ([]*gitlab.Snippet, error) {
 		return lab.SnippetList(opts, num)
 	}
 
-	project, err := lab.FindProject(rn)
-	if err != nil {
-		return nil, err
-	}
 	opts := gitlab.ListProjectSnippetsOptions(listOpts)
-	return lab.ProjectSnippetList(project.ID, opts, num)
+	return lab.ProjectSnippetList(rn, opts, num)
 }
 
 func init() {


### PR DESCRIPTION
It turns out that not only the internal gitlab code was calling
FindProject() without need (fixed on [1]). The commands themselves were
calling the FindProject() before requesting an action from an internal
gitlab module code. With that, there were places (MRCreate, IssueCreate,
...) that the FindProject() function was being called twice before actually
handing the request off to go-gitlab module.

This commit get rid of all FindProject() calls that were (1) redundant or
(2) not really needed, since GitLab's API accept both the project name or
the project number ID as input. Hopefully, this change will make many
different command calls much faster (with one or even two less API calls).

[1] https://github.com/zaquestion/lab/pull/761

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>