### PR TITLE
project_create_test: fix negative sign on testdata dir name

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -136,11 +136,14 @@ type fatalLogger interface {
 // Note: testdata-* must be in the .gitignore or the copies will create write
 // errors as Git attempts to add the Git repo to the the project repo's index.
 func copyTestRepo(log fatalLogger) string {
-	dst, err := filepath.Abs(os.ExpandEnv("$GOPATH/src/github.com/zaquestion/lab/testdata-" + strconv.Itoa(int(rand.Uint64()))))
+	dstDir := strconv.FormatUint(rand.Uint64(), 10)
+	dst, err := filepath.Abs(
+		os.ExpandEnv("$GOPATH/src/github.com/zaquestion/lab/testdata-" + dstDir))
 	if err != nil {
 		log.Fatal(err)
 	}
-	src, err := filepath.Abs(os.ExpandEnv("$GOPATH/src/github.com/zaquestion/lab/testdata"))
+	src, err := filepath.Abs(
+		os.ExpandEnv("$GOPATH/src/github.com/zaquestion/lab/testdata"))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
A random usigned interger is used for generating the testdata directory
name, but an int() casting is done right after and, because of that,
depending on the size of the generated uint, the int casting will make it a
negative number. Consequently, the negative sign is maintained in the
resulting string from the strconv.Itoa() conversion, leading to a directory
name with two dashes: "testdata--8339364144815363225".

Even though this name format isn't a problem to lab itself, it's used as
"project name" for the project_create command testing code, which isn't
supported by GitLab:

ERROR: project_create.go:94: POST https://gitlab.com/api/v4/projects: 400
{message: {path: [must not start or end with a special character and must
not contain consecutive special characters.]}}

This patch format the random uint directly to string without using the
intermediate int() casting.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>