### PR TITLE
cmd/project_browse.go: Add --file and --branch options

### DIFF
--- a/cmd/project_browse.go
+++ b/cmd/project_browse.go
@@ -1,15 +1,44 @@
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
 	lab "github.com/zaquestion/lab/internal/gitlab"
 )
 
+var (
+	projectFile    string
+	projectBranch  string
+	projectFileRef string
+)
+
+func projectBrowseGetPath(webURL string, defaultBranch string, branch string, file string, ref string) (path string) {
+	if branch == "" {
+		branch = defaultBranch
+	}
+
+	if ref != "" {
+		path = webURL + "/-/tree/" + ref
+		return path
+	}
+
+	if file != "" {
+		path = webURL + "/-/blob/" + branch + "/" + file
+	} else {
+		path = webURL + "/-/tree/" + branch
+	}
+
+	return path
+}
+
 var projectBrowseCmd = &cobra.Command{
-	Use:              "browse [remote]",
-	Aliases:          []string{"b"},
-	Short:            "View project in a browser",
-	Example:          "lab project browse origin",
+	Use:     "browse [remote]",
+	Aliases: []string{"b"},
+	Short:   "View project in a browser",
+	Example: heredoc.Doc(`
+		lab project browse origin
+		lab project browse --file arch/x86/Makefile
+		lab project b --ref ce697ccee1`),
 	PersistentPreRun: labPersistentPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, _, err := parseArgsRemoteAndID(args)
@@ -22,7 +51,7 @@ var projectBrowseCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		err = browse(p.WebURL)
+		err = browse(projectBrowseGetPath(p.WebURL, p.DefaultBranch, projectBranch, projectFile, projectFileRef))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -30,5 +59,8 @@ var projectBrowseCmd = &cobra.Command{
 }
 
 func init() {
+	projectBrowseCmd.Flags().StringVar(&projectFile, "file", "", "path to specified file")
+	projectBrowseCmd.Flags().StringVar(&projectFileRef, "ref", "", "commit reference for file")
+	projectBrowseCmd.Flags().StringVar(&projectBranch, "branch", "", "specific branch (overrides default branch)")
 	projectCmd.AddCommand(projectBrowseCmd)
 }

--- a/cmd/project_browse_test.go
+++ b/cmd/project_browse_test.go
@@ -11,9 +11,29 @@ func Test_projectBrowse(t *testing.T) {
 	defer func() { browse = oldBrowse }()
 
 	browse = func(url string) error {
-		require.Equal(t, "https://gitlab.com/zaquestion/test", url)
+		require.Equal(t, "https://gitlab.com/zaquestion/test/-/tree/master", url)
 		return nil
 	}
 
 	projectBrowseCmd.Run(nil, []string{""})
+}
+
+func Test_projectGetPath(t *testing.T) {
+	defaultPath := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "master", "", "", "")
+	require.Equal(t, defaultPath, "https://gitlab.com/zaquestion/test/-/tree/master")
+}
+
+func Test_projectGetPathAndFile(t *testing.T) {
+	pathAndFile := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "master", "", "README.md", "")
+	require.Equal(t, pathAndFile, "https://gitlab.com/zaquestion/test/-/blob/master/README.md")
+}
+
+func Test_projectGetPathAndFileAndBranch(t *testing.T) {
+	pathAndFileAndBranch := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "master", "newbranch", "README.md", "")
+	require.Equal(t, pathAndFileAndBranch, "https://gitlab.com/zaquestion/test/-/blob/newbranch/README.md")
+}
+
+func Test_projectGetPathAndRef(t *testing.T) {
+	pathRef := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "", "", "", "12345abcdef")
+	require.Equal(t, pathRef, "https://gitlab.com/zaquestion/test/-/tree/12345abcdef")
 }


### PR DESCRIPTION
@sding3 has requested the ability to browse to a specific file using a --file argument.  In addition to this I think it is a good idea to also add a --branch argument so users can browse a file on a specific branch.

Add --file and --branch options.

Close #866