### PR TITLE
Fix flag bypass for editing description

### DIFF
--- a/cmd/edit_common.go
+++ b/cmd/edit_common.go
@@ -41,7 +41,7 @@ func getUpdateUsers(currentUsers []string, users []string, remove []string) ([]i
 // editGetTitleDescription returns a title and description based on the
 // current issue title and description and various flags from the command
 // line
-func editGetTitleDescription(title string, body string, msgs []string, nFlag int) (string, string, error) {
+func editGetTitleDescription(title string, body string, msgs []string) (string, string, error) {
 	if len(msgs) > 0 {
 		title = msgs[0]
 
@@ -50,12 +50,6 @@ func editGetTitleDescription(title string, body string, msgs []string, nFlag int
 		}
 
 		// we have everything we need
-		return title, body, nil
-	}
-
-	// if other flags were given (eg label), then skip the editor and return
-	// what we already have
-	if nFlag != 0 {
 		return title, body, nil
 	}
 

--- a/cmd/edit_common.go
+++ b/cmd/edit_common.go
@@ -59,7 +59,7 @@ func editDescription(title string, body string, msgs []string, filename string) 
 
 		content, err := ioutil.ReadFile(filename)
 		if err != nil {
-			return "", "", nil
+			return "", "", err
 		}
 		lines = strings.Split(string(content), "\n")
 

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -137,10 +136,9 @@ var issueEditCmd = &cobra.Command{
 		// We only consider editing an issue with -m or when no other flag is
 		// passed, but --linebreak.
 		if len(msgs) > 0 || cmd.Flags().NFlag() == 0 || (cmd.Flags().NFlag() == 1 && linebreak) {
-			title, body, err = editGetTitleDescription(issue.Title, issue.Description, msgs)
+			title, body, err = editDescription(issue.Title, issue.Description, msgs, "")
 			if err != nil {
-				_, f, l, _ := runtime.Caller(0)
-				log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
+				log.Fatal(err)
 			}
 			if title == "" {
 				log.Fatal("aborting: empty issue title")

--- a/cmd/issue_edit.go
+++ b/cmd/issue_edit.go
@@ -1,19 +1,16 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"runtime"
 	"strconv"
 	"strings"
-	"text/template"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	gitlab "github.com/xanzy/go-gitlab"
 	"github.com/zaquestion/lab/internal/action"
-	"github.com/zaquestion/lab/internal/git"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
@@ -188,37 +185,6 @@ func issueGetCurrentAssignees(issue *gitlab.Issue) []string {
 		}
 	}
 	return currentAssignees
-}
-
-// editText returns an issue editing template that is suitable for loading
-// into an editor
-func editText(title string, body string) (string, error) {
-	tmpl := heredoc.Doc(`
-		{{.InitMsg}}
-
-		{{.CommentChar}} Edit the title and/or description. The first block of text
-		{{.CommentChar}} is the title and the rest is the description.`)
-
-	msg := &struct {
-		InitMsg     string
-		CommentChar string
-	}{
-		InitMsg:     title + "\n\n" + body,
-		CommentChar: git.CommentChar(),
-	}
-
-	t, err := template.New("tmpl").Parse(tmpl)
-	if err != nil {
-		return "", err
-	}
-
-	var b bytes.Buffer
-	err = t.Execute(&b, msg)
-	if err != nil {
-		return "", err
-	}
-
-	return b.String(), nil
 }
 
 func init() {

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -243,7 +243,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 			log.Fatal("option -F cannot be combined with -m/-c")
 		}
 
-		title, body, err = editGetTitleDescFromFile(filename)
+		title, body, err = editDescription("", "", nil, filename)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"runtime"
-	"strconv"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -192,28 +190,24 @@ var mrEditCmd = &cobra.Command{
 		title := mr.Title
 		body := mr.Description
 
-		if filename != "" {
-			if len(msgs) > 0 {
-				log.Fatal("option -F cannot be combined with -m")
-			}
+		if len(msgs) > 0 && filename != "" {
+			log.Fatal("option -F cannot be combined with -m")
+		}
 
-			title, body, err = editGetTitleDescFromFile(filename)
+		// We only consider editing title and body on -m, -F or when no other
+		// flag is passed, but --linebreak.
+		if len(msgs) > 0 || filename != "" ||
+			cmd.Flags().NFlag() == 0 || (cmd.Flags().NFlag() == 1 && linebreak) {
+			title, body, err = editDescription(mr.Title, mr.Description, msgs, filename)
 			if err != nil {
 				log.Fatal(err)
 			}
-		} else {
-			// We only consider editing an mr with -m, -F or when no other flag
-			// is passed, but --linebreak.
-			if len(msgs) > 0 || cmd.Flags().NFlag() == 0 || (cmd.Flags().NFlag() == 1 && linebreak) {
-				title, body, err = editGetTitleDescription(mr.Title, mr.Description, msgs)
-				if err != nil {
-					_, f, l, _ := runtime.Caller(0)
-					log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
-				}
-			}
-
 			if title == "" {
 				log.Fatal("aborting: empty mr title")
+			}
+
+			if linebreak {
+				body = textToMarkdown(body)
 			}
 		}
 
@@ -254,10 +248,6 @@ var mrEditCmd = &cobra.Command{
 			!targetBranchChanged && !reviewersChanged)
 		if abortUpdate {
 			log.Fatal("aborting: no changes")
-		}
-
-		if linebreak {
-			body = textToMarkdown(body)
 		}
 
 		opts := &gitlab.UpdateMergeRequestOptions{

--- a/cmd/mr_edit.go
+++ b/cmd/mr_edit.go
@@ -189,7 +189,8 @@ var mrEditCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		var title, body string
+		title := mr.Title
+		body := mr.Description
 
 		if filename != "" {
 			if len(msgs) > 0 {
@@ -201,16 +202,19 @@ var mrEditCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 		} else {
-			title, body, err = editGetTitleDescription(
-				mr.Title, mr.Description, msgs, cmd.Flags().NFlag())
-			if err != nil {
-				_, f, l, _ := runtime.Caller(0)
-				log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
+			// We only consider editing an mr with -m, -F or when no other flag
+			// is passed, but --linebreak.
+			if len(msgs) > 0 || cmd.Flags().NFlag() == 0 || (cmd.Flags().NFlag() == 1 && linebreak) {
+				title, body, err = editGetTitleDescription(mr.Title, mr.Description, msgs)
+				if err != nil {
+					_, f, l, _ := runtime.Caller(0)
+					log.Fatal(f+":"+strconv.Itoa(l)+" ", err)
+				}
 			}
-		}
 
-		if title == "" {
-			log.Fatal("aborting: empty mr title")
+			if title == "" {
+				log.Fatal("aborting: empty mr title")
+			}
 		}
 
 		isWIP := hasPrefix(title, "wip:") ||

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,20 +116,18 @@ func init() {
 
 	// We need to set the logger level before any other piece of code is
 	// called, thus we make sure we don't lose any debug message, but for
-	// that we need to parse the args from command input.
-	err := RootCmd.ParseFlags(os.Args[1:])
-	// Handle the err != nil case later
-	if err == nil {
-		debugLogger, _ := RootCmd.Flags().GetBool("debug")
-		quietLogger, _ := RootCmd.Flags().GetBool("quiet")
-		if debugLogger && quietLogger {
-			log.Fatal("option --debug cannot be combined with --quiet")
-		}
-		if debugLogger {
-			log.SetLogLevel(logger.LogLevelDebug)
-		} else if quietLogger {
-			log.SetLogLevel(logger.LogLevelNone)
-		}
+	// that we need to parse the args from command input and let flag errors be
+	// handled by the subcommands themselves.
+	_ = RootCmd.ParseFlags(os.Args[1:])
+	debugLogger, _ := RootCmd.Flags().GetBool("debug")
+	quietLogger, _ := RootCmd.Flags().GetBool("quiet")
+	if debugLogger && quietLogger {
+		log.Fatal("option --debug cannot be combined with --quiet")
+	}
+	if debugLogger {
+		log.SetLogLevel(logger.LogLevelDebug)
+	} else if quietLogger {
+		log.SetLogLevel(logger.LogLevelNone)
 	}
 	carapace.Gen(RootCmd)
 }

--- a/testdata/testedit
+++ b/testdata/testedit
@@ -1,0 +1,3 @@
+new title
+
+new body


### PR DESCRIPTION
While editing an MR or issue description if any flag different from -m and -F is used the editor is not opened. Add the --linebreak to this list of "accepted" flags to be used for editing the description.

Also, this MR bring other lateral fixes and improvements related to code organization, make sure to check each commit separately.