### PR TITLE
constrain gitlab API calls with context

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"math/rand"
 	"os"
@@ -65,7 +66,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	lab.Init(host, u.Username, token, false)
+	lab.Init(context.Background(), host, u.Username, token, false)
 
 	// Make "origin" the default remote for test cases calling
 	// cmd.Run() directly, instead of launching the labBinaryPath

--- a/internal/gitlab/gitlab_test.go
+++ b/internal/gitlab/gitlab_test.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"context"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -39,7 +40,7 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	Init(host, u.Username, token, false)
+	Init(context.Background(), host, u.Username, token, false)
 
 	code := m.Run()
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
+	"log"
 	"os"
+	"os/signal"
 
 	"github.com/rsteube/carapace"
 	"github.com/zaquestion/lab/cmd"
@@ -13,15 +16,20 @@ import (
 var version = "master"
 
 func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
 	cmd.Version = version
 	initSkipped := skipInit()
 	if !initSkipped {
 		h, u, t, ca, skipVerify := config.LoadMainConfig()
 
 		if ca != "" {
-			lab.InitWithCustomCA(h, u, t, ca)
+			if err := lab.InitWithCustomCA(ctx, h, u, t, ca); err != nil {
+				log.Fatal(err)
+			}
 		} else {
-			lab.Init(h, u, t, skipVerify)
+			lab.Init(ctx, h, u, t, skipVerify)
 		}
 	}
 	cmd.Execute(initSkipped)


### PR DESCRIPTION
Lab previously would appear to be hung if a gitlab API request is in-flight and the user wants to cancel the command with control-C. Now we set up a context whose cancellation is tied to `os.Interrupt` and this context is used in API requests with gitlab.

Lab previously ignored error in loading custom CA cert. Now that error is bubbled back into main and reported back to the user.