### PR TITLE
project_create: fix group lookup and allow custom remote name

### DIFF
--- a/cmd/project_create.go
+++ b/cmd/project_create.go
@@ -100,7 +100,6 @@ var projectCreateCmd = &cobra.Command{
 }
 
 func determineNamespacePath(args []string, name string) (string, string) {
-	var path string
 	if len(args) > 0 {
 		ps := strings.Split(args[0], "/")
 		if len(ps) == 1 {
@@ -108,7 +107,9 @@ func determineNamespacePath(args []string, name string) (string, string) {
 		}
 		return strings.Join(ps[:len(ps)-1], "/"), ps[len(ps)-1]
 	}
-	if path == "" && name == "" && git.InsideGitRepo() {
+
+	var path string
+	if name == "" && git.InsideGitRepo() {
 		wd, err := git.WorkingDir()
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/project_create_test.go
+++ b/cmd/project_create_test.go
@@ -22,7 +22,7 @@ func Test_projectCreateCmd(t *testing.T) {
 	os.Remove(filepath.Join(repo, ".git/config"))
 
 	t.Run("create", func(t *testing.T) {
-		cmd := exec.Command(labBinaryPath, "project", "create", "-p")
+		cmd := exec.Command(labBinaryPath, "project", "create", "-p", "-r", "origin")
 		cmd.Dir = repo
 
 		b, err := cmd.CombinedOutput()


### PR DESCRIPTION
The group search logic didn't consider the fact that the GitLab API
returns an alphabetical ordered list of groups within a certain group,
thus when multiple subgroups were nested the value groups[0] and list[0]
used in the code weren't always the expected ones.

With that, instead of looking up for the first group, we look for the
last one, meaning that all subgroups found in user's namespace or
wherever he has access to, is returned from the API. The match then
happens with the group full path or full name, which matches first.

In case the user has access to multiple groups with ambiguous names,
all possible paths are shown and lab's exits.

Also, a new flag `--remote` was added to allow the user to provide a
remote name in case needed. `lab` don't add a remote by default.

Related: #782 