### PR TITLE
cmd/mr_checkout: check existing remotes before creating one

### DIFF
--- a/cmd/mr_checkout.go
+++ b/cmd/mr_checkout.go
@@ -88,6 +88,7 @@ var checkoutCmd = &cobra.Command{
 				}
 				if path == project.PathWithNamespace {
 					remoteName = remote
+					break
 				}
 			}
 
@@ -137,7 +138,7 @@ var checkoutCmd = &cobra.Command{
 
 func init() {
 	checkoutCmd.Flags().StringVarP(&mrCheckoutCfg.branch, "branch", "b", "", "checkout merge request with <branch> name")
-	checkoutCmd.Flags().BoolVarP(&mrCheckoutCfg.track, "track", "t", false, "set checked out branch to track mr author remote branch, adds remote if needed")
+	checkoutCmd.Flags().BoolVarP(&mrCheckoutCfg.track, "track", "t", false, "set branch to track remote branch, adds remote if needed")
 	// useHTTP is defined in "project_create.go"
 	checkoutCmd.Flags().BoolVar(&useHTTP, "http", false, "checkout using HTTP protocol instead of SSH")
 	checkoutCmd.Flags().BoolVarP(&mrCheckoutCfg.force, "force", "f", false, "force branch checkout and override existing branch")

--- a/cmd/mr_checkout_test.go
+++ b/cmd/mr_checkout_test.go
@@ -151,7 +151,7 @@ func Test_mrDoubleCheckoutFailCmdRun(t *testing.T) {
 		t.Log(eLog)
 		t.Fatal(err)
 	}
-	require.Contains(t, eLog, "ERROR: mr 1 branch mrtest already exists")
+	require.Contains(t, eLog, "branch mrtest already exists")
 }
 
 func Test_mrDoubleCheckoutForceRun(t *testing.T) {

--- a/cmd/mr_checkout_test.go
+++ b/cmd/mr_checkout_test.go
@@ -87,7 +87,7 @@ func Test_mrCheckoutCmd_track(t *testing.T) {
 		t.Fatal(err)
 	}
 	remotes := string(gitOut)
-	require.Contains(t, remotes, "zaquestion	git@gitlab.com:zaquestion/test.git")
+	require.Contains(t, remotes, "origin	git@gitlab.com:zaquestion/test.git")
 }
 
 func Test_mrCheckoutCmdRunWithDifferentName(t *testing.T) {

--- a/cmd/mr_checkout_test.go
+++ b/cmd/mr_checkout_test.go
@@ -52,7 +52,7 @@ func Test_mrCheckoutCmd_track(t *testing.T) {
 	cmd.Dir = repo
 	cmd.CombinedOutput()
 
-	cmd = exec.Command(labBinaryPath, "mr", "checkout", "1", "-t", "-b", "mrtest_track")
+	cmd = exec.Command(labBinaryPath, "mr", "checkout", "1", "-f", "-t", "-b", "mrtest_track")
 	cmd.Dir = repo
 	b, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
In case tacking is enabled `lab mr checkout -t`, a new remote is created
with the name of the MR author's name without checking if the already
available remotes matches the one from which the MR was checked-out.
A particular case where it happens constantly is in the branching
development model: developers use a single repo to push their work as
branches.

This patch change the code behavor by first checking if any of the
existent remotes has the same path as the source MR project before
creating a new remote. If no remote is found, then create a new one with
the MR author's name.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>

Related: #774 