### PR TITLE
cmd/note-common.go: Fix context comments on diffs

### DIFF
--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1718,12 +1718,18 @@ func CreateCommitComment(projID string, sha string, newFile string, oldFile stri
 		PositionType: "text",
 	}
 
-	if linetype == "old" {
-		position.OldPath = oldFile
-		position.OldLine = line
-	} else {
+	switch linetype {
+	case "new":
 		position.NewPath = newFile
 		position.NewLine = line
+	case "old":
+		position.OldPath = oldFile
+		position.OldLine = line
+	case "context":
+		position.NewPath = newFile
+		position.NewLine = line
+		position.OldPath = oldFile
+		position.OldLine = line
 	}
 
 	opt := &gitlab.CreateCommitDiscussionOptions{
@@ -1760,9 +1766,13 @@ func CreateMergeRequestCommitDiscussion(projID string, id int, sha string, newFi
 		PositionType: "text",
 	}
 
-	if linetype == "new" {
+	switch linetype {
+	case "new":
 		position.NewLine = line
-	} else {
+	case "old":
+		position.OldLine = line
+	case "context":
+		position.NewLine = line
 		position.OldLine = line
 	}
 


### PR DESCRIPTION
@krobelus noticed that it wasnt possible to comment on the context portion
of a diff.  For example, when commenting on line 6 of

| newfile: Makefile oldfile: Makefile
|        @@ -5,6 +5,8 @@ SUBLEVEL = 0
|  5   5  EXTRAVERSION =
|  6   6  NAME = Merciless Moray
|  7   7
|      8 +# space
|      9 +
|  8  10  #
|  9  11  # DRM backport version
| 10  12  #

it was not possible to comment on line 6 and lab would output an error.
This is fixed by reworking the code to detect context diffs, however, this
only appears to work on code shown before the difflines.  There are
several open GitLab API issues that report errors when commenting on Merge
Request commits and it is likely that one of these is causing the error.

ex) https://gitlab.com/gitlab-org/gitlab-foss/-/issues/28599

Rework the code to allow for commenting on the context of diffs.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>