### PR TITLE
travis: increase timeout limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - ssh-add ~/.ssh/id_rsa
 
 script:
-  - make test
+  - travis_wait 20 make test
   - diff -u <(echo -n) <(gofmt -d .)
 
 after_success:


### PR DESCRIPTION
We're reaching the limit of 10min tests on Travis. This patch increases
the default 10min to explicit 20min.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>