### PR TITLE
label list: add `--name-only` flag

### DIFF
--- a/cmd/label_list.go
+++ b/cmd/label_list.go
@@ -27,6 +27,11 @@ var labelListCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		nameOnly, err := cmd.Flags().GetBool("name-only")
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		labelSearch = strings.ToLower(labelSearch)
 
 		labels, err := lab.LabelList(rn)
@@ -45,7 +50,7 @@ var labelListCmd = &cobra.Command{
 			}
 
 			description := ""
-			if label.Description != "" {
+			if !nameOnly && label.Description != "" {
 				description = " - " + label.Description
 			}
 
@@ -79,6 +84,7 @@ func mapLabels(rn string, labelTerms []string) ([]string, error) {
 }
 
 func init() {
+	labelListCmd.Flags().Bool("name-only", false, "only list label names, not descriptions")
 	labelCmd.AddCommand(labelListCmd)
 	carapace.Gen(labelCmd).PositionalCompletion(
 		action.Remotes(),


### PR DESCRIPTION
This adds a new `--name-only` flag to `lab label list` to print the labels w/o descriptions.

Example:
```
❯ lab label list
P1 - High priority
P2 - Medium Priority
P3 - Low priority
...

❯ lab label list --name-only
P1
P2
P3
...

# still works w/ searching, too
❯ lab label list Type
Type::bug - This is a defect; something that should not be happening.
Type::dev/maintenance - An internal or developer-centric issue.  Think: house cleaning or repair.
Type::discussion - Questions or discussion.
Type::feature - New features or an improvement to existing fuctionality.
Type::operations - Primarily server related. Server, DNS, hosting, etc.

❯ lab label list Type --name-only
Type::bug
Type::dev/maintenance
Type::discussion
Type::feature
Type::operations
```

I did not add a test, but I have been using this for a while. Also, the repo doesn't include any labels w/ descriptions. Thank you for considering this.