### PR TITLE
mr_list.go: Fix bounds error

### DIFF
--- a/cmd/mr_list.go
+++ b/cmd/mr_list.go
@@ -53,7 +53,7 @@ func truncateText(s string, length int) (string) {
 }
 
 func overwriteEndOfString(str string, index int, replacement string) string {
-	if index < 0 || index >= len(str) {
+	if index <= 0 || index >= len(str) {
 		return str
 	}
 	// The output looks weird if the character before the index is a space


### PR DESCRIPTION
Executing 'lab mr list --number 0 --order created_at --show-status'

results in:

panic: runtime error: index out of range [-1]

goroutine 1 [running]:
github.com/zaquestion/lab/cmd.overwriteEndOfString(...)
	/home/prarit/Other/github/lab/cmd/mr_list.go:60
github.com/zaquestion/lab/cmd.printColumns({0xc000916900, 0xc, 0xc000c07b30?})
	/home/prarit/Other/github/lab/cmd/mr_list.go:153 +0xc12
github.com/zaquestion/lab/cmd.init.func62(0x1a31c00, {0xc000622f00, 0x0, 0x5})
	/home/prarit/Other/github/lab/cmd/mr_list.go:332 +0x971
github.com/spf13/cobra.(*Command).execute(0x1a31c00, {0xc000622eb0, 0x5, 0x5})
	/home/prarit/Other/github/lab/vendor/github.com/spf13/cobra/command.go:987 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0x1a26400)
	/home/prarit/Other/github/lab/vendor/github.com/spf13/cobra/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/prarit/Other/github/lab/vendor/github.com/spf13/cobra/command.go:1039
github.com/zaquestion/lab/cmd.Execute(0xe0?)
	/home/prarit/Other/github/lab/cmd/root.go:226 +0x1e5
main.main()
	/home/prarit/Other/github/lab/main.go:35 +0x345

Fix a bounds error.