### PR TITLE
internal/gitlab: fix init with custom CA file

### DIFF
--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -72,8 +72,8 @@ func UserID() (int, error) {
 
 // Init initializes a gitlab client for use throughout lab.
 func Init(_host, _user, _token string, allowInsecure bool) {
-	if len(_host) > 0 && _host[len(_host)-1:][0] == '/' {
-		_host = _host[0 : len(_host)-1]
+	if len(_host) > 0 && _host[len(_host)-1] == '/' {
+		_host = _host[:len(_host)-1]
 	}
 	host = _host
 	user = _user
@@ -105,6 +105,13 @@ func Init(_host, _user, _token string, allowInsecure bool) {
 // one for instance) instead of relying only on those installed in the current
 // system database
 func InitWithCustomCA(_host, _user, _token, caFile string) error {
+	if len(_host) > 0 && _host[len(_host)-1] == '/' {
+		_host = _host[:len(_host)-1]
+	}
+	host = _host
+	user = _user
+	token = _token
+
 	caCert, err := ioutil.ReadFile(caFile)
 	if err != nil {
 		return err


### PR DESCRIPTION
None of the internal/API user's information (host, user, token) were
being set when a custom CA file was set in the cofiguration file. This
patch set them the same way as the Init() function.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>

Related: #787 