### PR TITLE
lab: Add token support

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var tokenCmd = &cobra.Command{
+	Use:              "token",
+	Short:            `Show, list, create, and revoke personal access tokens`,
+	Long:             ``,
+	PersistentPreRun: labPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Show data about current token
+		if show, _ := cmd.Flags().GetBool("show"); show {
+			tokenShowCmd.Run(cmd, args)
+			return
+		}
+		// List all tokens
+		if list, _ := cmd.Flags().GetBool("list"); list {
+			tokenListCmd.Run(cmd, args)
+			return
+		}
+		// Create a token
+		if create, _ := cmd.Flags().GetBool("create"); create {
+			tokenCreateCmd.Run(cmd, args)
+			return
+		}
+		// Revoke a token
+		if revoke, _ := cmd.Flags().GetBool("revoke"); revoke {
+			tokenRevokeCmd.Run(cmd, args)
+			return
+		}
+	},
+}
+
+func init() {
+	tokenCmd.Flags().BoolP("show", "s", false, "show details about current token")
+	tokenCmd.Flags().BoolP("list", "l", false, "list all personal access tokens")
+	tokenCmd.Flags().BoolP("create", "c", false, "create a personal access tokens")
+	tokenCmd.Flags().BoolP("revoke", "r", false, "revoke a personal access tokens")
+	RootCmd.AddCommand(tokenCmd)
+}

--- a/cmd/token_create.go
+++ b/cmd/token_create.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/spf13/cobra"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var (
+	expiresAt time.Time
+)
+
+var tokenCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "create a new Personal Access Token",
+	Args:  cobra.MaximumNArgs(1),
+	Example: heredoc.Doc(`
+		lab token create`),
+	PersistentPreRun: labPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		// The values of name and scopes must be specified, they are not optional.
+		name, _ := cmd.Flags().GetString("name")
+		if name == "" {
+			log.Fatal("The name of the token must be specified.")
+		}
+
+		scopes, _ := cmd.Flags().GetStringSlice("scopes")
+		if len(scopes) == 0 {
+			log.Fatal("Scopes must be specified.  See --help for available options.")
+		}
+
+		// expiresat is optional
+		expiresat, _ := cmd.Flags().GetString("expiresat")
+		if expiresat != "" {
+			s := strings.Split(expiresat, "-")
+			if len(s) != 3 {
+				log.Fatal("Incorrect date specified, must be YYYY-MM-DD format")
+			}
+
+			year, err := strconv.Atoi(s[0])
+			if err != nil {
+				log.Fatal("Invalid year specified")
+			}
+			month, err := strconv.Atoi(s[1])
+			if err != nil {
+				log.Fatal("Invalid month specified")
+			}
+			day, err := strconv.Atoi(s[2])
+			if err != nil {
+				log.Fatal("Invalid day specified")
+			}
+
+			loc, _ := time.LoadLocation("UTC")
+			expiresAt = time.Date(year, time.Month(month), day, 0, 0, 0, 0, loc)
+
+			yearNow, monthNow, dayNow := time.Now().UTC().Date()
+			yearFromNow := time.Date(yearNow, monthNow, dayNow, 0, 0, 0, 0, loc).AddDate(1, 0, 0)
+			if expiresAt.After(yearFromNow) {
+				log.Fatalf("Expires date can only be a maximum of one year from now (%s)", yearFromNow.String())
+			}
+		} else {
+			loc, _ := time.LoadLocation("UTC")
+			yearNow, monthNow, dayNow := time.Now().UTC().Date()
+			expiresAt = time.Date(yearNow, monthNow, dayNow, 0, 0, 0, 0, loc).AddDate(0, 0, 30)
+		}
+
+		pat, err := lab.CreatePAT(name, expiresAt, scopes)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s created set to expire on %s", pat, expiresat)
+	},
+}
+
+func init() {
+	tokenCreateCmd.Flags().StringP("name", "n", "", "name of token")
+	tokenCreateCmd.Flags().StringSliceP("scopes", "s", []string{}, "Comma separated scopes for this token. (Available scopes are: api, read_api, read_user, read_repository, write_repository, read_registry, write_registry, sudo, admin_mode.")
+	tokenCreateCmd.Flags().StringP("expiresat", "e", "", "YYYY-MM-DD formatted date the token will expire on (Default: 30 days from now, Maximum: One year from today.)")
+	tokenCmd.AddCommand(tokenCreateCmd)
+}

