### PR TITLE
cmd/mr_show.go: Provide a better error value for 'MR not found'

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -37,7 +38,8 @@ var mrShowCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		rn, mrNum, err := parseArgsWithGitBranchMR(args)
 		if err != nil {
-			log.Fatal(err)
+			log.Infoln("ERROR: cannot determine MR id")
+			os.Exit(0x16) // EINVAL
 		}
 
 		mr, err := lab.MRGet(rn, int(mrNum))


### PR DESCRIPTION
@sding3 points out a valid case for a unique error return in #847.

Provide a better error value when a branch doesn't have an associated MR.

Close #847