### PR TITLE
remove --branch on project browse command, as it is redundant with --ref

### DIFF
--- a/cmd/project_browse.go
+++ b/cmd/project_browse.go
@@ -7,28 +7,22 @@ import (
 )
 
 var (
-	projectFile    string
-	projectBranch  string
-	projectFileRef string
+	projectFile   string
+	projectGitRef string
 )
 
-func projectBrowseGetPath(webURL string, defaultBranch string, branch string, file string, ref string) (path string) {
-	if branch == "" {
-		branch = defaultBranch
+func projectBrowseGetPath(webURL string, defaultBranch string, ref string, file string) (path string) {
+	if ref == "" {
+		ref = defaultBranch
 	}
 
-	if ref != "" {
-		path = webURL + "/-/tree/" + ref
-		return path
-	}
+	path = webURL + "/-/blob/" + ref
 
 	if file != "" {
-		path = webURL + "/-/blob/" + branch + "/" + file
-	} else {
-		path = webURL + "/-/tree/" + branch
+		path += "/" + file
 	}
 
-	return path
+	return
 }
 
 var projectBrowseCmd = &cobra.Command{
@@ -51,7 +45,7 @@ var projectBrowseCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		err = browse(projectBrowseGetPath(p.WebURL, p.DefaultBranch, projectBranch, projectFile, projectFileRef))
+		err = browse(projectBrowseGetPath(p.WebURL, p.DefaultBranch, projectGitRef, projectFile))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -60,7 +54,6 @@ var projectBrowseCmd = &cobra.Command{
 
 func init() {
 	projectBrowseCmd.Flags().StringVar(&projectFile, "file", "", "path to specified file")
-	projectBrowseCmd.Flags().StringVar(&projectFileRef, "ref", "", "commit reference for file")
-	projectBrowseCmd.Flags().StringVar(&projectBranch, "branch", "", "specific branch (overrides default branch)")
+	projectBrowseCmd.Flags().StringVar(&projectGitRef, "ref", "", "git reference (branch, tag, or SHA)")
 	projectCmd.AddCommand(projectBrowseCmd)
 }

--- a/cmd/project_browse_test.go
+++ b/cmd/project_browse_test.go
@@ -11,7 +11,7 @@ func Test_projectBrowse(t *testing.T) {
 	defer func() { browse = oldBrowse }()
 
 	browse = func(url string) error {
-		require.Equal(t, "https://gitlab.com/zaquestion/test/-/tree/master", url)
+		require.Equal(t, "https://gitlab.com/zaquestion/test/-/blob/master", url)
 		return nil
 	}
 
@@ -19,21 +19,21 @@ func Test_projectBrowse(t *testing.T) {
 }
 
 func Test_projectGetPath(t *testing.T) {
-	defaultPath := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "master", "", "", "")
-	require.Equal(t, defaultPath, "https://gitlab.com/zaquestion/test/-/tree/master")
+	defaultPath := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "master", "", "")
+	require.Equal(t, defaultPath, "https://gitlab.com/zaquestion/test/-/blob/master")
 }
 
 func Test_projectGetPathAndFile(t *testing.T) {
-	pathAndFile := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "master", "", "README.md", "")
+	pathAndFile := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "master", "", "README.md")
 	require.Equal(t, pathAndFile, "https://gitlab.com/zaquestion/test/-/blob/master/README.md")
 }
 
 func Test_projectGetPathAndFileAndBranch(t *testing.T) {
-	pathAndFileAndBranch := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "master", "newbranch", "README.md", "")
-	require.Equal(t, pathAndFileAndBranch, "https://gitlab.com/zaquestion/test/-/blob/newbranch/README.md")
+	pathAndFileAndBranch := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "master", "new/branch", "README.md")
+	require.Equal(t, pathAndFileAndBranch, "https://gitlab.com/zaquestion/test/-/blob/new/branch/README.md")
 }
 
 func Test_projectGetPathAndRef(t *testing.T) {
-	pathRef := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "", "", "", "12345abcdef")
-	require.Equal(t, pathRef, "https://gitlab.com/zaquestion/test/-/tree/12345abcdef")
+	pathRef := projectBrowseGetPath("https://gitlab.com/zaquestion/test", "", "12345abcdef", "")
+	require.Equal(t, pathRef, "https://gitlab.com/zaquestion/test/-/blob/12345abcdef")
 }


### PR DESCRIPTION
This updates amends #869 by removing the `--branch` option, allowing the `--ref` option to be able to take in git branch, tag, or SHA. This updates also makes the `--ref` option orthogonal to the `--file`.

To test this update, target the [zaquestion/test repo hosted on gitlab](https://gitlab.com/zaquestion/test/-/tree/master) with various command invocations:

```
lab project browse
lab project browse --ref master
lab project browse --ref v0.1
lab project browse --ref 63cce1d0
lab project browse --ref master --file .gitlab-ci.yml
lab project browse --ref v0.1 --file .gitlab-ci.yml
lab project browse --ref 63cce1d0 --file .gitlab-ci.yml
```