### PR TITLE
Consider branch remote when guessing MR

### DIFF
--- a/cmd/mr_browse_test.go
+++ b/cmd/mr_browse_test.go
@@ -20,7 +20,7 @@ func Test_mrBrowseWithParameter(t *testing.T) {
 }
 
 func Test_mrBrowseCurrent(t *testing.T) {
-	git := exec.Command("git", "checkout", "mrtest")
+	git := exec.Command("git", "checkout", "mrtest2")
 	b, err := git.CombinedOutput()
 	if err != nil {
 		t.Log(string(b))
@@ -39,7 +39,7 @@ func Test_mrBrowseCurrent(t *testing.T) {
 	defer func() { browse = oldBrowse }()
 
 	browse = func(url string) error {
-		require.Equal(t, "https://gitlab.com/zaquestion/test/merge_requests/1", url)
+		require.Equal(t, "https://gitlab.com/zaquestion/test/merge_requests/3", url)
 		return nil
 	}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -102,6 +102,21 @@ func getBranchMR(rn, branch string) int {
 		mrBranch = branch
 	}
 
+	branchRemote, err := determineSourceRemote(branch)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	branchProjectName, err := git.PathWithNamespace(branchRemote)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	branchProject, err := lab.FindProject(branchProjectName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	mrs, err := lab.MRList(rn, gitlab.ListProjectMergeRequestsOptions{
 		Labels:       mrLabels,
 		State:        &mrState,
@@ -112,8 +127,11 @@ func getBranchMR(rn, branch string) int {
 		log.Fatal(err)
 	}
 
-	if len(mrs) > 0 {
-		num = mrs[0].IID
+	for _, mr := range mrs {
+		if mr.SourceProjectID == branchProject.ID {
+			num = mr.IID
+			break
+		}
 	}
 	return num
 }

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -463,18 +463,6 @@ func MRList(projID interface{}, opts gitlab.ListProjectMergeRequestsOptions, n i
 		if err != nil {
 			return nil, err
 		}
-		// SourceBranch was specified, so we need to make sure we're listing MRs
-		// for the source branch for the specific projID and not a fork.
-		if opts.SourceBranch != nil {
-			var projMRs []*gitlab.MergeRequest
-			for _, mr := range mrs {
-				if mr.SourceProjectID != mr.ProjectID {
-					continue
-				}
-				projMRs = append(projMRs, mr)
-			}
-			mrs = projMRs
-		}
 		list = append(list, mrs...)
 
 		var ok bool


### PR DESCRIPTION
When trying to guess the merge request that corresponds to a
local branch, we search for MRs that match the (upstream) branch
name.

But as branch names only have to be unique within a project, it
is possible that there are multiple merge requests from different
forks that use the same source branch name.

Luckily we do know which is the correct source project: It's the
one that corresponds to the remote that the local branch was pushed
to.

