### PR TITLE
gitlab: Fix limits calculation

### DIFF
--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -669,18 +669,25 @@ func IssueGet(projID interface{}, id int) (*gitlab.Issue, error) {
 
 // IssueList gets a list of issues on a GitLab Project
 func IssueList(projID interface{}, opts gitlab.ListProjectIssuesOptions, n int) ([]*gitlab.Issue, error) {
-	if n == -1 {
-		n = maxItemsPerPage
-	}
-
 	var list []*gitlab.Issue
-	for len(list) < n {
-		opts.PerPage = n - len(list)
+	for true {
+		opts.PerPage = maxItemsPerPage
+		if n != -1 {
+			opts.PerPage = n - len(list)
+			if opts.PerPage > maxItemsPerPage {
+				opts.PerPage = maxItemsPerPage
+			}
+		}
+
 		issues, resp, err := lab.Issues.ListProjectIssues(projID, &opts)
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, issues...)
+
+		if len(list) == n {
+			break
+		}
 
 		var ok bool
 		if opts.Page, ok = hasNextPage(resp); !ok {
@@ -996,18 +1003,25 @@ func ProjectSnippetDelete(projID interface{}, id int) error {
 
 // ProjectSnippetList lists snippets on a project
 func ProjectSnippetList(projID interface{}, opts gitlab.ListProjectSnippetsOptions, n int) ([]*gitlab.Snippet, error) {
-	if n == -1 {
-		n = maxItemsPerPage
-	}
-
 	var list []*gitlab.Snippet
-	for len(list) < n {
-		opts.PerPage = n - len(list)
+	for true {
+		opts.PerPage = maxItemsPerPage
+		if n != -1 {
+			opts.PerPage = n - len(list)
+			if opts.PerPage > maxItemsPerPage {
+				opts.PerPage = maxItemsPerPage
+			}
+		}
+
 		snips, resp, err := lab.ProjectSnippets.ListSnippets(projID, &opts)
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, snips...)
+
+		if len(list) == n {
+			break
+		}
 
 		var ok bool
 		if opts.Page, ok = hasNextPage(resp); !ok {


### PR DESCRIPTION
    The command 'lab mr list --author $author_name --state merged' was
    returning a list of 100 for each engineer on a project.  Evidence in the
    git tree showed that this was not the case (most had more than 100).
    
    This was due to a calcluational error in the MRList() code.  Implement a
    new algorithm that correctly returns all MRs instead of the last 100.

    The same code exists in the Project Snippet and Issue list code, so fix
    those as well.
    
    Signed-off-by: Prarit Bhargava <prarit@redhat.com>
