### PR TITLE
cmd/mr_create: add --no-edit flag to not open editor

### DIFF
--- a/internal/git/edit.go
+++ b/internal/git/edit.go
@@ -19,7 +19,7 @@ func Edit(filePrefix, message string) (string, string, error) {
 		return "", "", err
 	}
 
-	return parseTitleBody(strings.TrimSpace(string(contents)))
+	return ParseTitleBody(strings.TrimSpace(string(contents)))
 }
 
 // EditFile opens a file in the users editor and returns the contents. It
@@ -144,7 +144,7 @@ func removeComments(message string) (string, error) {
 	return strings.TrimSpace(strings.Join(noComments, "\n")), nil
 }
 
-func parseTitleBody(message string) (string, string, error) {
+func ParseTitleBody(message string) (string, string, error) {
 	msg, err := removeComments(message)
 	if err != nil {
 		return "", "", err

--- a/internal/git/edit_test.go
+++ b/internal/git/edit_test.go
@@ -1,14 +1,15 @@
 package git
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func Test_parseTitleBody(t *testing.T) {
+func TestParseTitleBody(t *testing.T) {
 	tests := []struct {
 		Name          string
 		Message       string
@@ -63,7 +64,7 @@ func Test_parseTitleBody(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			test := test
 			t.Parallel()
-			title, body, err := parseTitleBody(test.Message)
+			title, body, err := ParseTitleBody(test.Message)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
The default behavior when creating an MR is to open the editor regardless
the amount of commits:

- 1 commit: open editor with the commit's title and body already in place.
- 1+ commits: open editor with an empty message

This patch adds the --no-edit to allow users of the first option (single
commit) to tell lab to create the MR using the commit's message right away,
without opening the editor.

If --no-edit is used with the second option (multiple commits) lab exits
with a error message.

Fixes #819 

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>