### PR TITLE
travis: add travis_wait log file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ vendor
 # The testdata-* copies created by the unit tests must be ignored or the tests
 # will encounter write errors as Git attempts to add the dirs to its index.
 testdata-*
+
+# Travis "travis_wait" generated log.
+travis_wait_*


### PR DESCRIPTION
The previous commit added the `travis_wait 20` to the `make test`
command on travis yml file, however, this command generates a .log file
that polutes the git file system and makes goreleaser to finish its job
due to "dirty git repo". This patch is fixing it by adding the
travis_wait log file to .gitignore as suggested by goreleaser doc [1].

[1] https://goreleaser.com/errors/dirty

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>