### PR TITLE
Guess remote from current branch

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,6 +145,14 @@ func guessDefaultRemote() string {
 		if defaultRemote != "" {
 			return defaultRemote
 		}
+		remoteFromBranch := config.GetBool("core.remote_from_branch")
+		currentBranch, err := git.CurrentBranch()
+		if remoteFromBranch && err == nil {
+			remoteConf := fmt.Sprintf("branch.%s.remote", currentBranch)
+			if remote, err := gitconfig.Local(remoteConf); err == nil {
+				return remote
+			}
+		}
 	}
 
 	guess := ""


### PR DESCRIPTION
This PR adds the configuration option `core.remote_from_branch`.
If set, the default remote is inferred from the current checked-out branch.

If unset or if `core.default_remote` is set, the behaviour is unchanged.

Fixes: https://github.com/zaquestion/lab/issues/896
