### PR TITLE
Fix guessing the MR ID based on the current branch

### DIFF
--- a/cmd/mr_create_test.go
+++ b/cmd/mr_create_test.go
@@ -24,7 +24,7 @@ I am the default merge request template for lab
 #
 # Changes:
 #
-# 54fd49a (Zaq? Wiedmann`)
+# 54fd49a`)
 
 }
 
@@ -45,6 +45,6 @@ I am the default merge request template for lab
 # Changes:
 #
 
-54fd49a (Zaq? Wiedmann`)
+54fd49a`)
 
 }

--- a/cmd/mr_list_test.go
+++ b/cmd/mr_list_test.go
@@ -78,18 +78,14 @@ func Test_mrListStateMerged(t *testing.T) {
 func Test_mrListStateClosed(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
-	cmd := exec.Command(labBinaryPath, "mr", "list", "-a", "-s", "closed")
+	cmd := exec.Command(labBinaryPath, "mr", "list", "-n", "1", "-s", "closed")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	mrs := strings.Split(string(b), "\n")
-	t.Log(mrs)
-	require.Contains(t, mrs, "!5 closed mr")
-
+	require.Regexp(t, `!\d+`, string(b))
 }
 
 func Test_mrListFivePerPage(t *testing.T) {
@@ -102,10 +98,8 @@ func Test_mrListFivePerPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	mrs := strings.Split(string(b), "\n")
-	t.Log(mrs)
-	require.Contains(t, mrs, "!1 Test MR for lab list")
+	mrs := getAppOutput(b)
+	require.Len(t, mrs, 5)
 }
 
 func Test_mrFilterByTargetBranch(t *testing.T) {

--- a/cmd/mr_show_test.go
+++ b/cmd/mr_show_test.go
@@ -37,7 +37,7 @@ Approved By: None
 Approvers: None
 Approval Groups: None
 Reviewers: None
-Milestone: 1.0
+Milestone: None
 Labels: documentation
 Issues Closed by this MR: 
 Subscribed: Yes

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -325,7 +325,7 @@ func Test_mrCmd_Milestone(t *testing.T) {
 	repo := copyTestRepo(t)
 	var mrID string
 	t.Run("prepare", func(t *testing.T) {
-		cleanupMR(t, "origin", repo, "Test draft")
+		cleanupMR(t, "origin", repo, "MR for 1.0")
 	})
 	t.Run("create", func(t *testing.T) {
 		git := exec.Command("git", "checkout", "mrtest")
@@ -346,9 +346,13 @@ func Test_mrCmd_Milestone(t *testing.T) {
 		t.Log(out)
 		require.Contains(t, out, "https://gitlab.com/zaquestion/test/-/merge_requests")
 
-		i := strings.Index(out, "/diffs\n")
+		i := strings.Index(out, "/diffs")
+		if i < 0 {
+			t.Error("wrong MR URL format")
+		}
+
 		mrID = strings.TrimPrefix(out[:i], "https://gitlab.com/zaquestion/test/-/merge_requests/")
-		t.Log(mrID)
+		t.Log("mrID:", mrID)
 	})
 	t.Run("list", func(t *testing.T) {
 		if mrID == "" {
@@ -366,7 +370,8 @@ func Test_mrCmd_Milestone(t *testing.T) {
 		if mrID == "" {
 			t.Skip("mrID is empty, create likely failed")
 		}
-		cmd := exec.Command(labBinaryPath, "mr", "edit", "--milestone", "", "origin")
+		t.Log("mrID: ", mrID)
+		cmd := exec.Command(labBinaryPath, "mr", "edit", mrID, "--milestone", "")
 		cmd.Dir = repo
 
 		b, _ := cmd.CombinedOutput()

--- a/cmd/snippet_list_test.go
+++ b/cmd/snippet_list_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,7 +12,7 @@ import (
 func Test_snippetList(t *testing.T) {
 	t.Parallel()
 	repo := copyTestRepo(t)
-	cmd := exec.Command(labBinaryPath, "snippet", "list", "lab-testing")
+	cmd := exec.Command(labBinaryPath, "snippet", "list", "-n", "1", "lab-testing")
 	cmd.Dir = repo
 
 	b, err := cmd.CombinedOutput()
@@ -21,8 +20,5 @@ func Test_snippetList(t *testing.T) {
 		t.Log(string(b))
 		t.Fatal(err)
 	}
-
-	snips := strings.Split(string(b), "\n")
-	t.Log(snips)
-	require.Regexp(t, `#\d+ snippet title`, snips[0])
+	require.Regexp(t, `#\d+ snippet title`, string(b))
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -103,9 +103,6 @@ func getBranchMR(rn, branch string) int {
 	}
 
 	mrs, err := lab.MRList(rn, gitlab.ListProjectMergeRequestsOptions{
-		ListOptions: gitlab.ListOptions{
-			PerPage: 10,
-		},
 		Labels:       mrLabels,
 		State:        &mrState,
 		OrderBy:      gitlab.String("updated_at"),

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -453,29 +453,19 @@ func MRGet(projID interface{}, id int) (*gitlab.MergeRequest, error) {
 // MRList lists the MRs on a GitLab project
 func MRList(projID interface{}, opts gitlab.ListProjectMergeRequestsOptions, n int) ([]*gitlab.MergeRequest, error) {
 	if n == -1 {
-		opts.PerPage = maxItemsPerPage
+		n = maxItemsPerPage
 	}
 
-	list, resp, err := lab.MergeRequests.ListProjectMergeRequests(projID, &opts)
-	if err != nil {
-		return nil, err
-	}
-
-	var ok bool
-	if opts.Page, ok = hasNextPage(resp); !ok {
-		return list, nil
-	}
-
-	for len(list) < n || n == -1 {
-		if n != -1 {
-			opts.PerPage = n - len(list)
-		}
+	var list []*gitlab.MergeRequest
+	for len(list) < n {
+		opts.PerPage = n - len(list)
 		mrs, resp, err := lab.MergeRequests.ListProjectMergeRequests(projID, &opts)
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, mrs...)
 
+		var ok bool
 		if opts.Page, ok = hasNextPage(resp); !ok {
 			break
 		}
@@ -692,30 +682,19 @@ func IssueGet(projID interface{}, id int) (*gitlab.Issue, error) {
 // IssueList gets a list of issues on a GitLab Project
 func IssueList(projID interface{}, opts gitlab.ListProjectIssuesOptions, n int) ([]*gitlab.Issue, error) {
 	if n == -1 {
-		opts.PerPage = maxItemsPerPage
+		n = maxItemsPerPage
 	}
 
-	list, resp, err := lab.Issues.ListProjectIssues(projID, &opts)
-	if err != nil {
-		return nil, err
-	}
-
-	var ok bool
-	if opts.Page, ok = hasNextPage(resp); !ok {
-		return list, nil
-	}
-
-	opts.Page = resp.NextPage
-	for len(list) < n || n == -1 {
-		if n != -1 {
-			opts.PerPage = n - len(list)
-		}
+	var list []*gitlab.Issue
+	for len(list) < n {
+		opts.PerPage = n - len(list)
 		issues, resp, err := lab.Issues.ListProjectIssues(projID, &opts)
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, issues...)
 
+		var ok bool
 		if opts.Page, ok = hasNextPage(resp); !ok {
 			break
 		}
@@ -1030,28 +1009,19 @@ func ProjectSnippetDelete(projID interface{}, id int) error {
 // ProjectSnippetList lists snippets on a project
 func ProjectSnippetList(projID interface{}, opts gitlab.ListProjectSnippetsOptions, n int) ([]*gitlab.Snippet, error) {
 	if n == -1 {
-		opts.PerPage = maxItemsPerPage
-	}
-	list, resp, err := lab.ProjectSnippets.ListSnippets(projID, &opts)
-	if err != nil {
-		return nil, err
+		n = maxItemsPerPage
 	}
 
-	var ok bool
-	if opts.Page, ok = hasNextPage(resp); !ok {
-		return list, nil
-	}
-
-	for len(list) < n || n == -1 {
-		if n != -1 {
-			opts.PerPage = n - len(list)
-		}
+	var list []*gitlab.Snippet
+	for len(list) < n {
+		opts.PerPage = n - len(list)
 		snips, resp, err := lab.ProjectSnippets.ListSnippets(projID, &opts)
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, snips...)
 
+		var ok bool
 		if opts.Page, ok = hasNextPage(resp); !ok {
 			break
 		}
@@ -1079,28 +1049,19 @@ func SnippetDelete(id int) error {
 // SnippetList lists snippets on a project
 func SnippetList(opts gitlab.ListSnippetsOptions, n int) ([]*gitlab.Snippet, error) {
 	if n == -1 {
-		opts.PerPage = maxItemsPerPage
-	}
-	list, resp, err := lab.Snippets.ListSnippets(&opts)
-	if err != nil {
-		return nil, err
+		n = maxItemsPerPage
 	}
 
-	var ok bool
-	if opts.Page, ok = hasNextPage(resp); !ok {
-		return list, nil
-	}
-
-	for len(list) < n || n == -1 {
-		if n != -1 {
-			opts.PerPage = n - len(list)
-		}
+	var list []*gitlab.Snippet
+	for len(list) < n {
+		opts.PerPage = n - len(list)
 		snips, resp, err := lab.Snippets.ListSnippets(&opts)
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, snips...)
 
+		var ok bool
 		if opts.Page, ok = hasNextPage(resp); !ok {
 			break
 		}
@@ -1141,26 +1102,20 @@ func ProjectDelete(projID interface{}) error {
 
 // ProjectList gets a list of projects on GitLab
 func ProjectList(opts gitlab.ListProjectsOptions, n int) ([]*gitlab.Project, error) {
-	list, resp, err := lab.Projects.ListProjects(&opts)
-	if err != nil {
-		return nil, err
+	if n == -1 {
+		n = maxItemsPerPage
 	}
 
-	var ok bool
-	if opts.Page, ok = hasNextPage(resp); !ok {
-		return list, nil
-	}
-
-	for len(list) < n || n == -1 {
-		if n != -1 {
-			opts.PerPage = n - len(list)
-		}
+	var list []*gitlab.Project
+	for len(list) < n {
+		opts.PerPage = n - len(list)
 		projects, resp, err := lab.Projects.ListProjects(&opts)
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, projects...)
 
+		var ok bool
 		if opts.Page, ok = hasNextPage(resp); !ok {
 			break
 		}
@@ -1660,30 +1615,19 @@ func ResolveMRDiscussion(projID interface{}, mrID int, discussionID string, note
 // TodoList retuns a list of *gitlab.Todo refering to user's Todo list
 func TodoList(opts gitlab.ListTodosOptions, n int) ([]*gitlab.Todo, error) {
 	if n == -1 {
-		opts.PerPage = maxItemsPerPage
+		n = maxItemsPerPage
 	}
 
-	list, resp, err := lab.Todos.ListTodos(&opts)
-	if err != nil {
-		return nil, err
-	}
-
-	var ok bool
-	if opts.Page, ok = hasNextPage(resp); !ok {
-		return list, nil
-	}
-
-	for len(list) < n || n == -1 {
-		if n != -1 {
-			opts.PerPage = n - len(list)
-		}
-
+	var list []*gitlab.Todo
+	for len(list) < n {
+		opts.PerPage = n - len(list)
 		todos, resp, err := lab.Todos.ListTodos(&opts)
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, todos...)
 
+		var ok bool
 		if opts.Page, ok = hasNextPage(resp); !ok {
 			break
 		}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -463,6 +463,18 @@ func MRList(projID interface{}, opts gitlab.ListProjectMergeRequestsOptions, n i
 		if err != nil {
 			return nil, err
 		}
+		// SourceBranch was specified, so we need to make sure we're listing MRs
+		// for the source branch for the specific projID and not a fork.
+		if opts.SourceBranch != nil {
+			var projMRs []*gitlab.MergeRequest
+			for _, mr := range mrs {
+				if mr.SourceProjectID != mr.ProjectID {
+					continue
+				}
+				projMRs = append(projMRs, mr)
+			}
+			mrs = projMRs
+		}
 		list = append(list, mrs...)
 
 		var ok bool


### PR DESCRIPTION
This PR fixes the lab's "guess" operation for retrieving the MR ID
based on the currently checked-out branch, which was, recently,
causing issues with the testing code.

Currently, if any MR opened from a forked project but with the 
same source branch name will get mixed with MRs from the 
original project with that name, possibly returning the wrong
ID to the user.

Check the second commit for more detailed information.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>