### PR TITLE
fix(token): Show help when no subcommand given

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -30,6 +30,8 @@ var tokenCmd = &cobra.Command{
 			tokenRevokeCmd.Run(cmd, args)
 			return
 		}
+
+		cmd.Help()
 	},
 }
 


### PR DESCRIPTION
Trivial change to bring `lab token` in line w/ other commands when called w/ no subcommand is given on CLI.

@prarit nice work on the `token` command, BTW