### PR TITLE
remote: support remotes referred by URL only

### DIFF
--- a/cmd/ci_run.go
+++ b/cmd/ci_run.go
@@ -100,7 +100,10 @@ func getCIRunOptions(cmd *cobra.Command, args []string) (string, string, error) 
 
 	var pid string
 
-	remote := determineSourceRemote(branch)
+	remote, err := determineSourceRemote(branch)
+	if err != nil {
+		return "", "", err
+	}
 	rn, err := git.PathWithNamespace(remote)
 	if err != nil {
 		return "", "", err

--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -139,7 +139,11 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	sourceRemote := determineSourceRemote(localBranch)
+	sourceRemote, err := determineSourceRemote(localBranch)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Get the pushed branch name
 	sourceBranch, _ := git.UpstreamBranch(localBranch)
 	if sourceBranch == "" {

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -345,7 +345,10 @@ func Test_determineSourceRemote(t *testing.T) {
 		}
 
 		t.Run(test.desc, func(t *testing.T) {
-			sourceRemote := determineSourceRemote(test.branch)
+			sourceRemote, err := determineSourceRemote(test.branch)
+			if err != nil {
+				t.Fatal(err)
+			}
 			assert.Equal(t, test.expected, sourceRemote)
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/whilp/git-urls v1.0.0
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	github.com/yuin/goldmark v1.4.1 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tcnksm/go-gitconfig v0.1.2 h1:iiDhRitByXAEyjgBqsKi9QU4o2TNtv9kPP3RgPgXBPw=
 github.com/tcnksm/go-gitconfig v0.1.2/go.mod h1:/8EhP4H7oJZdIPyT+/UIsG87kTzrzM4UsLGSItWYCpE=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/xanzy/go-gitlab v0.51.0 h1:qCVJM9ijpY/ZG703p6DIK7RCUwZ4iQlBAig0TGJ/mRc=
 github.com/xanzy/go-gitlab v0.51.0/go.mod h1:Q+hQhV508bDPoBijv7YjK/Lvlb4PhVhJdKqXVQrUoAE=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -187,10 +187,10 @@ func TestPathWithNamespace(t *testing.T) {
 			expectedErr: "the key `remote.phoney.url` is not found",
 		},
 		{
-			desc:        "remote doesn't exist",
+			desc:        "invalid remote URL",
 			remote:      "garbage",
 			expected:    "",
-			expectedErr: "cannot parse remote: garbage url: garbageurl",
+			expectedErr: "invalid remote URL format for garbage",
 		},
 	}
 


### PR DESCRIPTION
When using git-push the user can set the upstream of a branch to a
remote that is not present in the current repository by referring to its
URL. In these cases, git checks for the validity of the URL itself
instead of checking if a remote with that name exists locally.

I.e.:
```
$ git push --set-upstream <URL>
```

This case affects lab mostly when we use the remote URL to lookup for it
in GitLab: lab checks for the branch's remote name.
`branch.<branch>.remote`, then it gets the remote URL itself; however,
in this situation, the `branch.<branch>.remote` will be the URL already
and any check for that remote in the local repository fails.

The biggest problem is the amount of different URL formats supported by
Git [1], which is bigger than the ones supported by the usual
url.Parse() (net/url Go module). Because of that, I brought the git-urls
module to help.

This new module threat anything that isn't an external URL as a possible
file URL, meaning that default remote names are also accepted, with that
we can pass all our remote names (URL or not) to its Parse() function
and just use the "path" component, which is pretty close to what we need
for the GitLab lookup.

[1] https://git-scm.com/docs/git-push#URLS

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>

Related: #381 