### PR TITLE
cmd/mr_create.go: Fix -f option

### DIFF
--- a/cmd/mr_create.go
+++ b/cmd/mr_create.go
@@ -241,7 +241,7 @@ func runMRCreate(cmd *cobra.Command, args []string) {
 
 	var title, body string
 
-	if filename != "" {
+	if filename != "" || ofilename != "" {
 		var openEditor bool
 
 		if ofilename != "" {


### PR DESCRIPTION
The -f option was reported to be broken.  This occurred due to a coding error and this simple change will fix it.

Fix the -f option (-F and no options have also been verified to work).