### PR TITLE
Don't load config during shell completion

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,10 @@ func main() {
 }
 
 func skipInit() bool {
+	if carapace.IsCallback() {
+		return true
+	}
+
 	nArgs := len(os.Args)
 	if nArgs <= 1 {
 		return false
@@ -43,8 +47,6 @@ func skipInit() bool {
 		return true
 	case "completion":
 		return true
-	case "_carapace":
-		return !carapace.IsCallback()
 	default:
 		return false
 	}


### PR DESCRIPTION
Tab completing `lab` causes it to try and load the config, which fails if it hasn't been initialised yet, causing it to produce an error and fail to show any completions. This is because the completion invokes `lab _carapace`, which wasn't correctly detected by `skipInit`.