### PR TITLE
cmd/issue: add "i" alias to the command

### DIFF
--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -6,6 +6,7 @@ import (
 
 var issueCmd = &cobra.Command{
 	Use:              "issue",
+	Aliases:          []string{"i"},
 	Short:            `Describe, list, and create issues`,
 	Long:             ``,
 	PersistentPreRun: labPersistentPreRun,


### PR DESCRIPTION
The 'issue' command is one of the high-demand commands within lab with,
probably, 'mr', and enabling the alias 'i' for it seems a good approach
for all lazy developers that we all are. 'mr', 'todo', 'ci', 'repo' are
already shorthand themselves, adding this specific to 'issue' should not
harm, even more considering we aren't creating one-letter aliases to
every single command.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>

Fix #810 .