### PR TITLE
goreleaser: fix homebrew test case

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,12 +16,8 @@ brews:
       email: goreleaser@carlosbecker.com
     install: bin.install "lab"
     test: |
-      system "git", "init"
-      %w[haunted house].each { |f| touch testpath/f }
-      system "git", "add", "haunted", "house"
-      system "git", "commit", "-a", "-m", "Initial Commit"
-      lab_env_config = "LAB_CORE_HOST=foo LAB_CORE_USER=bar LAB_CORE_TOKEN=baz"
-      assert_match "haunted\nhouse", shell_output("#{lab_env_config} #{bin}/lab ls-files").strip
+      lab_new_version = "lab version {{.Version}}"
+      assert_match lab_new_version, shell_output("#{bin}/lab --version").strip
 
 scoop:
   bucket:


### PR DESCRIPTION
On previous commits lab stopped to wrap git commands, thus the homebrew
test needed to be fixed in the point where a call to `lab ls-files` was
being made. At the same time, the whole test doesn't make sense
considering lab wasn't really being used. So, instead of only fixing the
`ls-files` portion, this patch is changing the test to only check the
lab version.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>

Fixes #833. 