### PR TITLE
cmd/token_test.go: Add testing

### DIFF
--- a/cmd/token_test.go
+++ b/cmd/token_test.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"fmt"
 	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -12,21 +10,10 @@ import (
 func Test_token(t *testing.T) {
 	repo := copyTestRepo(t)
 
-	now := time.Now()
-	expiryString := fmt.Sprintf("%d-%d-%d", now.Year(), now.Month(), now.Day() + 1)
-
-	t.Run("create", func(t *testing.T) {
-		cmd := exec.Command(labBinaryPath, "token", "create", "--name", now.String(), "--expiresat", expiryString, "--scopes", "read_api")
-		cmd.Dir = repo
-
-		cmdOut, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Log(string(cmdOut))
-			t.Fatal(err)
-		}
-		require.Contains(t, string(cmdOut), now.String())
-	})
-
+	// As of 16.1, token creation is limited to administrators.  Without
+	// creating a token it is difficult to test the creation and revoking
+	// of a token.  If GitLab changes the permissions on creating tokens
+	// then the commit that introduced this message can be reverted.
 	t.Run("list", func(t *testing.T) {
 		cmd2 := exec.Command(labBinaryPath, "token", "list")
 		cmd2.Dir = repo
@@ -36,30 +23,6 @@ func Test_token(t *testing.T) {
 			t.Log(string(cmd2Out))
 			t.Fatal(err)
 		}
-		require.Contains(t, string(cmd2Out), now.String())
-	})
-
-	t.Run("revoke", func(t *testing.T) {
-		cmd3 := exec.Command(labBinaryPath, "token", "revoke", now.String())
-		cmd3.Dir = repo
-
-		cmd3Out, err := cmd3.CombinedOutput()
-		if err != nil {
-			t.Log(string(cmd3Out))
-			t.Fatal(err)
-		}
-		require.Contains(t, string(cmd3Out), now.String())
-	})
-
-	t.Run("list after revoke", func(t *testing.T) {
-		cmd4 := exec.Command(labBinaryPath, "token", "list")
-		cmd4.Dir = repo
-
-		cmd4Out, err := cmd4.CombinedOutput()
-		if err != nil {
-			t.Log(string(cmd4Out))
-			t.Fatal(err)
-		}
-		require.NotContains(t, string(cmd4Out), now.String())
+		require.NotEmpty(t, string(cmd2Out))
 	})
 }

--- a/cmd/token_test.go
+++ b/cmd/token_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_token(t *testing.T) {
+	repo := copyTestRepo(t)
+
+	now := time.Now()
+	expiryString := fmt.Sprintf("%d-%d-%d", now.Year(), now.Month(), now.Day() + 1)
+
+	t.Run("create", func(t *testing.T) {
+		cmd := exec.Command(labBinaryPath, "token", "create", "--name", now.String(), "--expiresat", expiryString, "--scopes", "read_api")
+		cmd.Dir = repo
+
+		cmdOut, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Log(string(cmdOut))
+			t.Fatal(err)
+		}
+		require.Contains(t, string(cmdOut), now.String())
+	})
+
+	t.Run("list", func(t *testing.T) {
+		cmd2 := exec.Command(labBinaryPath, "token", "list")
+		cmd2.Dir = repo
+
+		cmd2Out, err := cmd2.CombinedOutput()
+		if err != nil {
+			t.Log(string(cmd2Out))
+			t.Fatal(err)
+		}
+		require.Contains(t, string(cmd2Out), now.String())
+	})
+
+	t.Run("revoke", func(t *testing.T) {
+		cmd3 := exec.Command(labBinaryPath, "token", "revoke", now.String())
+		cmd3.Dir = repo
+
+		cmd3Out, err := cmd3.CombinedOutput()
+		if err != nil {
+			t.Log(string(cmd3Out))
+			t.Fatal(err)
+		}
+		require.Contains(t, string(cmd3Out), now.String())
+	})
+
+	t.Run("list after revoke", func(t *testing.T) {
+		cmd4 := exec.Command(labBinaryPath, "token", "list")
+		cmd4.Dir = repo
+
+		cmd4Out, err := cmd4.CombinedOutput()
+		if err != nil {
+			t.Log(string(cmd4Out))
+			t.Fatal(err)
+		}
+		require.NotContains(t, string(cmd4Out), now.String())
+	})
+}


### PR DESCRIPTION
Add token command testing for create, list, and revoke.  This is best done in a single test where a token is created, listed, and then revoked.