### PR TITLE
cmd/util.go: Fix panic with getUserIDs

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -658,8 +658,13 @@ func getUserID(user string) *int {
 // getUsers returns the userIDs for use with other GitLab API calls.
 func getUserIDs(users []string) []int {
 	var ids []int
-	for _, a := range users {
-		ids = append(ids, *getUserID(a))
+	for _, user := range users {
+		userID := getUserID(user)
+		if userID != nil {
+			ids = append(ids, *userID)
+		} else {
+			fmt.Printf("Warning: %s is not a valid username\n", user)
+		}
 	}
 	return ids
 }


### PR DESCRIPTION
'lab mr create -a <username>' panics if someone specifies a username that
doesn't exist:

[prarit@prarit kernel-test]$ ~/Other/github/lab/lab mr create -a prarit123456
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc942b8]

goroutine 1 [running]:
github.com/zaquestion/lab/cmd.getUserIDs(0xc000242420, 0x1, 0x1, 0xc000034700, 0x0, 0x0)
	/home/prarit/Other/github/lab/cmd/util.go:662 +0x98
github.com/zaquestion/lab/cmd.runMRCreate(0x14a2940, 0xc0000fe540, 0x0, 0x2)
	/home/prarit/Other/github/lab/cmd/mr_create.go:347 +0x10e9
github.com/spf13/cobra.(*Command).execute(0x14a2940, 0xc0000fe520, 0x2, 0x2, 0x14a2940, 0xc0000fe520)
	/home/prarit/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:860 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x149c2c0, 0xc0000bc050, 0x5, 0x5)
	/home/prarit/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/home/prarit/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
github.com/zaquestion/lab/cmd.Execute(0xc000790500)
	/home/prarit/Other/github/lab/cmd/root.go:218 +0xf5
main.main()
	/home/prarit/Other/github/lab/main.go:27 +0x74

Fix the panic and output a warning that the username doesn't exist, and
continue to create the merge request.

Fixes #827

Reported-by: GitHub User twouters
Signed-off-by: Prarit Bhargava <prarit@redhat.com>