### PR TITLE
config: fix worktree git config dir path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -339,10 +339,19 @@ func LoadMainConfig() (string, string, string, string, bool) {
 }
 
 // default path of worktree lab.toml file
-var (
-	WorkTreePath string = ".git/lab"
-	WorkTreeName string = "lab"
-)
+var WorktreeConfigName string = "lab"
+
+// worktreeConfigPath gets the current git config path using the
+// `git rev-parse` command, which considers the worktree's gitdir path placed
+// into the .git file.
+func worktreeConfigPath() string {
+	gitDir, err := git.Dir()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return gitDir + "/lab"
+}
 
 // LoadConfig loads a config file specified by configpath and configname.
 // The configname must not have a '.toml' extension.  If configpath and/or
@@ -352,10 +361,10 @@ func LoadConfig(configpath string, configname string) *viper.Viper {
 	targetConfig.SetConfigType("toml")
 
 	if configpath == "" {
-		configpath = WorkTreePath
+		configpath = worktreeConfigPath()
 	}
 	if configname == "" {
-		configname = WorkTreeName
+		configname = WorktreeConfigName
 	}
 	targetConfig.AddConfigPath(configpath)
 	targetConfig.SetConfigName(configname)


### PR DESCRIPTION
The config code doesn't follow the worktree git config file when the
user calls for a command that depends on that from within a 
`git worktree` directory. In this cases, the .git path is in fact a file
instead of a valid directory, which turns to point to the actual
worktree configuration dir.

Instead of realying in a hardcoded path (`.git/lab`), make use of the
`git rev-parse --git-dir` command already available in the git commands
code (internal/git/git.go) and which follows the worktree situation.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>

Fixes #773 