### PR TITLE
fix(browse): Update browse URLs

### DIFF
--- a/cmd/issue_browse.go
+++ b/cmd/issue_browse.go
@@ -31,7 +31,7 @@ var issueBrowseCmd = &cobra.Command{
 
 		// path.Join will remove 1 "/" from "http://" as it's consider that's
 		// file system path. So we better use normal string concat
-		issueURL := project.WebURL + "/issues"
+		issueURL := project.WebURL + "/-/issues"
 		if num > 0 {
 			issueURL = issueURL + "/" + strconv.FormatInt(num, 10)
 		}

--- a/cmd/issue_browse_test.go
+++ b/cmd/issue_browse_test.go
@@ -11,7 +11,7 @@ func Test_issueBrowse(t *testing.T) {
 	defer func() { browse = oldBrowse }()
 
 	browse = func(url string) error {
-		require.Equal(t, "https://gitlab.com/zaquestion/test/issues/1", url)
+		require.Equal(t, "https://gitlab.com/zaquestion/test/-/issues/1", url)
 		return nil
 	}
 

--- a/cmd/issue_note_test.go
+++ b/cmd/issue_note_test.go
@@ -20,7 +20,7 @@ func Test_issueCreateNote(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/issues/1#note_")
+	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/-/issues/1#note_")
 }
 
 func Test_issueReplyNote(t *testing.T) {

--- a/cmd/mr_browse.go
+++ b/cmd/mr_browse.go
@@ -28,7 +28,7 @@ var mrBrowseCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		hostURL.Path = path.Join(hostURL.Path, rn, "merge_requests")
+		hostURL.Path = path.Join(hostURL.Path, rn, "-", "merge_requests")
 		hostURL.Path = path.Join(hostURL.Path, strconv.FormatInt(num, 10))
 
 		err = browse(hostURL.String())

--- a/cmd/mr_browse_test.go
+++ b/cmd/mr_browse_test.go
@@ -12,7 +12,7 @@ func Test_mrBrowseWithParameter(t *testing.T) {
 	defer func() { browse = oldBrowse }()
 
 	browse = func(url string) error {
-		require.Equal(t, "https://gitlab.com/zaquestion/test/merge_requests/1", url)
+		require.Equal(t, "https://gitlab.com/zaquestion/test/-/merge_requests/1", url)
 		return nil
 	}
 
@@ -39,7 +39,7 @@ func Test_mrBrowseCurrent(t *testing.T) {
 	defer func() { browse = oldBrowse }()
 
 	browse = func(url string) error {
-		require.Equal(t, "https://gitlab.com/zaquestion/test/merge_requests/3", url)
+		require.Equal(t, "https://gitlab.com/zaquestion/test/-/merge_requests/3", url)
 		return nil
 	}
 

--- a/cmd/mr_discussion_test.go
+++ b/cmd/mr_discussion_test.go
@@ -24,7 +24,7 @@ func Test_mrCreateDiscussion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/merge_requests/"+mrCommentSlashDiscussionDumpsterID+"#note_")
+	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/-/merge_requests/"+mrCommentSlashDiscussionDumpsterID+"#note_")
 }
 
 func Test_mrCreateDiscussion_file(t *testing.T) {
@@ -45,7 +45,7 @@ func Test_mrCreateDiscussion_file(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/merge_requests/"+mrCommentSlashDiscussionDumpsterID+"#note_")
+	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/-/merge_requests/"+mrCommentSlashDiscussionDumpsterID+"#note_")
 }
 
 func Test_mrDiscussionMsg(t *testing.T) {

--- a/cmd/mr_note_test.go
+++ b/cmd/mr_note_test.go
@@ -23,7 +23,7 @@ func Test_mrCreateNote(t *testing.T) {
 		{
 			Name:         "Normal text",
 			Args:         []string{"lab-testing", mrCommentSlashDiscussionDumpsterID, "-m", "note text"},
-			ExpectedBody: "https://gitlab.com/lab-testing/test/merge_requests/" + mrCommentSlashDiscussionDumpsterID + "#note_",
+			ExpectedBody: "https://gitlab.com/lab-testing/test/-/merge_requests/" + mrCommentSlashDiscussionDumpsterID + "#note_",
 		},
 		{
 			// Escaped sequence text direct in the argument list as the
@@ -31,7 +31,7 @@ func Test_mrCreateNote(t *testing.T) {
 			// https://github.com/zaquestion/lab/issues/376
 			Name:         "Escape char",
 			Args:         []string{"lab-testing", mrCommentSlashDiscussionDumpsterID, "-m", "{\"key\": \"value\"}"},
-			ExpectedBody: "https://gitlab.com/lab-testing/test/merge_requests/" + mrCommentSlashDiscussionDumpsterID + "#note_",
+			ExpectedBody: "https://gitlab.com/lab-testing/test/-/merge_requests/" + mrCommentSlashDiscussionDumpsterID + "#note_",
 		},
 	}
 	noteCmd := []string{"mr", "note"}
@@ -71,7 +71,7 @@ func Test_mrCreateNote_file(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/merge_requests/"+mrCommentSlashDiscussionDumpsterID+"#note_")
+	require.Contains(t, string(b), "https://gitlab.com/lab-testing/test/-/merge_requests/"+mrCommentSlashDiscussionDumpsterID+"#note_")
 }
 
 func Test_mrReplyAndResolve(t *testing.T) {

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -200,7 +200,7 @@ func Test_mrCmd_MR_description_and_options(t *testing.T) {
 
 		t.Log("commentID =", commentID)
 
-		url := "https://gitlab.com/lab-testing/test/merge_requests/" + mrID + "#note_" + commentID
+		url := "https://gitlab.com/lab-testing/test/-/merge_requests/" + mrID + "#note_" + commentID
 		require.Contains(t, out, url)
 	})
 	t.Run("show MR with comment", func(t *testing.T) {

--- a/cmd/snippet_browse.go
+++ b/cmd/snippet_browse.go
@@ -36,7 +36,7 @@ var snippetBrowseCmd = &cobra.Command{
 		if global || rn == "" {
 			hostURL.Path = path.Join(hostURL.Path, "dashboard", "snippets")
 		} else {
-			hostURL.Path = path.Join(hostURL.Path, rn, "snippets")
+			hostURL.Path = path.Join(hostURL.Path, rn, "-", "snippets")
 		}
 
 		if id > 0 {

--- a/cmd/snippet_browse_test.go
+++ b/cmd/snippet_browse_test.go
@@ -20,14 +20,14 @@ func Test_snippetBrowse(t *testing.T) {
 	defer func() { browse = oldBrowse }()
 
 	browse = func(url string) error {
-		require.Equal(t, "https://gitlab.com/zaquestion/test/snippets", url)
+		require.Equal(t, "https://gitlab.com/zaquestion/test/-/snippets", url)
 		return nil
 	}
 
 	snippetBrowseCmd.Run(nil, []string{})
 
 	browse = func(url string) error {
-		require.Equal(t, "https://gitlab.com/zaquestion/test/snippets/23", url)
+		require.Equal(t, "https://gitlab.com/zaquestion/test/-/snippets/23", url)
 		return nil
 	}
 

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -399,7 +399,7 @@ func MRCreateDiscussion(projID interface{}, id int, opts *gitlab.CreateMergeRequ
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+	return fmt.Sprintf("%s/-/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }
 
 // MRUpdate edits an merge request on a GitLab project
@@ -437,7 +437,7 @@ func MRCreateNote(projID interface{}, id int, opts *gitlab.CreateMergeRequestNot
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+	return fmt.Sprintf("%s/-/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }
 
 // MRGet retrieves the merge request from GitLab project
@@ -666,7 +666,7 @@ func IssueCreateNote(projID interface{}, id int, opts *gitlab.CreateIssueNoteOpt
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/issues/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+	return fmt.Sprintf("%s/-/issues/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }
 
 // IssueGet retrieves the issue information from a GitLab project
@@ -1460,7 +1460,7 @@ func AddMRDiscussionNote(projID interface{}, mrID int, discussionID string, body
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+	return fmt.Sprintf("%s/-/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }
 
 // AddIssueDiscussionNote adds a note to an existing issue discussion on GitLab
@@ -1478,7 +1478,7 @@ func AddIssueDiscussionNote(projID interface{}, issueID int, discussionID string
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/issues/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+	return fmt.Sprintf("%s/-/issues/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }
 
 // UpdateIssueDiscussionNote updates a specific discussion or note in the
@@ -1497,7 +1497,7 @@ func UpdateIssueDiscussionNote(projID interface{}, issueID int, discussionID str
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/issues/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+	return fmt.Sprintf("%s/-/issues/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }
 
 // UpdateMRDiscussionNote updates a specific discussion or note in the
@@ -1516,7 +1516,7 @@ func UpdateMRDiscussionNote(projID interface{}, mrID int, discussionID string, n
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+	return fmt.Sprintf("%s/-/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }
 
 // ListMRsClosingIssue returns a list of MR IDs that has relation to an issue
@@ -1586,7 +1586,7 @@ func MoveIssue(projID interface{}, id int, destProjID interface{}) (string, erro
 		return "", err
 	}
 
-	return fmt.Sprintf("%s/issues/%d", destProject.WebURL, issue.IID), nil
+	return fmt.Sprintf("%s/-/issues/%d", destProject.WebURL, issue.IID), nil
 }
 
 // GetMRApprovalsConfiguration returns the current MR approval rule
@@ -1614,7 +1614,7 @@ func ResolveMRDiscussion(projID interface{}, mrID int, discussionID string, note
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("Resolved %s/merge_requests/%d#note_%d", p.WebURL, mrID, noteID), nil
+	return fmt.Sprintf("Resolved %s/-/merge_requests/%d#note_%d", p.WebURL, mrID, noteID), nil
 }
 
 // TodoList retuns a list of *gitlab.Todo refering to user's Todo list
@@ -1842,7 +1842,7 @@ func CreateMergeRequestCommitDiscussion(projID interface{}, id int, sha string, 
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
+	return fmt.Sprintf("%s/-/merge_requests/%d#note_%d", p.WebURL, note.NoteableIID, note.ID), nil
 }
 
 // hasNextPage get the next page number in case the API response has more


### PR DESCRIPTION
Like #855, this also deals with a breaking change in GL 16.0. In this case, support for "legacy" URLs has been removed, and this is also breaking `lab issue browse`, `... mr browse`, and `... snippet browse`. This change should update all of these so that they work again.

**BREAKING**
As I understand it, these delimited URLs should work on any version of GL since v9 (2017) but these changes will bread the browse commands for users of older versions. If this is a concern, I suppose we could use a config flag to control the URL format.

**FMI** 
Deprecation notice: https://docs.gitlab.com/ee/update/deprecations.html?removal_milestone=16.0#legacy-urls-replaced-or-removed
List of affected URLs: https://gitlab.com/gitlab-org/gitlab/-/issues/28848#release-notes