### PR TITLE
cmd/root: skip remote discuvery for initSkipped commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -197,7 +197,7 @@ func Execute(initSkipped bool) {
 	// Try to gather remote information if running inside a git tree/repo.
 	// Otherwise, skip it, since the info won't be used at all, also avoiding
 	// misleading error/warning messages about missing remote.
-	if git.InsideGitRepo() {
+	if !initSkipped && git.InsideGitRepo() {
 		defaultRemote = guessDefaultRemote()
 		if defaultRemote == "" {
 			log.Infoln("No default remote found")


### PR DESCRIPTION
Some commands basically skips the lab.Init() code, meaning that they
don't intend to actually interact with the git repository. With that, we
can also skip the remote discovery code to avoid misleading errors
about missing remote for commands that skipped the init code.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>

Related: #789 