### PR TITLE
cmd/mr_show.go: Fix null pipeline error

### DIFF
--- a/cmd/mr_show.go
+++ b/cmd/mr_show.go
@@ -253,13 +253,18 @@ func printMR(mrx *gitlab.MergeRequest, project string, renderMarkdown bool) {
 		subscribed = "Yes"
 	}
 
-	ciStatus := mrx.HeadPipeline.Status
+	ciStatus := "no pipeline"
+	if mrx.HeadPipeline != nil {
+		ciStatus = mrx.HeadPipeline.Status
+	}
 	switch ciStatus {
 	case "failed":
 		ciStatus = color.RedString(ciStatus)
 	case "cancelled":
 		ciStatus = color.RedString(ciStatus)
 	case "success":
+		ciStatus = color.GreenString(ciStatus)
+	case "no pipeline":
 		ciStatus = color.GreenString(ciStatus)
 	}
 


### PR DESCRIPTION
Running 'lab mr show --comments' on an issue with no pipeline results in

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xecaa34]

goroutine 1 [running]:
github.com/zaquestion/lab/cmd.printMR(0xc000618008, {0xc00004132f, 0x18}, 0x1)
	/home/prarit/Other/github/lab/cmd/mr_show.go:256 +0xd74
github.com/zaquestion/lab/cmd.init.func63(0x1a31ee0, {0xc000694860, 0x1, 0x10e5b6f?})
	/home/prarit/Other/github/lab/cmd/mr_show.go:82 +0x3c9
github.com/spf13/cobra.(*Command).execute(0x1a31ee0, {0xc000694840, 0x2, 0x2})
	/home/prarit/Other/github/lab/vendor/github.com/spf13/cobra/command.go:987 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0x1a26400)
	/home/prarit/Other/github/lab/vendor/github.com/spf13/cobra/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/prarit/Other/github/lab/vendor/github.com/spf13/cobra/command.go:1039
github.com/zaquestion/lab/cmd.Execute(0xe0?)
	/home/prarit/Other/github/lab/cmd/root.go:226 +0x1e5
main.main()
	/home/prarit/Other/github/lab/main.go:35 +0x345

This occurs because the Merge Request may have no pipeline.

Verify the pipeline exists.  If it doesn't, set to 'no pipeline' and continue.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>