--- a/cmd/token_list.go
+++ b/cmd/token_list.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/spf13/cobra"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var tokenListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "list details about all Personal Access Tokens",
+	Args:  cobra.MaximumNArgs(1),
+	Example: heredoc.Doc(`
+		lab token list`),
+	PersistentPreRun: labPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		tokens, err := lab.GetAllPATs()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		all, _ := cmd.Flags().GetBool("all")
+		for _, token := range tokens {
+			if token.Active || all {
+				dumpToken(token)
+			}
+		}
+	},
+}
+
+func init() {
+	tokenListCmd.Flags().BoolP("all", "a", false, "list all tokens (including inactive)")
+	tokenCmd.AddCommand(tokenListCmd)
+}

--- a/cmd/token_revoke.go
+++ b/cmd/token_revoke.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"strconv"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/spf13/cobra"
+
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var tokenRevokeCmd = &cobra.Command{
+	Use:   "revoke [token_name]",
+	Short: "revoke a Personal Access Token",
+	Args:  cobra.MaximumNArgs(1),
+	Example: heredoc.Doc(`
+		lab token revoke`),
+
+	PersistentPreRun: labPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		id := 0
+		if len(args) == 1 {
+			var err error
+			id, err = strconv.Atoi(args[0])
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			name, _ := cmd.Flags().GetString("name")
+			if name == "" {
+				log.Fatalf("Must specify a valid token ID or name\n")
+			}
+			PATs, err := lab.GetAllPATs()
+			if err != nil {
+				log.Fatal(err)
+			}
+			for _, PAT := range PATs {
+				if PAT.Name == name {
+					id = PAT.ID
+					break
+				}
+			}
+			log.Fatalf("%s is not a valid Token name\n", name)
+		}
+
+		if id == 0 {
+			log.Fatalf("Must specify a valid token ID or name\n")
+		}
+
+		err := lab.RevokePAT(id)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		PATs, err := lab.GetAllPATs()
+		for _, PAT := range PATs {
+			if PAT.ID == id {
+				dumpToken(PAT)
+			}
+		}
+	},
+}
+
+func init() {
+	tokenRevokeCmd.Flags().StringP("name", "", "", "name of token (can be obtained from 'lab token list'")
+	tokenCmd.AddCommand(tokenRevokeCmd)
+}

--- a/cmd/token_show.go
+++ b/cmd/token_show.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/spf13/cobra"
+	lab "github.com/zaquestion/lab/internal/gitlab"
+)
+
+var tokenShowCmd = &cobra.Command{
+	Use:     "show",
+	Aliases: []string{"details", "current"},
+	Short:   "show details about current Personal Access Token",
+	Args:    cobra.MaximumNArgs(1),
+	Example: heredoc.Doc(`
+		lab token show
+		lab token details
+		lab token current`),
+
+	PersistentPreRun: labPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		tokendata, err := lab.GetCurrentPAT()
+		if err != nil {
+			log.Fatal(err)
+		}
+		dumpToken(tokendata)
+	},
+}
+
+func init() {
+	tokenCmd.AddCommand(tokenShowCmd)
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -717,4 +718,18 @@ func mapLabelsAsLabels(rn string, labelTerms []string) (gitlab.Labels, error) {
 	}
 
 	return gitlab.Labels(matches), nil
+}
+
+// dumpToken dumps information about a specific Personal Access Token
+func dumpToken(tokendata *gitlab.PersonalAccessToken) {
+	fmt.Println("ID:        ", tokendata.ID)
+	fmt.Println("Name:      ", tokendata.Name)
+	fmt.Println("Revoked:   ", tokendata.Revoked)
+	fmt.Println("CreatedAt: ", tokendata.CreatedAt)
+	fmt.Println("Scopes:    ", strings.Join(tokendata.Scopes, ","))
+	fmt.Println("UserID:    ", tokendata.UserID)
+	fmt.Println("LastUsedAt:", tokendata.LastUsedAt)
+	fmt.Println("Active:    ", tokendata.Active)
+	fmt.Println("ExpiresAt: ", time.Time(*tokendata.ExpiresAt).String())
+	fmt.Println("")
 }


### PR DESCRIPTION
Add support for showing the current token, listing all of a user's tokens, revoking tokens, and creating tokens (creating tokens is limited by the GitLab API to Administrator level only).

Signed-off-by: Prarit Bhargava <prarit@redhat.com>