### PR TITLE
lab: Provide a better "Project Not Found" error message

### DIFF
--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -231,6 +231,9 @@ func FindProject(projID interface{}) (*gitlab.Project, error) {
 
 	target, err := GetProject(search)
 	if err != nil {
+		if err == ErrProjectNotFound {
+			return nil, fmt.Errorf("GitLab project (%s) not found, verify you have access to the requested resource\n", search)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Currently lab outputs this error when an unknown project is found:

"GitLab project not found, verify you have access to the requested
resource".

While this error does match the webUI, it doesn't provide enough
information to debug the error.  The webUI in this case still provides
the name of the unknown project where lab only outputs the generic
warning.

Update the "Project Not Found" error with the unknown project name.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>