### PR TITLE
lab: Provide a better "Project Not Found" error message

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -194,6 +194,9 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 	}
 	targetProject, err := lab.FindProject(targetProjectName)
 	if err != nil {
+		if err == lab.ErrProjectNotFound {
+			log.Fatalf("GitLab project (%s) not found, verify you have access to the requested resource", targetProjectName)
+		}
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
Currently lab outputs this error when an unknown project is found:

"GitLab project not found, verify you have access to the requested
resource".

While this error does match the webUI, it doesn't provide enough
information to debug the error.  The webUI in this case still provides
the name of the unknown project where lab only outputs the generic
warning.

Update the "Project Not Found" error with the unknown project name.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>