### PR TITLE
feat(milestone): Add `--start` & `--due` to `create`; Add `browse` subcommand

### DIFF
--- a/cmd/milestone_browse.go
+++ b/cmd/milestone_browse.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/zaquestion/lab/internal/action"
+	"github.com/zaquestion/lab/internal/gitlab"
+)
+
+var milestoneBrowseCmd = &cobra.Command{
+	Use:     "browse [remote] [<name>]",
+	Aliases: []string{"b"},
+	Short:   "View milestone in a browser",
+	Example: heredoc.Doc(`
+		lab milestone browse
+		lab milestone browse upstream "my great milestone"`),
+	PersistentPreRun: labPersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		rn, name, err := parseArgsRemoteAndProject(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var milestoneURL string
+		if name == "" {
+			project, err := gitlab.FindProject(rn)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			milestoneURL = project.WebURL + "/-/milestones"
+		} else {
+			name = strings.TrimLeft(name, "%")
+			milestone, err := gitlab.MilestoneGet(rn, name)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			milestoneURL = milestone.WebURL
+		}
+
+		err = browse(milestoneURL)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	milestoneCmd.AddCommand(milestoneBrowseCmd)
+	carapace.Gen(milestoneCreateCmd).PositionalCompletion(
+		action.Remotes(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			project, _, err := parseArgsRemoteAndProject(c.Args)
+			if err != nil {
+				return carapace.ActionMessage(err.Error())
+			}
+			return action.Milestones(project, action.MilestoneOpts{Active: true})
+		}),
+	)
+}

--- a/cmd/milestone_browse_test.go
+++ b/cmd/milestone_browse_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_milestoneBrowse(t *testing.T) {
+	oldBrowse := browse
+	defer func() { browse = oldBrowse }()
+
+	browse = func(url string) error {
+		require.Equal(t, "https://gitlab.com/zaquestion/test/-/milestones/1", url)
+		return nil
+	}
+
+	// milestone "1.0" has id 1
+	milestoneBrowseCmd.Run(nil, []string{"1.0"})
+}


### PR DESCRIPTION
This adds a couple things to `lab milestone`:
- `milestone create` now accepts flags `--start` and `--due` to set the respective dates for the new milestone
  - GL API docs: https://docs.gitlab.com/ee/api/milestones.html#create-new-milestone
  - `go-gitlab` docs: https://pkg.go.dev/github.com/xanzy/go-gitlab#CreateMilestoneOptions
  - does *not* add tests for this because there is no test coverage for `milestone create` anyway
  - I have tested it manually and it worked as expected
  - date parse code was largely copied from `CreatePAT` in `internal/gitlab/gitlab.go`
- Adds a new `milestone browse` subcommand
  - unlike `issue/mr/snippet browse`, which all accept an `id` for a specific resource, `milestone browse` takes the name of a milestone
    - maybe it's just me, but I did this because I never refer to milestones by id, only by name; conversely, I never refer to issues and mrs by title, only by id
    - I *did* add a simple test for this, because it was really easy 😄 